### PR TITLE
refactor: updated pub/sub example to interoperate with ROS2 talker/listener

### DIFF
--- a/ros-z/examples/z_pubsub.rs
+++ b/ros-z/examples/z_pubsub.rs
@@ -7,7 +7,6 @@ use ros_z::{
 use ros_z_msgs::std_msgs::String as RosString;
 
 async fn run_subscriber(ctx: ZContext, topic: String) -> Result<()> {
-    // let ctx = ZContextBuilder::default().build()?;
     let node = ctx.create_node("Sub").build()?;
     let zsub = node.create_sub::<RosString>(&topic).build()?;
     while let Ok(msg) = zsub.async_recv().await {


### PR DESCRIPTION
The pub/sub example now uses the same type and topic name of ROS 2 talker/listener example to make it easier to show interoperability between ROS2 and ROS-Z