### PR TITLE
fix(ci): trigger on ready_for_review to unblock external contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/semantic-pr.yml'
       - '.github/workflows/pr-draft-check.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths-ignore:
       - '**.md'

--- a/.github/workflows/rmw-zenoh-rs.yml
+++ b/.github/workflows/rmw-zenoh-rs.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/semantic-pr.yml'
       - '.github/workflows/pr-draft-check.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths-ignore:
       - '**.md'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/semantic-pr.yml'
       - '.github/workflows/pr-draft-check.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
## Summary

CI workflows were not triggering when an external contributor converted their draft PR to ready for review. I hope this will fix the CI issue on #123.

## Root Cause

The `pull_request` event without explicit `types:` defaults to `[opened, synchronize, reopened]` — it does **not** include `ready_for_review`. Since the recommended workflow for external contributors (per `pr-draft-check.yml`) is to open as draft then mark ready, the heavy CI jobs (Python Tests, ROS Tests, Interop Tests, rmw_zenoh_rs Tests) were only triggered while the PR was a draft, where they were correctly skipped by the `draft == false` guard. Converting to ready never fired a new trigger.

## Key Changes

- Add `types: [opened, synchronize, reopened, ready_for_review]` to `ci.yml`, `test.yml`, and `rmw-zenoh-rs.yml`

## Breaking Changes

None