### PR TITLE
feat(cuda): add CUDA IPC tensor transport + Python data-scientist ergonomics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ jobs:
   formatting:
     name: Check Formatting
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
 
     steps:
       - name: Checkout repository
@@ -43,9 +40,6 @@ jobs:
 
       - name: Install Determinate Nix
         uses: DeterminateSystems/determinate-nix-action@v3
-
-      - name: FlakeHub cache
-        uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Check formatting
         run: nix build .#checks.x86_64-linux.pre-commit-check -L
@@ -81,10 +75,6 @@ jobs:
       - name: Install Determinate Nix (Linux)
         if: runner.os == 'Linux'
         uses: DeterminateSystems/determinate-nix-action@v3
-
-      - name: FlakeHub cache (Linux)
-        if: runner.os == 'Linux'
-        uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Install Nushell (Linux via Nix)
         if: runner.os == 'Linux'
@@ -340,7 +330,6 @@ jobs:
     name: Python Tests (ros-z-py) (${{ matrix.distro }})
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     strategy:
       fail-fast: false
@@ -372,9 +361,6 @@ jobs:
           # instead of rebuilding. ROS packages are already in ros.cachix.org
           # (maintained by nix-ros-overlay for all distros including kilted).
           skipPush: ${{ github.event_name == 'pull_request' }}
-
-      - name: FlakeHub cache
-        uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Install Nushell
         run: |
@@ -448,7 +434,6 @@ jobs:
     name: ROS Tests (clippy-rmw, interop) (${{ matrix.distro }})
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     strategy:
       fail-fast: false
@@ -476,9 +461,6 @@ jobs:
           name: ros
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           skipPush: ${{ github.event_name == 'pull_request' }}
-
-      - name: FlakeHub cache
-        uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Install Nushell
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,6 @@ jobs:
     name: Test documentation
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
 
     steps:
@@ -26,9 +25,6 @@ jobs:
 
       - name: Install Determinate Nix
         uses: DeterminateSystems/determinate-nix-action@v3
-
-      - name: FlakeHub / Magic cache
-        uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Build ros-z library (required for mdbook test link path)
         run: |
@@ -63,9 +59,6 @@ jobs:
 
       - name: Install Determinate Nix
         uses: DeterminateSystems/determinate-nix-action@v3
-
-      - name: FlakeHub / Magic cache
-        uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Build mdbook in flake shell
         run: |

--- a/.github/workflows/mdbook-preview.yml
+++ b/.github/workflows/mdbook-preview.yml
@@ -31,10 +31,6 @@ jobs:
         if: github.event.action != 'closed'
         uses: DeterminateSystems/determinate-nix-action@v3
 
-      - name: FlakeHub / Magic cache
-        if: github.event.action != 'closed'
-        uses: DeterminateSystems/flakehub-cache-action@main
-
       - name: Build mdBook documentation
         if: github.event.action != 'closed'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ ros-z-msgs/python/uv.lock
 /book/*.js
 /book/*.css
 
+# ORT demo assets (downloaded locally per book instructions, not tracked)
+assets/*.onnx
+assets/imagenet_classes.txt
+assets/test_image.jpg
+
 *.db
 *.log
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5272,6 +5272,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zenoh-mem-transport"
+version = "1.7.2"
+dependencies = [
+ "tracing",
+ "zenoh-buffers",
+ "zenoh-cuda",
+ "zenoh-result 1.7.2",
+ "zenoh-shm",
+]
+
+[[package]]
 name = "zenoh-plugin-trait"
 version = "1.7.2"
 dependencies = [
@@ -5420,6 +5431,7 @@ dependencies = [
  "zenoh-cuda",
  "zenoh-link",
  "zenoh-link-commons",
+ "zenoh-mem-transport",
  "zenoh-protocol",
  "zenoh-result 1.7.2",
  "zenoh-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5075,7 +5075,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -5127,7 +5127,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "zenoh-collections",
 ]
@@ -5135,7 +5135,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "tracing",
  "uhlc",
@@ -5148,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "ahash",
 ]
@@ -5156,7 +5156,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -5181,7 +5181,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -5192,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "aes",
  "hmac",
@@ -5205,7 +5205,7 @@ dependencies = [
 [[package]]
 name = "zenoh-cuda"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "tracing",
  "zenoh-buffers",
@@ -5235,7 +5235,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "getrandom 0.2.16",
  "hashbrown 0.16.0",
@@ -5250,7 +5250,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -5269,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "async-trait",
  "base64",
@@ -5302,7 +5302,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "async-trait",
  "base64",
@@ -5327,7 +5327,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic_datagram"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "async-trait",
  "quinn",
@@ -5347,7 +5347,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-serial"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "async-trait",
  "tokio",
@@ -5365,7 +5365,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "async-trait",
  "socket2 0.5.10",
@@ -5382,7 +5382,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "async-trait",
  "base64",
@@ -5411,7 +5411,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "async-trait",
  "libc",
@@ -5432,7 +5432,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -5450,7 +5450,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5482,7 +5482,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5491,9 +5491,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "zenoh-mem-transport"
+version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
+dependencies = [
+ "tracing",
+ "zenoh-buffers",
+ "zenoh-cuda",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
+ "zenoh-shm",
+]
+
+[[package]]
 name = "zenoh-plugin-trait"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "git-version",
  "libloading",
@@ -5510,7 +5522,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -5534,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "anyhow",
 ]
@@ -5542,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "lazy_static",
  "ron",
@@ -5556,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -5585,7 +5597,7 @@ dependencies = [
 [[package]]
 name = "zenoh-stats"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "ahash",
  "prometheus-client",
@@ -5598,7 +5610,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -5612,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "futures",
  "tokio",
@@ -5625,7 +5637,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -5648,6 +5660,7 @@ dependencies = [
  "zenoh-cuda",
  "zenoh-link",
  "zenoh-link-commons",
+ "zenoh-mem-transport",
  "zenoh-protocol",
  "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-runtime",
@@ -5688,7 +5701,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.7.2"
-source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#c053d002184844748ea236c2fca8f4ba24b9dc7d"
 dependencies = [
  "async-trait",
  "const_format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2771,6 +2771,7 @@ dependencies = [
  "uuid",
  "zenoh",
  "zenoh-buffers",
+ "zenoh-codec",
  "zenoh-cuda",
  "zenoh-ext",
 ]
@@ -3290,6 +3291,15 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
  "serde_core",
 ]
 
@@ -3979,6 +3989,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4007,6 +4032,12 @@ checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tracing"
@@ -4846,8 +4877,6 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9ff8cb89f5267b8486a69466bc42f240f1ee2d5089e72395a23094e7b74f21"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -4866,7 +4895,6 @@ dependencies = [
  "petgraph 0.8.3",
  "phf",
  "rand 0.8.5",
- "ref-cast",
  "rustc_version",
  "serde",
  "serde_json",
@@ -4878,40 +4906,39 @@ dependencies = [
  "vec_map",
  "zenoh-buffers",
  "zenoh-codec",
- "zenoh-collections 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-collections",
  "zenoh-config",
  "zenoh-core",
  "zenoh-keyexpr",
  "zenoh-link",
  "zenoh-link-commons",
- "zenoh-macros",
+ "zenoh-macros 1.7.2",
  "zenoh-plugin-trait",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
  "zenoh-runtime",
  "zenoh-shm",
  "zenoh-sync",
  "zenoh-task",
  "zenoh-transport",
- "zenoh-util",
+ "zenoh-util 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-buffers"
 version = "1.7.2"
 dependencies = [
- "zenoh-collections 1.7.2",
+ "zenoh-collections",
 ]
 
 [[package]]
 name = "zenoh-codec"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bc6747664aa9ecf17becd6e9a29282e535a350cd7c6bd8de7bf2dc662fb93d"
 dependencies = [
  "tracing",
  "uhlc",
  "zenoh-buffers",
+ "zenoh-cuda",
  "zenoh-protocol",
  "zenoh-shm",
 ]
@@ -4919,15 +4946,6 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.7.2"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "zenoh-collections"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d642ecfe0d85f0cd846be9bc92805d926c092a6e6c7a575b6346752f8c3ae16"
 dependencies = [
  "ahash",
 ]
@@ -4935,8 +4953,6 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39765a5f9975aba204c99f2f65308db4952dbea8e5ac79c78ac1eaf5711e970a"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -4946,41 +4962,38 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "toml",
  "tracing",
  "uhlc",
  "validated_struct",
  "zenoh-core",
  "zenoh-keyexpr",
- "zenoh-macros",
+ "zenoh-macros 1.7.2",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zenoh-util",
+ "zenoh-result 1.7.2",
+ "zenoh-util 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-core"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c0c1388dccf287aec4e9d5e638630dc9d536db9f1da3522889b42697723b9b"
 dependencies = [
  "lazy_static",
  "tokio",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
  "zenoh-runtime",
 ]
 
 [[package]]
 name = "zenoh-crypto"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b433e08df3b03f2af2d23bd29a32aa5f5522c52e66d63e3d135bfa66373736dd"
 dependencies = [
  "aes",
  "hmac",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sha3",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
 ]
 
 [[package]]
@@ -5008,15 +5021,13 @@ dependencies = [
  "tracing",
  "uhlc",
  "zenoh",
- "zenoh-macros",
- "zenoh-util",
+ "zenoh-macros 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-util 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a3c47c89cb55ea45a1b3fe7d1fe8682ea93530b1fc5245257812db14b55b3d"
 dependencies = [
  "getrandom 0.2.16",
  "hashbrown 0.16.0",
@@ -5025,14 +5036,12 @@ dependencies = [
  "schemars 1.1.0",
  "serde",
  "token-cell",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-link"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6218cecab58435f31fb8b2e185f74f35af8aedd96e8bdd3557b333206b1acfda"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -5045,14 +5054,12 @@ dependencies = [
  "zenoh-link-unixsock_stream",
  "zenoh-link-ws",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-link-commons"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98adc618f7edb570b9333ce583934a7c63e3a619cb49666515bfc06a000d7b6"
 dependencies = [
  "async-trait",
  "base64",
@@ -5077,16 +5084,14 @@ dependencies = [
  "zenoh-config",
  "zenoh-core",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
  "zenoh-runtime",
- "zenoh-util",
+ "zenoh-util 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-link-quic"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0c25d681db958b7714370d5e1d72a523129633d9262b098e18d44824d39893"
 dependencies = [
  "async-trait",
  "base64",
@@ -5104,15 +5109,13 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zenoh-util",
+ "zenoh-result 1.7.2",
+ "zenoh-util 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-link-quic_datagram"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb427adbc8d367505b9a62a6614c9d7802e420f03466d98644bb7bf24516f"
 dependencies = [
  "async-trait",
  "quinn",
@@ -5125,15 +5128,13 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zenoh-util",
+ "zenoh-result 1.7.2",
+ "zenoh-util 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-link-serial"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee91f2e7f7ea44e10e3cdffcda728fcbfcd1d1f9111420164dbfab4c3872c28"
 dependencies = [
  "async-trait",
  "tokio",
@@ -5144,15 +5145,13 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
  "zenoh-runtime",
 ]
 
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f23bd5d06a0014ce5a205961d6d47c8e8d792d9fd050ae9d0c9b609a187995"
 dependencies = [
  "async-trait",
  "socket2 0.5.10",
@@ -5163,14 +5162,12 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-link-tls"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17544cde682dbcd2a712114786feee14295c28a9f66fc1021637355511e32fa9"
 dependencies = [
  "async-trait",
  "base64",
@@ -5192,15 +5189,13 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
  "zenoh-runtime",
 ]
 
 [[package]]
 name = "zenoh-link-udp"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587ca1de1caa0b444106d31c26801f4e87b354293d2d37afd8f70d9e793fe35e"
 dependencies = [
  "async-trait",
  "libc",
@@ -5213,16 +5208,14 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
  "zenoh-sync",
- "zenoh-util",
+ "zenoh-util 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac46470a17af5861e07ed9d2440277e7a3dea55109b0988866b635f7daf29ac4"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -5233,15 +5226,13 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
  "zenoh-runtime",
 ]
 
 [[package]]
 name = "zenoh-link-ws"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4be09c3e32d510cdddf3289bc333d53471883198fca51d58248458a20df3d51"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5253,9 +5244,19 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
  "zenoh-runtime",
- "zenoh-util",
+ "zenoh-util 1.7.2",
+]
+
+[[package]]
+name = "zenoh-macros"
+version = "1.7.2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "zenoh-keyexpr",
 ]
 
 [[package]]
@@ -5273,8 +5274,6 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7325b773c43a86a94f800cb971ab7e4b7e01ce76819c9c100ea783a47c3a25e4"
 dependencies = [
  "git-version",
  "libloading",
@@ -5283,16 +5282,14 @@ dependencies = [
  "tracing",
  "zenoh-config",
  "zenoh-keyexpr",
- "zenoh-macros",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zenoh-util",
+ "zenoh-macros 1.7.2",
+ "zenoh-result 1.7.2",
+ "zenoh-util 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-protocol"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4d3dad7aeeea780495692b195cd56515569c32b76b9dd077cc408c3ebca03f"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -5300,7 +5297,8 @@ dependencies = [
  "uhlc",
  "zenoh-buffers",
  "zenoh-keyexpr",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-macros 1.7.2",
+ "zenoh-result 1.7.2",
 ]
 
 [[package]]
@@ -5322,23 +5320,19 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760a1f7880f98427ad849d600257d1455a18afe981681f362684a3f91042537e"
 dependencies = [
  "lazy_static",
  "ron",
  "serde",
  "tokio",
  "tracing",
- "zenoh-macros",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-macros 1.7.2",
+ "zenoh-result 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-shm"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42184ae820d64d40814c0dd3b48f748c55a3ff5591c524f1bde36f21ccfda488"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -5360,15 +5354,13 @@ dependencies = [
  "winapi",
  "zenoh-buffers",
  "zenoh-core",
- "zenoh-macros",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-macros 1.7.2",
+ "zenoh-result 1.7.2",
 ]
 
 [[package]]
 name = "zenoh-stats"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8954c79580ed3365580d86f40657f2cd6bf4b4c72dd463de936368df8c709c65"
 dependencies = [
  "ahash",
  "prometheus-client",
@@ -5381,23 +5373,19 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f132137bb003f10b7fff086cb18addf8e8273b9c0d2722a53b5074c8a79965"
 dependencies = [
  "arc-swap",
  "event-listener",
  "futures",
  "tokio",
  "zenoh-buffers",
- "zenoh-collections 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-collections",
  "zenoh-core",
 ]
 
 [[package]]
 name = "zenoh-task"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b17d10136fdabec7e21a3fcef568c210ee6a2d71cde6adcde99e9236584f3a1"
 dependencies = [
  "futures",
  "tokio",
@@ -5410,8 +5398,6 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50739b4c45e0963df8377abddb74701a4b708b178590eae92f27a604e25daf44"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -5434,13 +5420,38 @@ dependencies = [
  "zenoh-link",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenoh-result 1.7.2",
  "zenoh-runtime",
  "zenoh-shm",
  "zenoh-stats",
  "zenoh-sync",
  "zenoh-task",
- "zenoh-util",
+ "zenoh-util 1.7.2",
+]
+
+[[package]]
+name = "zenoh-util"
+version = "1.7.2"
+dependencies = [
+ "async-trait",
+ "const_format",
+ "flume",
+ "home",
+ "humantime",
+ "lazy_static",
+ "libc",
+ "libloading",
+ "pnet_datalink",
+ "schemars 1.2.0",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "winapi",
+ "zenoh-core",
+ "zenoh-result 1.7.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2761,7 +2761,6 @@ dependencies = [
  "ros-z-schema",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha2",
  "slab",
  "strum 0.27.2",
@@ -2882,7 +2881,7 @@ dependencies = [
  "ros-z",
  "ros-z-cdr",
  "ros-z-msgs",
- "serde",
+ "serde_json",
  "tokio",
  "zenoh",
  "zenoh-buffers",
@@ -4909,6 +4908,7 @@ dependencies = [
  "zenoh-collections",
  "zenoh-config",
  "zenoh-core",
+ "zenoh-cuda",
  "zenoh-keyexpr",
  "zenoh-link",
  "zenoh-link-commons",
@@ -5417,6 +5417,7 @@ dependencies = [
  "zenoh-config",
  "zenoh-core",
  "zenoh-crypto",
+ "zenoh-cuda",
  "zenoh-link",
  "zenoh-link-commons",
  "zenoh-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1326,12 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "home"
@@ -1771,6 +1792,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,6 +1813,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
 ]
 
 [[package]]
@@ -1857,6 +1894,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -1943,6 +2012,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,16 +2088,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
+]
 
 [[package]]
 name = "parking"
@@ -2255,6 +2395,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2613,6 +2762,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,6 +2897,7 @@ dependencies = [
 name = "ros-z"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "byteorder",
  "clap",
  "csv",
@@ -2749,6 +2905,8 @@ dependencies = [
  "event-listener",
  "flume",
  "json5",
+ "ndarray",
+ "ort",
  "parking_lot",
  "paste",
  "prost",
@@ -3547,6 +3705,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4246,6 +4415,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ureq"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+dependencies = [
+ "base64",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf-8",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2771,6 +2771,7 @@ dependencies = [
  "uuid",
  "zenoh",
  "zenoh-buffers",
+ "zenoh-cuda",
  "zenoh-ext",
 ]
 
@@ -2884,6 +2885,7 @@ dependencies = [
  "tokio",
  "zenoh",
  "zenoh-buffers",
+ "zenoh-cuda",
 ]
 
 [[package]]
@@ -4876,7 +4878,7 @@ dependencies = [
  "vec_map",
  "zenoh-buffers",
  "zenoh-codec",
- "zenoh-collections",
+ "zenoh-collections 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-config",
  "zenoh-core",
  "zenoh-keyexpr",
@@ -4885,7 +4887,7 @@ dependencies = [
  "zenoh-macros",
  "zenoh-plugin-trait",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-runtime",
  "zenoh-shm",
  "zenoh-sync",
@@ -4897,10 +4899,8 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9216c3d6c84b56f3e3be634e52365022038e1ac1b9f662f10d425cbf6c0fa8"
 dependencies = [
- "zenoh-collections",
+ "zenoh-collections 1.7.2",
 ]
 
 [[package]]
@@ -4914,6 +4914,13 @@ dependencies = [
  "zenoh-buffers",
  "zenoh-protocol",
  "zenoh-shm",
+]
+
+[[package]]
+name = "zenoh-collections"
+version = "1.7.2"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -4946,7 +4953,7 @@ dependencies = [
  "zenoh-keyexpr",
  "zenoh-macros",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-util",
 ]
 
@@ -4958,7 +4965,7 @@ checksum = "85c0c1388dccf287aec4e9d5e638630dc9d536db9f1da3522889b42697723b9b"
 dependencies = [
  "lazy_static",
  "tokio",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-runtime",
 ]
 
@@ -4973,7 +4980,16 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sha3",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zenoh-cuda"
+version = "1.7.2"
+dependencies = [
+ "tracing",
+ "zenoh-buffers",
+ "zenoh-result 1.7.2",
 ]
 
 [[package]]
@@ -5009,7 +5025,7 @@ dependencies = [
  "schemars 1.1.0",
  "serde",
  "token-cell",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5029,7 +5045,7 @@ dependencies = [
  "zenoh-link-unixsock_stream",
  "zenoh-link-ws",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5061,7 +5077,7 @@ dependencies = [
  "zenoh-config",
  "zenoh-core",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-runtime",
  "zenoh-util",
 ]
@@ -5088,7 +5104,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-util",
 ]
 
@@ -5109,7 +5125,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-util",
 ]
 
@@ -5128,7 +5144,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-runtime",
 ]
 
@@ -5147,7 +5163,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5176,7 +5192,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-runtime",
 ]
 
@@ -5197,7 +5213,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -5217,7 +5233,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-runtime",
 ]
 
@@ -5237,7 +5253,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-runtime",
  "zenoh-util",
 ]
@@ -5268,7 +5284,7 @@ dependencies = [
  "zenoh-config",
  "zenoh-keyexpr",
  "zenoh-macros",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-util",
 ]
 
@@ -5284,7 +5300,14 @@ dependencies = [
  "uhlc",
  "zenoh-buffers",
  "zenoh-keyexpr",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zenoh-result"
+version = "1.7.2"
+dependencies = [
+ "anyhow",
 ]
 
 [[package]]
@@ -5308,7 +5331,7 @@ dependencies = [
  "tokio",
  "tracing",
  "zenoh-macros",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5338,7 +5361,7 @@ dependencies = [
  "zenoh-buffers",
  "zenoh-core",
  "zenoh-macros",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5366,7 +5389,7 @@ dependencies = [
  "futures",
  "tokio",
  "zenoh-buffers",
- "zenoh-collections",
+ "zenoh-collections 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-core",
 ]
 
@@ -5411,7 +5434,7 @@ dependencies = [
  "zenoh-link",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenoh-runtime",
  "zenoh-shm",
  "zenoh-stats",
@@ -5444,7 +5467,7 @@ dependencies = [
  "tracing-subscriber",
  "winapi",
  "zenoh-core",
- "zenoh-result",
+ "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5075,6 +5075,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -5111,21 +5112,22 @@ dependencies = [
  "zenoh-keyexpr",
  "zenoh-link",
  "zenoh-link-commons",
- "zenoh-macros 1.7.2",
+ "zenoh-macros 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-plugin-trait",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-runtime",
  "zenoh-shm",
  "zenoh-sync",
  "zenoh-task",
  "zenoh-transport",
- "zenoh-util 1.7.2",
+ "zenoh-util 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-buffers"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "zenoh-collections",
 ]
@@ -5133,6 +5135,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "tracing",
  "uhlc",
@@ -5145,6 +5148,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "ahash",
 ]
@@ -5152,6 +5156,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -5167,41 +5172,44 @@ dependencies = [
  "validated_struct",
  "zenoh-core",
  "zenoh-keyexpr",
- "zenoh-macros 1.7.2",
+ "zenoh-macros 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
- "zenoh-util 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
+ "zenoh-util 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-core"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "lazy_static",
  "tokio",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-runtime",
 ]
 
 [[package]]
 name = "zenoh-crypto"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "aes",
  "hmac",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sha3",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-cuda"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "tracing",
  "zenoh-buffers",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
@@ -5227,6 +5235,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "getrandom 0.2.16",
  "hashbrown 0.16.0",
@@ -5235,12 +5244,13 @@ dependencies = [
  "schemars 1.1.0",
  "serde",
  "token-cell",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-link"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -5253,12 +5263,13 @@ dependencies = [
  "zenoh-link-unixsock_stream",
  "zenoh-link-ws",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-link-commons"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "async-trait",
  "base64",
@@ -5283,14 +5294,15 @@ dependencies = [
  "zenoh-config",
  "zenoh-core",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-runtime",
- "zenoh-util 1.7.2",
+ "zenoh-util 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-link-quic"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "async-trait",
  "base64",
@@ -5308,13 +5320,14 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
- "zenoh-util 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
+ "zenoh-util 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-link-quic_datagram"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "async-trait",
  "quinn",
@@ -5327,13 +5340,14 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
- "zenoh-util 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
+ "zenoh-util 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-link-serial"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "async-trait",
  "tokio",
@@ -5344,13 +5358,14 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-runtime",
 ]
 
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "async-trait",
  "socket2 0.5.10",
@@ -5361,12 +5376,13 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-link-tls"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "async-trait",
  "base64",
@@ -5388,13 +5404,14 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-runtime",
 ]
 
 [[package]]
 name = "zenoh-link-udp"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "async-trait",
  "libc",
@@ -5407,14 +5424,15 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-sync",
- "zenoh-util 1.7.2",
+ "zenoh-util 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -5425,13 +5443,14 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-runtime",
 ]
 
 [[package]]
 name = "zenoh-link-ws"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5443,19 +5462,9 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-runtime",
- "zenoh-util 1.7.2",
-]
-
-[[package]]
-name = "zenoh-macros"
-version = "1.7.2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "zenoh-keyexpr",
+ "zenoh-util 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
@@ -5471,19 +5480,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "zenoh-mem-transport"
+name = "zenoh-macros"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
- "tracing",
- "zenoh-buffers",
- "zenoh-cuda",
- "zenoh-result 1.7.2",
- "zenoh-shm",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "zenoh-keyexpr",
 ]
 
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "git-version",
  "libloading",
@@ -5492,14 +5502,15 @@ dependencies = [
  "tracing",
  "zenoh-config",
  "zenoh-keyexpr",
- "zenoh-macros 1.7.2",
- "zenoh-result 1.7.2",
- "zenoh-util 1.7.2",
+ "zenoh-macros 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
+ "zenoh-util 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-protocol"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -5507,15 +5518,8 @@ dependencies = [
  "uhlc",
  "zenoh-buffers",
  "zenoh-keyexpr",
- "zenoh-macros 1.7.2",
- "zenoh-result 1.7.2",
-]
-
-[[package]]
-name = "zenoh-result"
-version = "1.7.2"
-dependencies = [
- "anyhow",
+ "zenoh-macros 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
@@ -5528,21 +5532,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "zenoh-result"
+version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "zenoh-runtime"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "lazy_static",
  "ron",
  "serde",
  "tokio",
  "tracing",
- "zenoh-macros 1.7.2",
- "zenoh-result 1.7.2",
+ "zenoh-macros 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-shm"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -5564,13 +5578,14 @@ dependencies = [
  "winapi",
  "zenoh-buffers",
  "zenoh-core",
- "zenoh-macros 1.7.2",
- "zenoh-result 1.7.2",
+ "zenoh-macros 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
 name = "zenoh-stats"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "ahash",
  "prometheus-client",
@@ -5583,6 +5598,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -5596,6 +5612,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "futures",
  "tokio",
@@ -5608,6 +5625,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -5630,40 +5648,14 @@ dependencies = [
  "zenoh-cuda",
  "zenoh-link",
  "zenoh-link-commons",
- "zenoh-mem-transport",
  "zenoh-protocol",
- "zenoh-result 1.7.2",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
  "zenoh-runtime",
  "zenoh-shm",
  "zenoh-stats",
  "zenoh-sync",
  "zenoh-task",
- "zenoh-util 1.7.2",
-]
-
-[[package]]
-name = "zenoh-util"
-version = "1.7.2"
-dependencies = [
- "async-trait",
- "const_format",
- "flume",
- "home",
- "humantime",
- "lazy_static",
- "libc",
- "libloading",
- "pnet_datalink",
- "schemars 1.2.0",
- "serde",
- "serde_json",
- "shellexpand",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "winapi",
- "zenoh-core",
- "zenoh-result 1.7.2",
+ "zenoh-util 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]
@@ -5691,6 +5683,32 @@ dependencies = [
  "winapi",
  "zenoh-core",
  "zenoh-result 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zenoh-util"
+version = "1.7.2"
+source = "git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport#6cff5db14a50c290d78379036f955cacbc4686c4"
+dependencies = [
+ "async-trait",
+ "const_format",
+ "flume",
+ "home",
+ "humantime",
+ "lazy_static",
+ "libc",
+ "libloading",
+ "pnet_datalink",
+ "schemars 1.2.0",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "winapi",
+ "zenoh-core",
+ "zenoh-result 1.7.2 (git+https://github.com/ZettaScaleLabs/zenoh?branch=feat%2Fmem-transport)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ zenoh = { version = "1.7.2", default-features = false, features = [
 zenoh-ext = { version = "1.7.2", features = ["unstable"] }
 zenoh-buffers = { version = "1.7.2" }
 zenoh-codec = { version = "1.7.2" }
-zenoh-cuda = { version = "1.7.2", path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-cuda" }
+zenoh-cuda = { version = "1.7.2", git = "https://github.com/ZettaScaleLabs/zenoh", branch = "feat/mem-transport" }
 
 # CLI
 clap = "4.5.45"
@@ -110,14 +110,14 @@ cxx-build = "1.0.168"
 # - zenoh-protocol: same source as crates.io 1.7.2, but patched so that
 #   zenoh-link-commons (crates.io) and local zenoh-codec share one instance
 #   of the zenoh-protocol types (TransportMessage, etc.) — avoiding type mismatches.
-zenoh = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/zenoh" }
-zenoh-buffers = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-buffers" }
-zenoh-codec = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-codec" }
-zenoh-protocol = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-protocol" }
-zenoh-keyexpr = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-keyexpr" }
-zenoh-shm = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-shm" }
-zenoh-core = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-core" }
-zenoh-transport = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/io/zenoh-transport" }
+zenoh = { git = "https://github.com/ZettaScaleLabs/zenoh", branch = "feat/mem-transport" }
+zenoh-buffers = { git = "https://github.com/ZettaScaleLabs/zenoh", branch = "feat/mem-transport" }
+zenoh-codec = { git = "https://github.com/ZettaScaleLabs/zenoh", branch = "feat/mem-transport" }
+zenoh-protocol = { git = "https://github.com/ZettaScaleLabs/zenoh", branch = "feat/mem-transport" }
+zenoh-keyexpr = { git = "https://github.com/ZettaScaleLabs/zenoh", branch = "feat/mem-transport" }
+zenoh-shm = { git = "https://github.com/ZettaScaleLabs/zenoh", branch = "feat/mem-transport" }
+zenoh-core = { git = "https://github.com/ZettaScaleLabs/zenoh", branch = "feat/mem-transport" }
+zenoh-transport = { git = "https://github.com/ZettaScaleLabs/zenoh", branch = "feat/mem-transport" }
 
 [profile.opt]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,10 @@ hex = "0.4"
 # FFI
 cxx = "1.0.168"
 
+# ML inference
+ort = { version = "2.0.0-rc.10", features = ["cuda"] }
+ndarray = "0.17"
+
 # Python
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py311"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ zenoh = { version = "1.7.2", default-features = false, features = [
 ] }
 zenoh-ext = { version = "1.7.2", features = ["unstable"] }
 zenoh-buffers = { version = "1.7.2" }
+zenoh-codec = { version = "1.7.2" }
 zenoh-cuda = { version = "1.7.2", path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-cuda" }
 
 # CLI
@@ -98,9 +99,20 @@ cxx-build = "1.0.168"
 
 [patch.crates-io]
 # Point to feat/cuda-zslice branch for CUDA IPC transport support.
-# Only patching zenoh-buffers gives ros-z access to ZSliceKind::CudaPtr and CudaBufInner
-# without disrupting the full Zenoh transport stack.
+#
+# We must patch all three together:
+# - zenoh-buffers: adds ZSliceKind::CudaPtr (gated by `cuda` feature)
+# - zenoh-codec:   adds the matching CudaPtr codec arm (non-exhaustive otherwise)
+# - zenoh-protocol: same source as crates.io 1.7.2, but patched so that
+#   zenoh-link-commons (crates.io) and local zenoh-codec share one instance
+#   of the zenoh-protocol types (TransportMessage, etc.) — avoiding type mismatches.
+zenoh = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/zenoh" }
 zenoh-buffers = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-buffers" }
+zenoh-codec = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-codec" }
+zenoh-protocol = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-protocol" }
+zenoh-keyexpr = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-keyexpr" }
+zenoh-shm = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-shm" }
+zenoh-core = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-core" }
 
 [profile.opt]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ zenoh = { version = "1.7.2", default-features = false, features = [
 ] }
 zenoh-ext = { version = "1.7.2", features = ["unstable"] }
 zenoh-buffers = { version = "1.7.2" }
+zenoh-cuda = { version = "1.7.2", path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-cuda" }
 
 # CLI
 clap = "4.5.45"
@@ -94,6 +95,12 @@ serde-big-array = "0.5"
 # Build dependencies
 bindgen = "0.72.0"
 cxx-build = "1.0.168"
+
+[patch.crates-io]
+# Point to feat/cuda-zslice branch for CUDA IPC transport support.
+# Only patching zenoh-buffers gives ros-z access to ZSliceKind::CudaPtr and CudaBufInner
+# without disrupting the full Zenoh transport stack.
+zenoh-buffers = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-buffers" }
 
 [profile.opt]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ zenoh-protocol = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/c
 zenoh-keyexpr = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-keyexpr" }
 zenoh-shm = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-shm" }
 zenoh-core = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/commons/zenoh-core" }
+zenoh-transport = { path = "../../../../../project/zenoh-src/src/worktree-zenoh/cuda-zslice/io/zenoh-transport" }
 
 [profile.opt]
 inherits = "release"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -42,6 +42,7 @@
 # Experimental
 
 - [Shared Memory (SHM)](./chapters/shm.md)
+- [GPU Tensor Transport](./chapters/gpu-tensor-transport.md)
 - [Key Expression Formats](./chapters/keyexpr_formats.md)
 - [rmw_zenoh_rs](./chapters/rmw_zenoh_rs.md)
 

--- a/book/src/chapters/gpu-tensor-transport.md
+++ b/book/src/chapters/gpu-tensor-transport.md
@@ -1,0 +1,209 @@
+# GPU Tensor Transport
+
+ros-z supports zero-copy GPU tensor transport over CUDA IPC.
+A publisher can send a `torch.Tensor` (or raw CUDA buffer) directly from GPU memory;
+the subscriber reconstructs the tensor on the same device with the original shape
+and dtype — no CPU copies, no serialization overhead.
+
+> **Experimental.** Requires CUDA hardware and ros-z built with `--features cuda`.
+> Both publisher and subscriber must run on the **same host** (CUDA IPC is local-only).
+
+---
+
+## Architecture
+
+ros-z extends Zenoh's ZSlice with two new memory kinds:
+
+| Kind | Use case | Wire payload |
+|------|----------|-------------|
+| `CudaPtr` | Raw device memory (1-D `uint8` view on subscriber) | IPC handle + length + device ID |
+| `CudaTensor` | Typed N-D tensor (shape + dtype preserved) | IPC handle + `TensorMeta` (DLPack) |
+
+On the publisher side, `cudaIpcGetMemHandle` captures a handle to the live GPU
+allocation.  The handle travels in the Zenoh payload as a 77-byte wire blob.
+On the subscriber side, `cudaIpcOpenMemHandle` remaps the same physical pages into
+the subscriber process — zero bytes copied between GPU and CPU.
+
+The Zenoh SHM transport path is extended to pass `CudaPtr`/`CudaTensor` slices
+through without converting them to POSIX shared memory.
+
+---
+
+## Publisher quickstart
+
+```python
+import torch
+from ros_z_py import ZContextBuilder, sensor_msgs
+
+ctx = ZContextBuilder().with_shm_enabled().build()
+node = ctx.create_node("gpu_pub").build()
+pub = node.create_publisher("/camera/image", sensor_msgs.Image)
+
+tensor = torch.zeros(480, 640, 3, dtype=torch.float16, device="cuda:0")
+
+# One call — zero-copy GPU IPC, shape + dtype preserved end-to-end.
+pub.publish_tensor(tensor)
+```
+
+`publish_tensor` dispatches on `tensor.device.type`:
+
+- **`"cuda"`** — wraps via `PyCudaBuf.from_torch()`, sends as a `CudaTensor` ZSlice.
+- **`"cpu"`** or **`numpy.ndarray`** — serializes with NumPy NPY format (CPU path, see below).
+
+---
+
+## Subscriber quickstart
+
+```python
+view = sub.recv_raw_view(timeout=5.0)  # returns ZPayloadView
+tensor = view.as_torch()               # torch.Tensor on the originating CUDA device
+```
+
+`as_torch()` dispatches on payload type:
+
+- **CUDA payload** — calls `torch.from_dlpack(view.as_dlpack())`.  No data copied.
+  Returns a tensor on the originating device with the original shape and dtype.
+- **CPU numpy payload** — decodes NPY wire format; returns a CPU `torch.Tensor`.
+- **Other CPU bytes** — returns a 1-D `torch.uint8` tensor.
+
+> **Import order:** Import `torch` before creating the `ZContextBuilder` to avoid
+> a double-free in the CUDA allocator.  See the `cuda_pubsub.py` example for the
+> correct pattern.
+
+---
+
+## Typed tensor round-trip
+
+Shape and dtype travel with the tensor — no out-of-band conventions needed:
+
+```python
+# Publisher
+tensor = torch.randn(1024, 1024, dtype=torch.bfloat16, device="cuda:0")
+pub.publish_tensor(tensor)
+
+# Subscriber
+view = sub.recv_raw_view()
+t = view.as_torch()
+assert t.shape == torch.Size([1024, 1024])
+assert t.dtype == torch.bfloat16
+assert t.device.type == "cuda"
+```
+
+The following dtypes are supported: `float16`, `float32`, `float64`, `bfloat16`,
+`int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`, `uint64`, `bool`.
+
+Non-contiguous tensors are supported; strides are preserved in the wire format.
+
+---
+
+## CPU tensor transport
+
+`publish_tensor` also handles CPU tensors and NumPy arrays:
+
+```python
+# torch CPU tensor
+pub.publish_tensor(torch.arange(1024, dtype=torch.float32))
+
+# numpy array
+import numpy as np
+pub.publish_tensor(np.zeros((256, 256), dtype=np.uint8))
+```
+
+Wire format: NumPy NPY (magic `\x93NUMPY`, shape + dtype + strides header, raw data).
+The subscriber receives the same shape and dtype with no extra metadata:
+
+```python
+view = sub.recv_raw_view()
+t = view.as_torch()    # CPU torch.Tensor with original shape + dtype
+a = view.as_numpy()    # numpy.ndarray with original shape + dtype
+```
+
+---
+
+## Low-level API
+
+For cases where `publish_tensor` is not flexible enough, use the lower-level
+`PyCudaBuf` API directly:
+
+```python
+from ros_z_py import PyCudaBuf
+
+# Wrap an existing tensor (non-owning — no cudaFree on drop)
+buf = PyCudaBuf.from_torch(tensor)
+
+# Attach metadata manually (alternative to from_torch)
+buf = PyCudaBuf.from_device_ptr(tensor.data_ptr(), tensor.nbytes, device_id=0)
+buf.with_tensor_meta(list(tensor.shape), "float16")
+
+# Build the ZBuf (keeps tensor alive until zbuf is dropped)
+zbuf = buf.into_zbuf(keepalive=tensor)
+pub.publish_zbuf(zbuf)
+```
+
+Allocating a fresh GPU buffer (fill it with cupy or a CUDA kernel):
+
+```python
+buf = PyCudaBuf.alloc_device(4 * 1024 * 1024, device_id=0)
+# ... fill buf.device_ptr via cupy / kernel ...
+pub.publish_zbuf(buf.into_zbuf())
+```
+
+---
+
+## Lifetime and keepalive contract
+
+CUDA IPC sends a *handle*, not a copy.  The subscriber must call
+`cudaIpcOpenMemHandle` before the publisher frees the allocation:
+
+1. **`publish_tensor(tensor)`** — holds `tensor` alive until `publish_zbuf` returns
+   (IPC handle serialized on wire).  The publisher should **not** delete the tensor
+   immediately after returning; keep it alive for at least one expected round-trip.
+
+2. **`into_zbuf(keepalive=tensor)`** — same guarantee for the manual API.
+   The source tensor is held until the `CudaZBuf` is garbage-collected.
+
+3. **Subscriber side** — `cudaIpcOpenMemHandle` is called inside `as_dlpack()` /
+   `as_torch()`.  If the publisher has already freed the buffer by this point, the
+   behaviour is undefined (typically a segfault or silent data corruption).
+
+A safe pattern for tight publish loops:
+
+```python
+for tensor in stream:
+    pub.publish_tensor(tensor)
+    time.sleep(0.005)   # ~5 ms window for subscriber to open the handle
+```
+
+---
+
+## Limitations
+
+| Limitation | Detail |
+|-----------|--------|
+| Same-host only | CUDA IPC handles are not portable across machines |
+| CUDA devices only | CUDA IPC does not work for CPU or other accelerators |
+| Single-consumer | Opening an IPC handle in multiple subscriber processes simultaneously is undefined by the CUDA spec |
+| PyTorch import order | `import torch` must come before `ZContextBuilder()` to avoid allocator conflicts |
+
+---
+
+## Running the example
+
+```bash
+# Terminal 1 (subscriber — start first)
+python crates/ros-z-py/examples/cuda_pubsub.py --sub --torch
+
+# Terminal 2 (publisher)
+python crates/ros-z-py/examples/cuda_pubsub.py --pub --torch --warmup 5
+```
+
+Expected output:
+
+```text
+[pub] publish_tensor: shape=[480, 640, 3], dtype=torch.float16, device=cuda:0, nbytes=1843200
+[pub] published typed CUDA tensor via publish_tensor()
+
+[sub] received CUDA IPC view  (is_cuda=True)
+[sub] tensor: shape=[480, 640, 3], dtype=torch.float16, device=cuda:0
+[sub] PASS - shape=[480, 640, 3], dtype=torch.float16 (metadata preserved)
+```

--- a/book/src/chapters/gpu-tensor-transport.md
+++ b/book/src/chapters/gpu-tensor-transport.md
@@ -207,3 +207,151 @@ Expected output:
 [sub] tensor: shape=[480, 640, 3], dtype=torch.float16, device=cuda:0
 [sub] PASS - shape=[480, 640, 3], dtype=torch.float16 (metadata preserved)
 ```
+
+---
+
+## Real-world example: cross-language ML inference pipeline
+
+The `ort_publisher.py` + `ort_classifier` example shows a complete cross-language
+inference pipeline: a **Python** node preprocesses an image on the GPU and publishes
+the tensor; a **Rust** node receives it over CUDA IPC and runs
+[SqueezeNet 1.1](https://github.com/onnx/models/tree/main/validated/vision/classification/squeezenet)
+inference via [ONNX Runtime](https://onnxruntime.ai/).
+
+```text
+Python (torchvision, GPU)          Rust (ort, ONNX Runtime)
+┌──────────────────────────┐       ┌──────────────────────────────┐
+│ Image → transforms       │       │ recv_serialized_timeout()    │
+│ → [1,3,224,224] f32 NCHW │       │ → typed_cuda_slices()        │
+│ → publish_tensor()       │──────▶│ → copy_to_host() (D→H)      │
+│   (CUDA IPC handle)      │       │ → ONNX Runtime inference     │
+└──────────────────────────┘       │ → top-1 ImageNet label       │
+                                   └──────────────────────────────┘
+```
+
+The image is preprocessed entirely on the GPU (resize, crop, normalize).
+The resulting tensor crosses the process boundary as a CUDA IPC handle — 77 bytes
+on the wire, zero bytes of pixel data copied through the CPU.
+The Rust subscriber performs one D→H transfer (`copy_to_host`) to hand the data
+to ONNX Runtime, which re-uploads it to the GPU via its CUDA execution provider.
+
+### Setup
+
+**1. Download the model and class labels (first time only):**
+
+```bash
+mkdir -p assets
+
+# SqueezeNet 1.1 ONNX model (~4 MB)
+curl -L https://github.com/onnx/models/raw/main/validated/vision/classification/squeezenet/model/squeezenet1.1-7.onnx \
+     -o assets/squeezenet1.1-7.onnx
+
+# ImageNet class labels (1000 lines)
+curl -L https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt \
+     -o assets/imagenet_classes.txt
+```
+
+Provide any JPEG/PNG as the test image:
+
+```bash
+# Use your own image, or download a sample:
+curl -L https://upload.wikimedia.org/wikipedia/commons/thumb/5/5f/Pomeranian_dog_named_Boo_wearing_a_scarf.jpg/640px-Pomeranian_dog_named_Boo_wearing_a_scarf.jpg \
+     -o assets/test_image.jpg
+```
+
+**2. Install Python dependencies:**
+
+```bash
+pip install torch torchvision pillow
+```
+
+**3. Build the Rust subscriber with CUDA support:**
+
+```bash
+cargo build --example ort_classifier --features jazzy,cuda
+```
+
+### Running
+
+Start the Rust subscriber first — it listens for the Python publisher to connect
+(direct peer, no router needed):
+
+```bash
+# Terminal 1
+cargo run --example ort_classifier --features jazzy,cuda
+```
+
+Once the subscriber prints `listening on /ort/image`, start the publisher:
+
+```bash
+# Terminal 2
+python crates/ros-z-py/examples/ort_publisher.py assets/test_image.jpg
+```
+
+### Expected output
+
+**Subscriber (Rust):**
+
+```text
+loaded 1000 labels, model ready
+listening on /ort/image (peer addr tcp/127.0.0.1:7449)
+run: python crates/ros-z-py/examples/ort_publisher.py [image.jpg]
+top-1: Samoyed (3099.9%)
+top-1: Samoyed (3099.9%)
+```
+
+**Publisher (Python):**
+
+```text
+[pub] loading image: assets/test_image.jpg
+[pub] tensor ready: shape=[1, 3, 224, 224] dtype=torch.float32 device=cuda:0 nbytes=602112
+[pub] waiting for subscriber …
+[pub] publishing on /ort/image at 1 Hz
+[pub] published
+[pub] published
+```
+
+### How it works in code
+
+**Publisher** (`crates/ros-z-py/examples/ort_publisher.py`):
+
+```python
+# Standard torchvision preprocessing on GPU
+transform = T.Compose([T.Resize(256), T.CenterCrop(224),
+                       T.ToImage(), T.ToDtype(torch.float32, scale=True),
+                       T.Normalize(mean=MEAN, std=STD)])
+
+img = Image.open(image_path).convert("RGB")
+tensor = transform(img).unsqueeze(0).cuda(0).contiguous()  # [1, 3, 224, 224] f32
+
+# One call — IPC handle on wire, no pixel data through CPU
+pub.publish_tensor(tensor)
+```
+
+**Subscriber** (`crates/ros-z/examples/ort_classifier.rs`):
+
+```rust,ignore
+// recv_serialized_timeout bypasses CDR — CUDA ZSlice kind bits are preserved
+let sample = sub.recv_serialized_timeout(Duration::from_secs(60))?;
+
+let zbuf = ZBuf::from_zenoh(sample.payload().clone().into());
+
+// Iterate typed CUDA slices (shape + dtype from DLPack metadata)
+let (cuda_buf, meta) = zbuf.typed_cuda_slices().next().unwrap();
+
+// One D→H copy for ONNX Runtime input
+let mut host_buf = vec![0u8; n_bytes];
+cuda_buf.copy_to_host(&mut host_buf)?;
+
+// Build ndarray and run inference
+let arr = Array4::from_shape_vec([1, 3, 224, 224], floats)?;
+let outputs = session.run(ort::inputs![TensorRef::from_array_view(arr.view())?])?;
+```
+
+### Key point: `recv_serialized_timeout`
+
+The subscriber uses `recv_serialized_timeout` instead of the usual `recv`.
+The standard `recv` deserializes the payload as a ROS 2 CDR message; that would
+destroy the CUDA ZSlice metadata.  `recv_serialized_timeout` returns the raw
+Zenoh `Sample` with the payload intact, so `ZBuf::typed_cuda_slices()` can find
+the `CudaTensor` slice and recover its `TensorMeta`.

--- a/crates/rmw-zenoh-rs/src/msg.rs
+++ b/crates/rmw-zenoh-rs/src/msg.rs
@@ -46,10 +46,10 @@ impl ZSerializer for RosSerdes {
         Self::serialize_to_zbuf(input)
     }
 
-    fn serialize_to_shm(
+    fn serialize_to_shm<B: zenoh::shm::ShmProviderBackend>(
         input: Self::Input<'_>,
         _estimated_size: usize,
-        provider: &zenoh::shm::ShmProvider<zenoh::shm::PosixShmProviderBackend>,
+        provider: &zenoh::shm::ShmProvider<B>,
     ) -> zenoh::Result<(zenoh_buffers::ZBuf, usize)> {
         // RosMessage uses C FFI serialization, which produces Vec<u8>
         // So we serialize to Vec first, then copy to SHM

--- a/crates/ros-z-py/Cargo.toml
+++ b/crates/ros-z-py/Cargo.toml
@@ -27,6 +27,7 @@ serde = { workspace = true, features = ["derive"] }
 flume = { workspace = true }
 parking_lot = { workspace = true }
 once_cell = "1.19"
+serde_json = { workspace = true }
 
 [features]
 cuda = ["zenoh-buffers/cuda", "dep:zenoh-cuda", "ros-z/cuda"]

--- a/crates/ros-z-py/Cargo.toml
+++ b/crates/ros-z-py/Cargo.toml
@@ -20,12 +20,16 @@ ros-z-msgs = { path = "../ros-z-msgs", features = [
 ] }
 zenoh = { workspace = true }
 zenoh-buffers = { workspace = true }
+zenoh-cuda = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
 anyhow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 flume = { workspace = true }
 parking_lot = { workspace = true }
 once_cell = "1.19"
+
+[features]
+cuda = ["zenoh-buffers/cuda", "dep:zenoh-cuda"]
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/ros-z-py/Cargo.toml
+++ b/crates/ros-z-py/Cargo.toml
@@ -29,7 +29,7 @@ parking_lot = { workspace = true }
 once_cell = "1.19"
 
 [features]
-cuda = ["zenoh-buffers/cuda", "dep:zenoh-cuda"]
+cuda = ["zenoh-buffers/cuda", "dep:zenoh-cuda", "ros-z/cuda"]
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/ros-z-py/examples/cuda_pubsub.py
+++ b/crates/ros-z-py/examples/cuda_pubsub.py
@@ -24,12 +24,13 @@ memory and optionally verifies via torch.from_dlpack().
 
 import argparse
 import sys
+import time
 
 try:
     from ros_z_py import (
         PyCudaBuf,
-        PyZContextBuilder,
-        PyZNodeBuilder,
+        ZContextBuilder,
+        sensor_msgs,
     )
 except ImportError as e:
     print(f"Failed to import ros_z_py (build with --features cuda): {e}")
@@ -40,11 +41,25 @@ PAYLOAD_BYTES = 4 * 1024 * 1024  # 4 MB
 DEVICE_ID = 0
 FILL_VALUE = 42
 
+# Use LaserScan as a placeholder type for the publisher/subscriber factory.
+# publish_zbuf() bypasses message serialization so any registered type works.
+MSG_TYPE = sensor_msgs.LaserScan
+
+# Direct peer connection: subscriber listens on a fixed port, publisher connects.
+# This ensures the SHM/CUDA IPC extension is negotiated directly without a router.
+SUB_LISTEN = "tcp/127.0.0.1:7448"
+
 
 def run_publisher(use_torch: bool):
-    ctx = PyZContextBuilder().build()
-    node = PyZNodeBuilder(ctx).build()
-    pub = node.create_publisher(TOPIC, "sensor_msgs/msg/Image")
+    ctx = (
+        ZContextBuilder()
+        .with_shm_enabled()
+        .with_logging_enabled()
+        .with_connect_endpoints([SUB_LISTEN])
+        .build()
+    )
+    node = ctx.create_node("cuda_pub").build()
+    pub = node.create_publisher(TOPIC, MSG_TYPE)
 
     print(f"[pub] allocating {PAYLOAD_BYTES // 1024 // 1024} MB on GPU {DEVICE_ID} …")
     buf = PyCudaBuf.alloc_device(PAYLOAD_BYTES, device_id=DEVICE_ID)
@@ -64,15 +79,29 @@ def run_publisher(use_torch: bool):
         except ImportError:
             print("[pub] cupy not available, skipping fill")
 
+    # Allow subscriber declaration to propagate before publishing.
+    time.sleep(1.0)
+
     zbuf = buf.into_zbuf()
     pub.publish_zbuf(zbuf)
     print("[pub] published CUDA IPC handle — subscriber can now map this memory")
 
+    # Keep the GPU allocation alive while the subscriber opens the IPC handle.
+    # cudaIpcOpenMemHandle requires the source allocation to still exist.
+    time.sleep(3.0)
+    print("[pub] done — releasing GPU memory")
+
 
 def run_subscriber(use_torch: bool, timeout: float = 30.0):
-    ctx = PyZContextBuilder().build()
-    node = PyZNodeBuilder(ctx).build()
-    sub = node.create_subscriber(TOPIC, "sensor_msgs/msg/Image")
+    ctx = (
+        ZContextBuilder()
+        .with_shm_enabled()
+        .with_logging_enabled()
+        .with_listen_endpoints([SUB_LISTEN])
+        .build()
+    )
+    node = ctx.create_node("cuda_sub").build()
+    sub = node.create_subscriber(TOPIC, MSG_TYPE)
 
     print(f"[sub] waiting for CUDA tensor on {TOPIC} (timeout={timeout}s) …")
     view = sub.recv_raw_view(timeout=timeout)

--- a/crates/ros-z-py/examples/cuda_pubsub.py
+++ b/crates/ros-z-py/examples/cuda_pubsub.py
@@ -9,6 +9,7 @@ Requirements:
     - ros_z_py built with --features cuda
     - CUDA-capable GPU (tested on GTX 1650 Ti)
     - Optional: cupy for publisher-side tensor fill
+    - Optional: torch for typed tensor round-trip (--torch)
 
 Usage:
     Terminal 1 (subscriber first):
@@ -17,9 +18,16 @@ Usage:
     Terminal 2 (publisher):
         python cuda_pubsub.py --pub [--torch]
 
-The publisher allocates device memory, fills it (via cupy if available),
-then publishes the IPC handle over Zenoh.  The subscriber maps the GPU
-memory and optionally verifies via torch.from_dlpack().
+    Typed tensor round-trip (shape + dtype preserved end-to-end):
+        python cuda_pubsub.py --sub --torch &
+        python cuda_pubsub.py --pub --torch --warmup 5
+
+The --torch mode uses PyCudaBuf.from_torch() on the publisher side to attach
+tensor metadata (shape, dtype) to the wire format, so the subscriber receives
+a correctly-shaped tensor via torch.from_dlpack() with no out-of-band convention.
+
+Without --torch the example uses raw device memory (CudaPtr ZSlice) and the
+subscriber sees a 1-D uint8 view.
 """
 
 import argparse
@@ -37,9 +45,14 @@ except ImportError as e:
     sys.exit(1)
 
 TOPIC = "/cuda_demo/raw"
-PAYLOAD_BYTES = 4 * 1024 * 1024  # 4 MB
+PAYLOAD_BYTES = 4 * 1024 * 1024  # 4 MB (used for raw CudaPtr mode)
 DEVICE_ID = 0
 FILL_VALUE = 42
+
+# Typed tensor shape/dtype used for --torch mode.
+# A "video frame" sized tensor: 480×640×3 half-precision.
+TENSOR_SHAPE = (480, 640, 3)
+TENSOR_DTYPE = "torch.float16"  # matches torch.dtype repr
 
 # Use LaserScan as a placeholder type for the publisher/subscriber factory.
 # publish_zbuf() bypasses message serialization so any registered type works.
@@ -61,11 +74,46 @@ def run_publisher(use_torch: bool, warmup: float = 1.0):
     node = ctx.create_node("cuda_pub").build()
     pub = node.create_publisher(TOPIC, MSG_TYPE)
 
-    print(f"[pub] allocating {PAYLOAD_BYTES // 1024 // 1024} MB on GPU {DEVICE_ID} …")
-    buf = PyCudaBuf.alloc_device(PAYLOAD_BYTES, device_id=DEVICE_ID)
-    print(f"[pub] device ptr: 0x{buf.device_ptr:016x}  len: {buf.cuda_len}")
+    # Allow subscriber declaration to propagate before publishing.
+    time.sleep(warmup)
 
     if use_torch:
+        # Typed tensor path: PyCudaBuf.from_torch() wraps the tensor and
+        # attaches shape + dtype metadata so the subscriber receives a
+        # correctly-shaped tensor via as_dlpack() with no out-of-band convention.
+        import torch
+
+        shape = TENSOR_SHAPE
+        dtype = torch.float16
+        tensor = torch.full(
+            shape, FILL_VALUE / 255.0, dtype=dtype, device=f"cuda:{DEVICE_ID}"
+        )
+        torch.cuda.synchronize(DEVICE_ID)
+
+        nbytes = tensor.nbytes
+        print(
+            f"[pub] from_torch: shape={list(tensor.shape)}, dtype={tensor.dtype},"
+            f" device={tensor.device}, nbytes={nbytes}"
+        )
+
+        # from_torch() captures data_ptr + shape + dtype + strides.
+        # The tensor stays alive throughout this function (IPC handle keepalive).
+        buf = PyCudaBuf.from_torch(tensor)
+        zbuf = buf.into_zbuf()
+        pub.publish_zbuf(zbuf)
+        print("[pub] published typed CUDA tensor (CudaTensor ZSlice)")
+
+        # Keep allocation alive while subscriber opens the IPC handle.
+        time.sleep(3.0)
+        del tensor  # explicit to show when it drops
+    else:
+        # Raw bytes path: allocate + fill via cupy, publish as 1-D uint8 (CudaPtr ZSlice).
+        print(
+            f"[pub] allocating {PAYLOAD_BYTES // 1024 // 1024} MB on GPU {DEVICE_ID} …"
+        )
+        buf = PyCudaBuf.alloc_device(PAYLOAD_BYTES, device_id=DEVICE_ID)
+        print(f"[pub] device ptr: 0x{buf.device_ptr:016x}  len: {buf.cuda_len}")
+
         try:
             import cupy as cp
 
@@ -79,16 +127,13 @@ def run_publisher(use_torch: bool, warmup: float = 1.0):
         except ImportError:
             print("[pub] cupy not available, skipping fill")
 
-    # Allow subscriber declaration to propagate before publishing.
-    time.sleep(warmup)
+        zbuf = buf.into_zbuf()
+        pub.publish_zbuf(zbuf)
+        print("[pub] published CUDA IPC handle — subscriber can now map this memory")
 
-    zbuf = buf.into_zbuf()
-    pub.publish_zbuf(zbuf)
-    print("[pub] published CUDA IPC handle — subscriber can now map this memory")
+        # Keep the GPU allocation alive while the subscriber opens the IPC handle.
+        time.sleep(3.0)
 
-    # Keep the GPU allocation alive while the subscriber opens the IPC handle.
-    # cudaIpcOpenMemHandle requires the source allocation to still exist.
-    time.sleep(3.0)
     print("[pub] done — releasing GPU memory")
 
 
@@ -134,13 +179,29 @@ def run_subscriber(use_torch: bool, timeout: float = 30.0):
         print(
             f"[sub] tensor: shape={list(tensor.shape)}, dtype={tensor.dtype}, device={tensor.device}"
         )
-        # If publisher filled with FILL_VALUE, spot-check
-        sample = tensor[:16].cpu().tolist()
-        print(f"[sub] first 16 bytes: {sample}")
-        if all(b == FILL_VALUE for b in sample):
-            print(f"[sub] PASS — all bytes are {FILL_VALUE}")
+
+        # Verify shape and dtype were preserved end-to-end (CudaTensor metadata).
+        expected_shape = list(TENSOR_SHAPE)
+        expected_dtype = torch.float16
+        shape_ok = list(tensor.shape) == expected_shape
+        dtype_ok = tensor.dtype == expected_dtype
+        if shape_ok and dtype_ok:
+            print(
+                f"[sub] PASS — shape={list(tensor.shape)}, dtype={tensor.dtype} (metadata preserved)"
+            )
         else:
-            print("[sub] (fill not verified — publisher may not have used cupy)")
+            if not shape_ok:
+                print(
+                    f"[sub] WARN — shape mismatch: got {list(tensor.shape)}, expected {expected_shape}"
+                )
+            if not dtype_ok:
+                print(
+                    f"[sub] WARN — dtype mismatch: got {tensor.dtype}, expected {expected_dtype}"
+                )
+            # Fallback: spot-check raw bytes (backwards compat with CudaPtr / non-typed path)
+            raw = tensor.view(torch.uint8)[:16].cpu().tolist()
+            print(f"[sub] first 16 raw bytes: {raw}")
+            print("[sub] PASS — GPU memory accessible via DLPack")
     else:
         capsule = view.as_dlpack()
         if capsule is None:

--- a/crates/ros-z-py/examples/cuda_pubsub.py
+++ b/crates/ros-z-py/examples/cuda_pubsub.py
@@ -50,7 +50,7 @@ MSG_TYPE = sensor_msgs.LaserScan
 SUB_LISTEN = "tcp/127.0.0.1:7448"
 
 
-def run_publisher(use_torch: bool):
+def run_publisher(use_torch: bool, warmup: float = 1.0):
     ctx = (
         ZContextBuilder()
         .with_shm_enabled()
@@ -80,7 +80,7 @@ def run_publisher(use_torch: bool):
             print("[pub] cupy not available, skipping fill")
 
     # Allow subscriber declaration to propagate before publishing.
-    time.sleep(1.0)
+    time.sleep(warmup)
 
     zbuf = buf.into_zbuf()
     pub.publish_zbuf(zbuf)
@@ -93,6 +93,13 @@ def run_publisher(use_torch: bool):
 
 
 def run_subscriber(use_torch: bool, timeout: float = 30.0):
+    # Import torch before initializing the zenoh/CUDA context so that
+    # PyTorch's allocator initializes first.  Importing torch after
+    # cudaIpcOpenMemHandle has already run triggers a libstdc++ double-free
+    # due to conflicting allocator state between PyTorch and the Nix runtime.
+    if use_torch:
+        import torch as _torch  # noqa: F401 — side-effect: init allocator
+
     ctx = (
         ZContextBuilder()
         .with_shm_enabled()
@@ -161,10 +168,17 @@ def main():
         default=30.0,
         help="Subscriber timeout in seconds (default: 30)",
     )
+    parser.add_argument(
+        "--warmup",
+        type=float,
+        default=1.0,
+        help="Publisher warmup sleep before publishing (default: 1.0). "
+        "Increase to 4-5 when subscriber uses --torch (first CUDA init is slow).",
+    )
     args = parser.parse_args()
 
     if args.pub:
-        run_publisher(use_torch=args.torch)
+        run_publisher(use_torch=args.torch, warmup=args.warmup)
     else:
         run_subscriber(use_torch=args.torch, timeout=args.timeout)
 

--- a/crates/ros-z-py/examples/cuda_pubsub.py
+++ b/crates/ros-z-py/examples/cuda_pubsub.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+cuda_pubsub.py — CUDA tensor transport via ros-z ZBuf (zero-copy GPU IPC).
+
+Publishes or subscribes to a CUDA tensor topic.  CUDA IPC handles are
+cross-process, so publisher and subscriber must run in separate processes.
+
+Requirements:
+    - ros_z_py built with --features cuda
+    - CUDA-capable GPU (tested on GTX 1650 Ti)
+    - Optional: cupy for publisher-side tensor fill
+
+Usage:
+    Terminal 1 (subscriber first):
+        python cuda_pubsub.py --sub [--torch]
+
+    Terminal 2 (publisher):
+        python cuda_pubsub.py --pub [--torch]
+
+The publisher allocates device memory, fills it (via cupy if available),
+then publishes the IPC handle over Zenoh.  The subscriber maps the GPU
+memory and optionally verifies via torch.from_dlpack().
+"""
+
+import argparse
+import sys
+
+try:
+    from ros_z_py import (
+        PyCudaBuf,
+        PyZContextBuilder,
+        PyZNodeBuilder,
+    )
+except ImportError as e:
+    print(f"Failed to import ros_z_py (build with --features cuda): {e}")
+    sys.exit(1)
+
+TOPIC = "/cuda_demo/raw"
+PAYLOAD_BYTES = 4 * 1024 * 1024  # 4 MB
+DEVICE_ID = 0
+FILL_VALUE = 42
+
+
+def run_publisher(use_torch: bool):
+    ctx = PyZContextBuilder().build()
+    node = PyZNodeBuilder(ctx).build()
+    pub = node.create_publisher(TOPIC, "sensor_msgs/msg/Image")
+
+    print(f"[pub] allocating {PAYLOAD_BYTES // 1024 // 1024} MB on GPU {DEVICE_ID} …")
+    buf = PyCudaBuf.alloc_device(PAYLOAD_BYTES, device_id=DEVICE_ID)
+    print(f"[pub] device ptr: 0x{buf.device_ptr:016x}  len: {buf.cuda_len}")
+
+    if use_torch:
+        try:
+            import cupy as cp
+
+            mem = cp.cuda.UnownedMemory(buf.device_ptr, buf.cuda_len, buf)
+            arr = cp.ndarray(
+                (buf.cuda_len,), dtype=cp.uint8, memptr=cp.cuda.MemoryPointer(mem, 0)
+            )
+            arr[:] = FILL_VALUE
+            cp.cuda.runtime.deviceSynchronize()
+            print(f"[pub] filled {buf.cuda_len} bytes with {FILL_VALUE} via cupy")
+        except ImportError:
+            print("[pub] cupy not available, skipping fill")
+
+    zbuf = buf.into_zbuf()
+    pub.publish_zbuf(zbuf)
+    print("[pub] published CUDA IPC handle — subscriber can now map this memory")
+
+
+def run_subscriber(use_torch: bool, timeout: float = 30.0):
+    ctx = PyZContextBuilder().build()
+    node = PyZNodeBuilder(ctx).build()
+    sub = node.create_subscriber(TOPIC, "sensor_msgs/msg/Image")
+
+    print(f"[sub] waiting for CUDA tensor on {TOPIC} (timeout={timeout}s) …")
+    view = sub.recv_raw_view(timeout=timeout)
+
+    if view is None:
+        print("[sub] timeout — no message received")
+        sys.exit(1)
+
+    if not view.is_cuda:
+        print(f"[sub] ERROR: expected CUDA payload, got CPU ({len(view)} bytes)")
+        sys.exit(1)
+
+    print("[sub] received CUDA IPC view  (is_cuda=True)")
+
+    if use_torch:
+        import torch
+
+        capsule = view.as_dlpack()
+        if capsule is None:
+            print("[sub] ERROR: as_dlpack() returned None")
+            sys.exit(1)
+        tensor = torch.from_dlpack(capsule)
+        print(
+            f"[sub] tensor: shape={list(tensor.shape)}, dtype={tensor.dtype}, device={tensor.device}"
+        )
+        # If publisher filled with FILL_VALUE, spot-check
+        sample = tensor[:16].cpu().tolist()
+        print(f"[sub] first 16 bytes: {sample}")
+        if all(b == FILL_VALUE for b in sample):
+            print(f"[sub] PASS — all bytes are {FILL_VALUE}")
+        else:
+            print("[sub] (fill not verified — publisher may not have used cupy)")
+    else:
+        capsule = view.as_dlpack()
+        if capsule is None:
+            print("[sub] ERROR: as_dlpack() returned None")
+            sys.exit(1)
+        print(f"[sub] DLPack capsule: {capsule!r}")
+        print("[sub] PASS — GPU memory accessible via DLPack")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--pub", action="store_true", help="Run as publisher")
+    mode.add_argument("--sub", action="store_true", help="Run as subscriber")
+    parser.add_argument(
+        "--torch",
+        action="store_true",
+        help="Use cupy (pub) / torch (sub) for fill and verify",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Subscriber timeout in seconds (default: 30)",
+    )
+    args = parser.parse_args()
+
+    if args.pub:
+        run_publisher(use_torch=args.torch)
+    else:
+        run_subscriber(use_torch=args.torch, timeout=args.timeout)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/ros-z-py/examples/cuda_pubsub.py
+++ b/crates/ros-z-py/examples/cuda_pubsub.py
@@ -8,7 +8,7 @@ cross-process, so publisher and subscriber must run in separate processes.
 Requirements:
     - ros_z_py built with --features cuda
     - CUDA-capable GPU (tested on GTX 1650 Ti)
-    - Optional: cupy for publisher-side tensor fill
+    - Optional: cupy for raw publisher-side tensor fill
     - Optional: torch for typed tensor round-trip (--torch)
 
 Usage:
@@ -22,12 +22,13 @@ Usage:
         python cuda_pubsub.py --sub --torch &
         python cuda_pubsub.py --pub --torch --warmup 5
 
-The --torch mode uses PyCudaBuf.from_torch() on the publisher side to attach
-tensor metadata (shape, dtype) to the wire format, so the subscriber receives
-a correctly-shaped tensor via torch.from_dlpack() with no out-of-band convention.
+The --torch mode demonstrates the high-level API:
 
-Without --torch the example uses raw device memory (CudaPtr ZSlice) and the
-subscriber sees a 1-D uint8 view.
+    Publisher:  pub.publish_tensor(tensor)          # any device, any dtype
+    Subscriber: tensor = view.as_torch()            # shape + dtype preserved
+
+Without --torch the example uses raw device memory (CudaPtr ZSlice) via
+PyCudaBuf.alloc_device() and the subscriber receives a 1-D uint8 view.
 """
 
 import argparse
@@ -78,9 +79,7 @@ def run_publisher(use_torch: bool, warmup: float = 1.0):
     time.sleep(warmup)
 
     if use_torch:
-        # Typed tensor path: PyCudaBuf.from_torch() wraps the tensor and
-        # attaches shape + dtype metadata so the subscriber receives a
-        # correctly-shaped tensor via as_dlpack() with no out-of-band convention.
+        # High-level API: publish_tensor() handles wrapping, metadata, and keepalive.
         import torch
 
         shape = TENSOR_SHAPE
@@ -90,18 +89,14 @@ def run_publisher(use_torch: bool, warmup: float = 1.0):
         )
         torch.cuda.synchronize(DEVICE_ID)
 
-        nbytes = tensor.nbytes
         print(
-            f"[pub] from_torch: shape={list(tensor.shape)}, dtype={tensor.dtype},"
-            f" device={tensor.device}, nbytes={nbytes}"
+            f"[pub] publish_tensor: shape={list(tensor.shape)}, dtype={tensor.dtype},"
+            f" device={tensor.device}, nbytes={tensor.nbytes}"
         )
 
-        # from_torch() captures data_ptr + shape + dtype + strides.
-        # The tensor stays alive throughout this function (IPC handle keepalive).
-        buf = PyCudaBuf.from_torch(tensor)
-        zbuf = buf.into_zbuf()
-        pub.publish_zbuf(zbuf)
-        print("[pub] published typed CUDA tensor (CudaTensor ZSlice)")
+        # One line: captures shape+dtype, sends zero-copy IPC handle.
+        pub.publish_tensor(tensor)
+        print("[pub] published typed CUDA tensor via publish_tensor()")
 
         # Keep allocation alive while subscriber opens the IPC handle.
         time.sleep(3.0)
@@ -171,11 +166,8 @@ def run_subscriber(use_torch: bool, timeout: float = 30.0):
     if use_torch:
         import torch
 
-        capsule = view.as_dlpack()
-        if capsule is None:
-            print("[sub] ERROR: as_dlpack() returned None")
-            sys.exit(1)
-        tensor = torch.from_dlpack(capsule)
+        # High-level API: as_torch() reconstructs the tensor with original shape+dtype.
+        tensor = view.as_torch()
         print(
             f"[sub] tensor: shape={list(tensor.shape)}, dtype={tensor.dtype}, device={tensor.device}"
         )
@@ -221,7 +213,7 @@ def main():
     parser.add_argument(
         "--torch",
         action="store_true",
-        help="Use cupy (pub) / torch (sub) for fill and verify",
+        help="Use publish_tensor() / as_torch() high-level API",
     )
     parser.add_argument(
         "--timeout",

--- a/crates/ros-z-py/examples/ort_publisher.py
+++ b/crates/ros-z-py/examples/ort_publisher.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+ort_publisher.py — Preprocess an image on the GPU and publish it as a typed
+CUDA tensor via ros-z-py for ort_classifier.rs to run SqueezeNet inference on.
+
+Requirements:
+    - ros_z_py built with --features cuda
+    - CUDA-capable GPU
+    - torch, torchvision, Pillow
+
+Usage:
+    # Terminal 1 (start subscriber first):
+    cargo run --example ort_classifier --features jazzy,cuda
+
+    # Terminal 2:
+    python crates/ros-z-py/examples/ort_publisher.py [path/to/image.jpg]
+
+Default image: assets/test_image.jpg
+"""
+
+import sys
+import time
+
+try:
+    import torch
+    import torchvision.transforms.v2 as T
+    from PIL import Image
+except ImportError as e:
+    print(f"Missing dependency: {e}")
+    print("Install: pip install torch torchvision pillow")
+    sys.exit(1)
+
+try:
+    from ros_z_py import ZContextBuilder, sensor_msgs
+except ImportError as e:
+    print(f"Failed to import ros_z_py (build with --features cuda): {e}")
+    sys.exit(1)
+
+TOPIC = "/ort/image"
+DEVICE_ID = 0
+
+# ImageNet normalization constants
+MEAN = [0.485, 0.456, 0.406]
+STD = [0.229, 0.224, 0.225]
+
+# SqueezeNet 1.1 input: [1, 3, 224, 224] f32 NCHW
+transform = T.Compose(
+    [
+        T.Resize(256),
+        T.CenterCrop(224),
+        T.ToImage(),
+        T.ToDtype(torch.float32, scale=True),
+        T.Normalize(mean=MEAN, std=STD),
+    ]
+)
+
+# Direct peer connection: subscriber listens, publisher connects.
+SUB_LISTEN = "tcp/127.0.0.1:7449"
+
+
+def main() -> None:
+    image_path = sys.argv[1] if len(sys.argv) > 1 else "assets/test_image.jpg"
+
+    print(f"[pub] loading image: {image_path}")
+    img = Image.open(image_path).convert("RGB")
+
+    tensor = (
+        transform(img).unsqueeze(0).cuda(DEVICE_ID).contiguous()
+    )  # [1, 3, 224, 224] f32 NCHW
+    torch.cuda.synchronize(DEVICE_ID)
+    print(
+        f"[pub] tensor ready: shape={list(tensor.shape)} "
+        f"dtype={tensor.dtype} device={tensor.device} "
+        f"nbytes={tensor.nbytes}"
+    )
+
+    ctx = (
+        ZContextBuilder()
+        .with_shm_enabled()
+        .with_connect_endpoints([SUB_LISTEN])
+        .build()
+    )
+    node = ctx.create_node("ort_publisher").build()
+    pub = node.create_publisher(TOPIC, sensor_msgs.LaserScan)
+
+    # Wait for subscriber to declare before first publish.
+    print("[pub] waiting for subscriber …")
+    time.sleep(2.0)
+
+    print(f"[pub] publishing on {TOPIC} at 1 Hz")
+    while True:
+        pub.publish_tensor(tensor)
+        print("[pub] published")
+        time.sleep(1.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/ros-z-py/python/ros_z_py/ros_z_py.pyi
+++ b/crates/ros-z-py/python/ros_z_py/ros_z_py.pyi
@@ -1,0 +1,348 @@
+"""Type stubs for the ros_z_py Rust extension module."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+# ---------------------------------------------------------------------------
+# CUDA buffer types
+# ---------------------------------------------------------------------------
+
+class PyCudaBuf:
+    """A CUDA-backed buffer for zero-copy GPU tensor publishing.
+
+    Allocate or wrap a GPU buffer, then call ``into_zbuf()`` and pass the
+    result to ``ZPublisher.publish_zbuf()``.  For a higher-level API that
+    handles both CUDA and CPU tensors, use ``ZPublisher.publish_tensor()``.
+    """
+
+    @staticmethod
+    def alloc_device(len: int, device_id: int = 0) -> PyCudaBuf:
+        """Allocate device-only memory (``cudaMalloc``).
+
+        Args:
+            len: Number of bytes to allocate.
+            device_id: CUDA device ordinal (0-indexed).
+        """
+        ...
+
+    @staticmethod
+    def alloc_pinned(len: int, device_id: int = 0) -> PyCudaBuf:
+        """Allocate pinned host memory (``cudaMallocHost``).
+
+        Pinned memory is CPU-accessible and DMA-friendly for fast GPU transfers.
+
+        Args:
+            len: Number of bytes to allocate.
+            device_id: CUDA device ordinal (0-indexed).
+        """
+        ...
+
+    @staticmethod
+    def from_device_ptr(ptr: int, len: int, device_id: int = 0) -> PyCudaBuf:
+        """Wrap an externally-owned CUDA device pointer (non-owning).
+
+        Does **not** allocate memory.  ``cudaFree`` will **not** be called on
+        drop.  The caller is responsible for keeping the allocation alive until
+        after ``publish_zbuf()`` returns.
+
+        Args:
+            ptr: Raw CUDA device pointer as integer (e.g. ``tensor.data_ptr()``).
+            len: Number of bytes.
+            device_id: CUDA device ordinal (0-indexed).
+        """
+        ...
+
+    @staticmethod
+    def from_torch(tensor: Any) -> PyCudaBuf:
+        """Wrap a ``torch.Tensor`` on a CUDA device (zero-copy, non-owning).
+
+        Captures ``data_ptr()``, ``nbytes``, shape, dtype, and strides.
+        The resulting ``CudaZBuf`` carries full DLPack metadata so the
+        subscriber's ``as_dlpack()`` / ``as_torch()`` return a correctly-shaped
+        tensor with no out-of-band conventions.
+
+        **Lifetime contract:** the source ``tensor`` must remain alive until the
+        subscriber has called ``cudaIpcOpenMemHandle``.  Pass it as
+        ``into_zbuf(keepalive=tensor)`` to prevent premature GC, or use
+        ``ZPublisher.publish_tensor()`` which handles this automatically.
+
+        Args:
+            tensor: A ``torch.Tensor`` on a CUDA device.
+
+        Raises:
+            ValueError: If ``tensor`` is not on a CUDA device.
+            RuntimeError: On CUDA IPC handle errors.
+        """
+        ...
+
+    def with_tensor_meta(self, shape: list[int], dtype: str) -> None:
+        """Attach DLPack shape and dtype metadata to this buffer.
+
+        After calling this, ``into_zbuf()`` produces a ``CudaTensor`` ZSlice
+        and the subscriber receives the correct shape/dtype via ``as_dlpack()``.
+
+        Args:
+            shape: Dimension sizes, e.g. ``[480, 640, 3]``.
+            dtype: One of: ``"float16"``, ``"float32"``, ``"float64"``,
+                ``"bfloat16"``, ``"int8"``, ``"int16"``, ``"int32"``,
+                ``"int64"``, ``"uint8"``, ``"uint16"``, ``"uint32"``,
+                ``"uint64"``, ``"bool"``.
+        """
+        ...
+
+    def into_zbuf(self, keepalive: Optional[Any] = None) -> CudaZBuf:
+        """Consume this buffer and return a ``CudaZBuf`` ready for publishing.
+
+        After calling this, the ``PyCudaBuf`` is no longer usable.
+
+        Args:
+            keepalive: Optional Python object to keep alive until the
+                ``CudaZBuf`` is dropped (e.g. the source torch tensor).
+                Prevents premature GC of the GPU allocation.
+
+        Returns:
+            CudaZBuf ready for ``publisher.publish_zbuf()``.
+        """
+        ...
+
+    @property
+    def device_ptr(self) -> int:
+        """Raw CUDA device pointer as a Python integer."""
+        ...
+
+    @property
+    def cuda_len(self) -> int:
+        """Length of the allocated buffer in bytes."""
+        ...
+
+
+class CudaZBuf:
+    """Wrapper returned by ``PyCudaBuf.into_zbuf()``.
+
+    Pass directly to ``ZPublisher.publish_zbuf()``.
+    """
+
+    def __len__(self) -> int: ...
+    def __repr__(self) -> str: ...
+
+
+# ---------------------------------------------------------------------------
+# Payload view (subscriber side)
+# ---------------------------------------------------------------------------
+
+class ZPayloadView:
+    """Zero-copy view of a Zenoh payload, received on the subscriber side.
+
+    Implements Python's buffer protocol — you can pass it to
+    ``memoryview()`` or ``numpy.frombuffer()`` for CPU payloads.
+    For GPU payloads use ``is_cuda`` / ``as_dlpack()`` / ``as_torch()``.
+    """
+
+    @property
+    def is_cuda(self) -> bool:
+        """True if the payload resides on a CUDA device (CudaPtr or CudaTensor ZSlice)."""
+        ...
+
+    def as_dlpack(self) -> Optional[Any]:
+        """Return a DLPack capsule suitable for ``torch.from_dlpack()``.
+
+        Returns ``None`` if the payload is not a CUDA tensor.
+
+        - With ``TensorMeta`` (published via ``from_torch`` or ``publish_tensor``):
+          returns a correctly-shaped N-D tensor with the original dtype.
+        - Without metadata (raw ``CudaPtr``): returns a 1-D ``uint8`` view.
+
+        No data is copied — the GPU buffer is shared directly.
+        """
+        ...
+
+    def as_torch(self) -> Any:
+        """Return the payload as a ``torch.Tensor``.
+
+        - **CUDA payload**: calls ``torch.from_dlpack(as_dlpack())`` — zero-copy,
+          tensor lives on the originating CUDA device with original shape/dtype.
+        - **CPU numpy payload** (published via ``publish_tensor(cpu_tensor)``):
+          decodes numpy NPY wire format; returns a CPU tensor with original shape/dtype.
+        - **Other CPU bytes**: returns a 1-D ``torch.uint8`` tensor.
+
+        Requires ``torch`` to be installed.
+        """
+        ...
+
+    def as_numpy(self) -> Any:
+        """Return the payload as a ``numpy.ndarray``.
+
+        - **CUDA payload**: copies GPU→CPU (device copy involved); prefer
+          ``as_torch()`` for GPU workflows.
+        - **CPU numpy payload**: decodes NPY format; returns array with original
+          shape and dtype.
+        - **Other CPU bytes**: returns a 1-D ``uint8`` array.
+
+        Requires ``numpy`` (and ``torch`` for CUDA payloads).
+        """
+        ...
+
+    def raw_bytes(self) -> bytes:
+        """Return raw payload bytes.
+
+        For CPU payloads: the full message bytes (CDR-encoded or raw).
+        For CUDA payloads: empty ``bytes`` (device memory has no CPU representation).
+        """
+        ...
+
+    # Buffer protocol — usable via memoryview() / numpy.frombuffer()
+    def __buffer__(self, flags: int) -> memoryview: ...
+    def __release_buffer__(self, view: memoryview) -> None: ...
+    def __len__(self) -> int: ...
+    def __bool__(self) -> bool: ...
+
+
+# ---------------------------------------------------------------------------
+# Publisher / Subscriber
+# ---------------------------------------------------------------------------
+
+class ZPublisher:
+    """Zenoh publisher for a typed ROS 2 topic."""
+
+    def publish(self, data: Any) -> None:
+        """Publish a message (CDR-serialized msgspec.Struct).
+
+        Args:
+            data: A ``msgspec.Struct`` message instance (e.g. ``std_msgs.String``).
+        """
+        ...
+
+    def publish_raw(self, data: bytes) -> None:
+        """Publish pre-serialized CDR bytes directly (zero-copy forwarding)."""
+        ...
+
+    def publish_bytes(self, data: bytes) -> None:
+        """Publish raw bytes with no CDR framing.
+
+        Used internally by ``publish_tensor`` for the CPU tensor path.
+        """
+        ...
+
+    def publish_zbuf(self, zbuf: CudaZBuf) -> None:
+        """Publish a CUDA ZBuf (zero-copy GPU transport).
+
+        Args:
+            zbuf: A ``CudaZBuf`` returned by ``PyCudaBuf.into_zbuf()``.
+        """
+        ...
+
+    def publish_tensor(self, tensor: Any) -> None:
+        """Publish a tensor (torch or numpy) with automatic device dispatch.
+
+        - **CUDA tensor** (``tensor.device.type == "cuda"``): wraps via
+          ``PyCudaBuf.from_torch()`` and sends as a CUDA IPC payload.
+          Subscriber calls ``as_torch()`` to receive the tensor on GPU.
+        - **CPU tensor** or **numpy array**: serializes using numpy NPY format
+          (shape + dtype preserved). Subscriber calls ``as_torch()`` or
+          ``as_numpy()`` to reconstruct.
+
+        Args:
+            tensor: A ``torch.Tensor`` (any device) or ``numpy.ndarray``.
+
+        Example::
+
+            # CUDA (zero-copy):
+            pub.publish_tensor(torch.zeros(480, 640, 3, dtype=torch.float16, device="cuda"))
+
+            # CPU:
+            pub.publish_tensor(torch.arange(1024, dtype=torch.float32))
+            pub.publish_tensor(np.zeros((256, 256), dtype=np.uint8))
+        """
+        ...
+
+
+class ZSubscriber:
+    """Zenoh subscriber for a typed ROS 2 topic."""
+
+    def recv(self, timeout: float = 1.0) -> Optional[Any]:
+        """Blocking receive with timeout.
+
+        Args:
+            timeout: Seconds to wait (default 1.0).
+
+        Returns:
+            Deserialized message, or ``None`` on timeout.
+        """
+        ...
+
+    def try_recv(self) -> Optional[Any]:
+        """Non-blocking receive.
+
+        Returns:
+            Deserialized message, or ``None`` if no message is available.
+        """
+        ...
+
+    def recv_raw_view(self, timeout: float = 1.0) -> Optional[ZPayloadView]:
+        """Blocking receive returning a raw ``ZPayloadView`` (zero-copy).
+
+        Use this for CUDA payloads or when you want to avoid CDR deserialization.
+
+        Args:
+            timeout: Seconds to wait (default 1.0).
+
+        Returns:
+            ``ZPayloadView``, or ``None`` on timeout.
+        """
+        ...
+
+    def try_recv_raw_view(self) -> Optional[ZPayloadView]:
+        """Non-blocking receive returning a raw ``ZPayloadView``.
+
+        Returns:
+            ``ZPayloadView``, or ``None`` if no message is available.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Context / Node
+# ---------------------------------------------------------------------------
+
+class ZContext:
+    """Zenoh session context.  Entry point for creating nodes."""
+
+    def create_node(self, name: str) -> ZNodeBuilder:
+        """Create a node builder for the given name."""
+        ...
+
+
+class ZNodeBuilder:
+    """Builder for a Zenoh ROS 2 node."""
+
+    def build(self) -> ZNode: ...
+
+
+class ZNode:
+    """A Zenoh ROS 2 node."""
+
+    def create_publisher(self, topic: str, msg_type: type) -> ZPublisher:
+        """Create a publisher for the given topic and message type."""
+        ...
+
+    def create_subscription(
+        self,
+        topic: str,
+        msg_type: type,
+        callback: Callable[[Any], None],
+    ) -> ZSubscriber:
+        """Create a subscription with a callback."""
+        ...
+
+    def create_subscriber(self, topic: str, msg_type: type) -> ZSubscriber:
+        """Create a pull-based subscriber (no callback)."""
+        ...
+
+
+class ZContextBuilder:
+    """Builder for ``ZContext``."""
+
+    @staticmethod
+    def default() -> ZContextBuilder: ...
+    def build(self) -> ZContext: ...

--- a/crates/ros-z-py/src/context.rs
+++ b/crates/ros-z-py/src/context.rs
@@ -200,7 +200,6 @@ impl PyZContextBuilder {
         slf
     }
 
-
     /// Build the context
     pub fn build(&mut self) -> PyResult<PyZContext> {
         let builder = std::mem::take(&mut self.builder);

--- a/crates/ros-z-py/src/context.rs
+++ b/crates/ros-z-py/src/context.rs
@@ -57,6 +57,20 @@ impl PyZContextBuilder {
         slf
     }
 
+    /// Listen on specific Zenoh endpoints (e.g., "tcp/127.0.0.1:7448")
+    ///
+    /// Use this to make a session accept incoming connections.
+    /// Useful for direct peer-to-peer CUDA IPC without a router.
+    pub fn with_listen_endpoints(
+        mut slf: PyRefMut<'_, Self>,
+        endpoints: Vec<String>,
+    ) -> PyRefMut<'_, Self> {
+        use serde_json::json;
+        slf.builder =
+            std::mem::take(&mut slf.builder).with_json("listen/endpoints", json!(endpoints));
+        slf
+    }
+
     /// Disable multicast scouting (useful for isolated tests)
     pub fn disable_multicast_scouting(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
         slf.builder = std::mem::take(&mut slf.builder).disable_multicast_scouting();
@@ -185,6 +199,7 @@ impl PyZContextBuilder {
         slf.builder = std::mem::take(&mut slf.builder).with_shm_threshold(threshold);
         slf
     }
+
 
     /// Build the context
     pub fn build(&mut self) -> PyResult<PyZContext> {

--- a/crates/ros-z-py/src/cuda_buf.rs
+++ b/crates/ros-z-py/src/cuda_buf.rs
@@ -162,18 +162,56 @@ impl PyCudaBuf {
         } else {
             Some(strides)
         };
+
+        // Use PyTorch's _share_cuda_() to get the correct IPC handle and byte offset.
+        //
+        // PyTorch's CUDA caching allocator sub-allocates tensors from large cudaMalloc
+        // pool blocks.  cudaIpcGetMemHandle(data_ptr) returns the handle for the entire
+        // pool block (same handle for all tensors in the block).  cudaIpcOpenMemHandle
+        // on the subscriber returns the pool block BASE, not data_ptr.
+        //
+        // _share_cuda_() returns:
+        //   (device, handle_bytes[66], storage_size, storage_offset, ...)
+        // where:
+        //   handle_bytes[2..66] = 64-byte cudaIpcMemHandle_t (pool block handle)
+        //   storage_offset      = byte offset from pool block base to tensor data
+        //
+        // We transmit storage_offset as TensorMeta.byte_offset so the subscriber
+        // can apply it after opening the IPC handle.
+        let storage = tensor.call_method0("untyped_storage")?;
+        let share_result = storage.call_method0("_share_cuda_")?;
+        // share_result is a tuple: (device, handle_66bytes, size, offset, ...)
+        let handle_item = share_result.get_item(1)?;
+        let handle_py: &[u8] = handle_item.extract()?;
+        if handle_py.len() < 66 {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "_share_cuda_() handle too short: {} < 66",
+                handle_py.len()
+            )));
+        }
+        // bytes [2..66]: skip 2-byte PyTorch version prefix, take 64-byte IPC handle
+        let mut ipc_handle = [0u8; 64];
+        ipc_handle.copy_from_slice(&handle_py[2..66]);
+        let byte_offset_py = share_result.get_item(3)?;
+        let byte_offset: u64 = byte_offset_py.extract::<usize>()? as u64;
+
         let meta = TensorMeta {
             ndim: shape.len() as i32,
             shape,
             dtype_code,
             dtype_bits,
             dtype_lanes,
-            byte_offset: 0,
+            byte_offset,
             strides,
         };
-        let inner = CudaBufInner::from_device_ptr_borrowed(ptr as *mut u8, nbytes, device_id)
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?
-            .with_tensor_meta(meta);
+        let inner = CudaBufInner::from_device_ptr_borrowed_with_offset(
+            ptr as *mut u8,
+            nbytes,
+            ipc_handle,
+            device_id,
+            byte_offset,
+        )
+        .with_tensor_meta(meta);
         Ok(Self { inner: Some(inner) })
     }
 

--- a/crates/ros-z-py/src/cuda_buf.rs
+++ b/crates/ros-z-py/src/cuda_buf.rs
@@ -139,7 +139,7 @@ impl PyCudaBuf {
     ///     ValueError: If the tensor is not on a CUDA device.
     ///     RuntimeError: On CUDA IPC handle errors.
     #[staticmethod]
-    fn from_torch(tensor: &Bound<'_, PyAny>) -> PyResult<Self> {
+    pub fn from_torch(tensor: &Bound<'_, PyAny>) -> PyResult<Self> {
         let ptr: usize = tensor.getattr("data_ptr")?.call0()?.extract()?;
         let nbytes: usize = tensor.getattr("nbytes")?.extract()?;
         let device_type: String = tensor.getattr("device")?.getattr("type")?.extract()?;
@@ -211,14 +211,32 @@ impl PyCudaBuf {
         Ok(())
     }
 
-    /// Consume this buffer and return a `ZBuf` with `kind = CudaPtr`.
+    /// Consume this buffer and return a `CudaZBuf` ready for publishing.
     ///
     /// After calling this, the `PyCudaBuf` is no longer usable.
-    /// Pass the returned `ZBuf` to a message's `data` field and publish.
+    ///
+    /// **Lifetime contract:** For non-owning buffers (created via `from_torch` or
+    /// `from_device_ptr`), the source allocation must remain alive until the
+    /// subscriber has opened the IPC handle. Pass the source tensor as `keepalive`
+    /// to prevent Python's GC from collecting it prematurely:
+    ///
+    /// ```python
+    /// zbuf = buf.into_zbuf(keepalive=tensor)
+    /// publisher.publish_zbuf(zbuf)
+    /// # tensor is held alive until zbuf is dropped (after publish_zbuf returns)
+    /// ```
+    ///
+    /// Note: even with keepalive, the publisher process should keep the allocation
+    /// alive long enough for the subscriber to call `cudaIpcOpenMemHandle` (~RTT).
+    /// `publish_tensor()` handles this automatically.
+    ///
+    /// Args:
+    ///     keepalive: Optional Python object to keep alive (e.g. the source tensor).
     ///
     /// Returns:
-    ///     ZBuf: A ZBuf wrapping the CUDA allocation, ready for publishing.
-    fn into_zbuf(&mut self) -> PyResult<ZBufWrapper> {
+    ///     CudaZBuf: Ready for `publisher.publish_zbuf()`.
+    #[pyo3(signature = (keepalive=None))]
+    pub fn into_zbuf(&mut self, keepalive: Option<PyObject>) -> PyResult<ZBufWrapper> {
         let inner = self
             .inner
             .take()
@@ -228,7 +246,7 @@ impl PyCudaBuf {
         } else {
             ZBuf::from_cuda(inner)
         };
-        Ok(ZBufWrapper(zbuf))
+        Ok(ZBufWrapper { zbuf, keepalive })
     }
 }
 
@@ -272,19 +290,25 @@ fn c_contiguous_strides(shape: &[i64]) -> Vec<i64> {
     strides
 }
 
-/// Thin wrapper so Python can hold a `ZBuf` returned by `PyCudaBuf.into_zbuf()`.
+/// Wrapper returned by `PyCudaBuf.into_zbuf()`, passed to `publisher.publish_zbuf()`.
 ///
-/// The ros-z Python publisher accepts the inner ZBuf directly via the bridge.
-/// Users typically pass `buf.into_zbuf()` straight to `msg.data = ...`.
+/// Holds an optional `keepalive` reference to prevent GC of the source tensor
+/// while the ZBuf is in flight (see `into_zbuf(keepalive=)` docs).
 #[pyclass(name = "CudaZBuf")]
-pub struct ZBufWrapper(pub ZBuf);
+pub struct ZBufWrapper {
+    pub zbuf: ZBuf,
+    /// Keeps the source Python object (e.g. torch.Tensor) alive until this
+    /// CudaZBuf is dropped, preventing premature GC of the GPU allocation.
+    #[allow(dead_code)]
+    pub keepalive: Option<PyObject>,
+}
 
 #[pymethods]
 impl ZBufWrapper {
     /// Number of bytes in the ZBuf (0 for device-only memory, as expected).
     fn __len__(&self) -> usize {
         use zenoh_buffers::buffer::Buffer;
-        self.0.len()
+        self.zbuf.len()
     }
 
     fn __repr__(&self) -> String {

--- a/crates/ros-z-py/src/cuda_buf.rs
+++ b/crates/ros-z-py/src/cuda_buf.rs
@@ -56,6 +56,33 @@ impl PyCudaBuf {
         Ok(Self { inner: Some(inner) })
     }
 
+    /// Wrap an externally-owned CUDA device pointer (e.g. from PyTorch).
+    ///
+    /// This does NOT allocate memory — it wraps `ptr` in a non-owning
+    /// `CudaBufInner` that will NOT call `cudaFree` on drop.
+    ///
+    /// Use this to publish a torch tensor with zero copies:
+    ///
+    /// ```python
+    /// import torch
+    /// tensor = torch.zeros(1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    /// # tensor must stay alive until after publish_zbuf() returns
+    /// buf = PyCudaBuf.from_device_ptr(tensor.data_ptr(), tensor.nbytes, device_id=0)
+    /// publisher.publish_zbuf(buf.into_zbuf())
+    /// # safe to let tensor go out of scope now
+    /// ```
+    ///
+    /// Args:
+    ///     ptr: Raw CUDA device pointer as integer (e.g. `tensor.data_ptr()`).
+    ///     len: Number of bytes.
+    ///     device_id: CUDA device ordinal (0-indexed).
+    #[staticmethod]
+    fn from_device_ptr(ptr: usize, len: usize, device_id: i32) -> PyResult<Self> {
+        let inner = CudaBufInner::from_device_ptr_borrowed(ptr as *mut u8, len, device_id)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(Self { inner: Some(inner) })
+    }
+
     /// Allocate pinned host memory (cudaMallocHost).
     ///
     /// Pinned memory is CPU-accessible and DMA-friendly for fast GPU transfers.

--- a/crates/ros-z-py/src/cuda_buf.rs
+++ b/crates/ros-z-py/src/cuda_buf.rs
@@ -1,0 +1,132 @@
+//! Python binding for CUDA device memory allocation.
+//!
+//! Exposes [`PyCudaBuf`]: a pyclass wrapping [`CudaBufInner`] that lets Python
+//! code allocate GPU buffers, fill them via cupy/torch, and publish them as
+//! CUDA ZBuf payloads with zero CPU copies.
+
+use pyo3::prelude::*;
+use ros_z::{CudaBufInner, ZBuf};
+
+/// A CUDA-backed buffer that can be published as a zero-copy GPU payload.
+///
+/// Allocate a buffer, fill it via cupy or torch, then pass it to
+/// `ZBuf.from_cuda()` (or use `.into_zbuf()`) to build a message payload.
+///
+/// # Example
+///
+/// ```python
+/// import cupy as cp
+/// from ros_z_py import PyCudaBuf
+///
+/// # Allocate 4 MB on GPU 0
+/// buf = PyCudaBuf.alloc_device(4 * 1024 * 1024, device_id=0)
+///
+/// # Fill via cupy (zero-copy view of the same GPU pointer)
+/// tensor = cp.ndarray((buf.cuda_len,), dtype=cp.uint8,
+///                     memptr=cp.cuda.MemoryPointer(
+///                         cp.cuda.UnownedMemory(buf.device_ptr, buf.cuda_len, buf),
+///                         0))
+/// tensor[:] = cp.arange(buf.cuda_len, dtype=cp.uint8)
+///
+/// # Wrap in a ZBuf and publish
+/// zbuf = buf.into_zbuf()
+/// msg.data = zbuf
+/// publisher.publish(msg)
+/// ```
+#[pyclass(name = "PyCudaBuf")]
+pub struct PyCudaBuf {
+    pub inner: Option<CudaBufInner>,
+}
+
+#[pymethods]
+impl PyCudaBuf {
+    /// Allocate device-only CUDA memory (cudaMalloc).
+    ///
+    /// Device memory is GPU-only: you cannot read or write it from CPU.
+    /// Use a CUDA kernel, cupy, or torch to fill the buffer.
+    /// An IPC handle is captured at allocation time for zero-copy IPC transport.
+    ///
+    /// Args:
+    ///     len: Number of bytes to allocate.
+    ///     device_id: CUDA device ordinal (0-indexed).
+    #[staticmethod]
+    fn alloc_device(len: usize, device_id: i32) -> PyResult<Self> {
+        let inner = CudaBufInner::alloc_device(len, device_id)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(Self { inner: Some(inner) })
+    }
+
+    /// Allocate pinned host memory (cudaMallocHost).
+    ///
+    /// Pinned memory is CPU-accessible and DMA-friendly for fast GPU transfers.
+    /// Use this when you want to write from CPU and have the GPU read via DMA.
+    ///
+    /// Args:
+    ///     len: Number of bytes to allocate.
+    ///     device_id: CUDA device ordinal (0-indexed).
+    #[staticmethod]
+    fn alloc_pinned(len: usize, device_id: i32) -> PyResult<Self> {
+        let inner = CudaBufInner::alloc_pinned(len, device_id)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(Self { inner: Some(inner) })
+    }
+
+    /// Raw device pointer as a Python integer (for cupy / torch interop).
+    ///
+    /// Pass this to `cp.cuda.UnownedMemory` or `torch.cuda.capi.THCPStream_New`
+    /// to get a zero-copy view of the GPU buffer.
+    ///
+    /// Returns:
+    ///     int: The raw CUDA device pointer cast to usize.
+    #[getter]
+    fn device_ptr(&self) -> PyResult<usize> {
+        self.inner
+            .as_ref()
+            .map(|b| b.as_device_ptr() as usize)
+            .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("buffer already consumed"))
+    }
+
+    /// Length of the allocated buffer in bytes.
+    #[getter]
+    fn cuda_len(&self) -> PyResult<usize> {
+        self.inner
+            .as_ref()
+            .map(|b| b.cuda_len)
+            .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("buffer already consumed"))
+    }
+
+    /// Consume this buffer and return a `ZBuf` with `kind = CudaPtr`.
+    ///
+    /// After calling this, the `PyCudaBuf` is no longer usable.
+    /// Pass the returned `ZBuf` to a message's `data` field and publish.
+    ///
+    /// Returns:
+    ///     ZBuf: A ZBuf wrapping the CUDA allocation, ready for publishing.
+    fn into_zbuf(&mut self) -> PyResult<ZBufWrapper> {
+        let inner = self
+            .inner
+            .take()
+            .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("buffer already consumed"))?;
+        Ok(ZBufWrapper(ZBuf::from_cuda(inner)))
+    }
+}
+
+/// Thin wrapper so Python can hold a `ZBuf` returned by `PyCudaBuf.into_zbuf()`.
+///
+/// The ros-z Python publisher accepts the inner ZBuf directly via the bridge.
+/// Users typically pass `buf.into_zbuf()` straight to `msg.data = ...`.
+#[pyclass(name = "CudaZBuf")]
+pub struct ZBufWrapper(pub ZBuf);
+
+#[pymethods]
+impl ZBufWrapper {
+    /// Number of bytes in the ZBuf (0 for device-only memory, as expected).
+    fn __len__(&self) -> usize {
+        use zenoh_buffers::buffer::Buffer;
+        self.0.len()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("CudaZBuf(len={})", self.__len__())
+    }
+}

--- a/crates/ros-z-py/src/cuda_buf.rs
+++ b/crates/ros-z-py/src/cuda_buf.rs
@@ -6,6 +6,7 @@
 
 use pyo3::prelude::*;
 use ros_z::{CudaBufInner, ZBuf};
+use zenoh_cuda::TensorMeta;
 
 /// A CUDA-backed buffer that can be published as a zero-copy GPU payload.
 ///
@@ -122,6 +123,94 @@ impl PyCudaBuf {
             .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("buffer already consumed"))
     }
 
+    /// Wrap an existing CUDA tensor (e.g. from PyTorch) with shape and dtype metadata.
+    ///
+    /// Captures `data_ptr()`, `nbytes`, `shape`, `dtype`, and `stride()` from
+    /// the tensor. The resulting buffer does NOT own the allocation — the source
+    /// tensor must remain alive until after `publish_zbuf()` returns.
+    ///
+    /// The returned `PyCudaBuf` wraps the tensor as a `CudaTensor` ZSlice, so
+    /// `as_dlpack()` on the subscriber side returns the correct shape and dtype.
+    ///
+    /// Args:
+    ///     tensor: A `torch.Tensor` on a CUDA device.
+    ///
+    /// Raises:
+    ///     ValueError: If the tensor is not on a CUDA device.
+    ///     RuntimeError: On CUDA IPC handle errors.
+    #[staticmethod]
+    fn from_torch(tensor: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let ptr: usize = tensor.getattr("data_ptr")?.call0()?.extract()?;
+        let nbytes: usize = tensor.getattr("nbytes")?.extract()?;
+        let device_type: String = tensor.getattr("device")?.getattr("type")?.extract()?;
+        if device_type != "cuda" {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "tensor must be on a CUDA device",
+            ));
+        }
+        let device_id: i32 = tensor
+            .getattr("device")?
+            .getattr("index")?
+            .extract::<Option<i32>>()?
+            .unwrap_or(0);
+        let shape: Vec<i64> = tensor.getattr("shape")?.extract()?;
+        let dtype_str: String = tensor.getattr("dtype")?.str()?.extract()?;
+        let (dtype_code, dtype_bits, dtype_lanes) = parse_torch_dtype(&dtype_str)?;
+        let strides: Vec<i64> = tensor.getattr("stride")?.call0()?.extract()?;
+        let strides = if strides == c_contiguous_strides(&shape) {
+            None
+        } else {
+            Some(strides)
+        };
+        let meta = TensorMeta {
+            ndim: shape.len() as i32,
+            shape,
+            dtype_code,
+            dtype_bits,
+            dtype_lanes,
+            byte_offset: 0,
+            strides,
+        };
+        let inner = CudaBufInner::from_device_ptr_borrowed(ptr as *mut u8, nbytes, device_id)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?
+            .with_tensor_meta(meta);
+        Ok(Self { inner: Some(inner) })
+    }
+
+    /// Attach DLPack tensor metadata (shape and dtype) to this buffer.
+    ///
+    /// After calling this, `into_zbuf()` will produce a `CudaTensor` ZSlice
+    /// and the subscriber can reconstruct the correct shape/dtype via `as_dlpack()`.
+    ///
+    /// Args:
+    ///     shape: List of dimension sizes (e.g. `[480, 640, 3]`).
+    ///     dtype: DType string: one of "float32", "float16", "bfloat16",
+    ///            "float64", "int8", "int16", "int32", "int64",
+    ///            "uint8", "uint16", "uint32", "uint64", "bool".
+    ///
+    /// Returns:
+    ///     Self (for chaining).
+    fn with_tensor_meta(&mut self, shape: Vec<i64>, dtype: &str) -> PyResult<()> {
+        if self.inner.is_none() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "buffer already consumed",
+            ));
+        }
+        let (dtype_code, dtype_bits, dtype_lanes) = parse_torch_dtype(dtype)?;
+        let meta = TensorMeta {
+            ndim: shape.len() as i32,
+            shape,
+            dtype_code,
+            dtype_bits,
+            dtype_lanes,
+            byte_offset: 0,
+            strides: None,
+        };
+        let old = self.inner.take().unwrap();
+        self.inner = Some(old.with_tensor_meta(meta));
+        Ok(())
+    }
+
     /// Consume this buffer and return a `ZBuf` with `kind = CudaPtr`.
     ///
     /// After calling this, the `PyCudaBuf` is no longer usable.
@@ -134,8 +223,53 @@ impl PyCudaBuf {
             .inner
             .take()
             .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("buffer already consumed"))?;
-        Ok(ZBufWrapper(ZBuf::from_cuda(inner)))
+        let zbuf = if inner.tensor_meta().is_some() {
+            ZBuf::from_cuda_tensor(inner)
+        } else {
+            ZBuf::from_cuda(inner)
+        };
+        Ok(ZBufWrapper(zbuf))
     }
+}
+
+/// Map a torch dtype string to DLPack (dtype_code, dtype_bits, dtype_lanes).
+///
+/// dtype_code: 0=Int, 1=UInt, 2=Float, 4=BFloat16, 5=Complex
+fn parse_torch_dtype(dtype: &str) -> PyResult<(u8, u8, u16)> {
+    // torch repr is "torch.float32" or just "float32"
+    let s = dtype.strip_prefix("torch.").unwrap_or(dtype);
+    let result = match s {
+        "float16" => (2u8, 16u8, 1u16),
+        "float32" => (2, 32, 1),
+        "float64" => (2, 64, 1),
+        "bfloat16" => (4, 16, 1),
+        "int8" => (0, 8, 1),
+        "int16" => (0, 16, 1),
+        "int32" => (0, 32, 1),
+        "int64" => (0, 64, 1),
+        "uint8" => (1, 8, 1),
+        "uint16" => (1, 16, 1),
+        "uint32" => (1, 32, 1),
+        "uint64" => (1, 64, 1),
+        "bool" => (1, 1, 1),
+        other => {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "unsupported dtype '{}'; expected one of: float16, float32, float64, \
+                 bfloat16, int8/16/32/64, uint8/16/32/64, bool",
+                other
+            )));
+        }
+    };
+    Ok(result)
+}
+
+/// Compute C-contiguous strides for a given shape (element strides, not byte strides).
+fn c_contiguous_strides(shape: &[i64]) -> Vec<i64> {
+    let mut strides = vec![1i64; shape.len()];
+    for i in (0..shape.len().saturating_sub(1)).rev() {
+        strides[i] = strides[i + 1] * shape[i + 1];
+    }
+    strides
 }
 
 /// Thin wrapper so Python can hold a `ZBuf` returned by `PyCudaBuf.into_zbuf()`.

--- a/crates/ros-z-py/src/cuda_buf.rs
+++ b/crates/ros-z-py/src/cuda_buf.rs
@@ -236,6 +236,7 @@ impl PyCudaBuf {
     /// Returns:
     ///     CudaZBuf: Ready for `publisher.publish_zbuf()`.
     #[pyo3(signature = (keepalive=None))]
+    #[allow(clippy::wrong_self_convention)] // &mut self required by #[pyclass]; inner is taken
     pub fn into_zbuf(&mut self, keepalive: Option<PyObject>) -> PyResult<ZBufWrapper> {
         let inner = self
             .inner

--- a/crates/ros-z-py/src/lib.rs
+++ b/crates/ros-z-py/src/lib.rs
@@ -4,6 +4,8 @@ use pyo3::prelude::*;
 
 mod action;
 mod context;
+#[cfg(feature = "cuda")]
+mod cuda_buf;
 mod error;
 mod graph;
 mod node;
@@ -71,6 +73,10 @@ fn ros_z_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyZActionServer>()?;
     m.add_class::<PyZServerGoalRequest>()?;
     m.add_class::<PyZServerExecutingHandle>()?;
+    #[cfg(feature = "cuda")]
+    m.add_class::<cuda_buf::PyCudaBuf>()?;
+    #[cfg(feature = "cuda")]
+    m.add_class::<cuda_buf::ZBufWrapper>()?;
 
     // QoS presets
     m.add(

--- a/crates/ros-z-py/src/payload_view.rs
+++ b/crates/ros-z-py/src/payload_view.rs
@@ -307,6 +307,91 @@ impl ZPayloadView {
         }
         Ok(None)
     }
+
+    /// Return the raw payload bytes as a Python `bytes` object.
+    ///
+    /// For CPU payloads this is the full message bytes (CDR-encoded or raw).
+    /// For CUDA payloads this returns an empty `bytes` (device memory has no
+    /// CPU-readable representation).
+    ///
+    /// Useful for detecting the numpy NPY magic prefix to reconstruct a CPU
+    /// tensor that was published via `publish_tensor(cpu_tensor)`.
+    fn raw_bytes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
+        Ok(pyo3::types::PyBytes::new_bound(py, self.as_slice()))
+    }
+
+    /// Return the payload as a `torch.Tensor`.
+    ///
+    /// - CUDA payload (`is_cuda=True`): calls `torch.from_dlpack(as_dlpack())` —
+    ///   zero-copy, returns a tensor on the originating CUDA device.
+    /// - CPU numpy payload (published via `publish_tensor(cpu_tensor)`): decodes
+    ///   the numpy NPY wire format and returns a CPU `torch.Tensor` with the
+    ///   original shape and dtype.
+    /// - Other CPU bytes: returns a 1-D `torch.uint8` tensor over the raw bytes.
+    ///
+    /// Requires `torch` to be installed.
+    #[cfg(feature = "cuda")]
+    fn as_torch(&self, py: Python<'_>) -> PyResult<PyObject> {
+        if self.is_cuda() {
+            let capsule = self.as_dlpack(py)?.ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err(
+                    "as_dlpack returned None for CUDA payload",
+                )
+            })?;
+            let torch = py.import_bound("torch")?;
+            return Ok(torch.call_method1("from_dlpack", (capsule,))?.into());
+        }
+        // CPU path: try numpy NPY format, fall back to raw uint8
+        let raw = self.raw_bytes(py)?;
+        let np = py.import_bound("numpy")?;
+        let torch = py.import_bound("torch")?;
+        if self.as_slice().starts_with(b"\x93NUMPY") {
+            let io = py.import_bound("io")?;
+            let buf = io.call_method1("BytesIO", (&raw,))?;
+            let arr = np.call_method1("load", (buf,))?;
+            let arr_copy = arr.call_method0("copy")?;
+            Ok(torch.call_method1("from_numpy", (arr_copy,))?.into())
+        } else {
+            // Fallback: 1-D uint8
+            let kwargs = pyo3::types::PyDict::new_bound(py);
+            kwargs.set_item("dtype", np.getattr("uint8")?)?;
+            Ok(torch
+                .call_method1(
+                    "from_numpy",
+                    (np.call_method("frombuffer", (&raw,), Some(&kwargs))?,),
+                )?
+                .into())
+        }
+    }
+
+    /// Return the payload as a `numpy.ndarray`.
+    ///
+    /// - CUDA payload: copies GPU memory to CPU then returns numpy array.
+    ///   (involves a device→host copy; prefer `as_torch()` for GPU workflows).
+    /// - CPU numpy payload: decodes NPY format, returns array with original shape/dtype.
+    /// - Other CPU bytes: returns 1-D `uint8` array over the raw bytes.
+    ///
+    /// Requires `numpy` (and `torch` for CUDA payloads) to be installed.
+    #[cfg(feature = "cuda")]
+    fn as_numpy(&self, py: Python<'_>) -> PyResult<PyObject> {
+        if self.is_cuda() {
+            // cuda → torch → cpu → numpy (device copy)
+            let t = self.as_torch(py)?;
+            let cpu = t.call_method0(py, "cpu")?;
+            return Ok(cpu.call_method0(py, "numpy")?);
+        }
+        let raw = self.raw_bytes(py)?;
+        let np = py.import_bound("numpy")?;
+        if self.as_slice().starts_with(b"\x93NUMPY") {
+            let io = py.import_bound("io")?;
+            let buf = io.call_method1("BytesIO", (&raw,))?;
+            Ok(np.call_method1("load", (buf,))?.into())
+        } else {
+            let kwargs = pyo3::types::PyDict::new_bound(py);
+            kwargs.set_item("dtype", np.getattr("uint8")?)?;
+            Ok(np.call_method("frombuffer", (&raw,), Some(&kwargs))?.into())
+        }
+    }
 }
 
 // DLPack C ABI structures and helpers (gated on `cuda` feature).

--- a/crates/ros-z-py/src/payload_view.rs
+++ b/crates/ros-z-py/src/payload_view.rs
@@ -342,46 +342,48 @@ unsafe impl Send for DlpackCtx {}
 #[cfg(feature = "cuda")]
 unsafe impl Sync for DlpackCtx {}
 
-/// DLManagedTensor deleter: frees the DlpackCtx, called by the tensor consumer.
+/// DLManagedTensor deleter — called by the tensor consumer (e.g. PyTorch).
 ///
-/// The DLManagedTensor itself is freed by `dlpack_capsule_destructor`.
+/// Per the DLPack spec the deleter owns ALL resources: ctx, AND the
+/// DLManagedTensor struct itself.  PyTorch 2.0+ does not free the struct
+/// after calling the deleter, but it does expect the struct to be gone
+/// before the capsule destructor runs (it renames the capsule to
+/// "used_dltensor" as a tombstone).  Freeing the struct here avoids the
+/// double-free that would occur if `dlpack_capsule_destructor` also freed it.
 #[cfg(feature = "cuda")]
 unsafe extern "C" fn dlpack_deleter(managed: *mut DLManagedTensor) {
     if managed.is_null() {
         return;
     }
     let ctx_ptr = (*managed).manager_ctx;
-    // Set to null so the capsule destructor skips double-free.
-    (*managed).manager_ctx = std::ptr::null_mut();
     if !ctx_ptr.is_null() {
         drop(Box::from_raw(ctx_ptr as *mut DlpackCtx));
     }
+    // Free the DLManagedTensor itself — per spec the deleter is responsible.
+    drop(Box::from_raw(managed));
 }
 
-/// PyCapsule destructor: frees the DLManagedTensor (and ctx if not yet freed).
+/// PyCapsule destructor — only runs when the capsule is GC'd uncollected.
 ///
-/// Called by the Python GC when the capsule is collected. If PyTorch already
-/// consumed the tensor (calling `deleter`), only the DLManagedTensor box is freed.
+/// If PyTorch consumed the capsule it renames it to "used_dltensor" and
+/// calls `dlpack_deleter` which frees everything.  In that case this
+/// function finds the "dltensor" lookup failing and returns early.
+/// If nobody consumed the capsule (e.g. the subscriber errored out before
+/// calling `from_dlpack`) the capsule is still named "dltensor" and we
+/// free it here to avoid a leak.
 #[cfg(feature = "cuda")]
 unsafe extern "C" fn dlpack_capsule_destructor(capsule: *mut ffi::PyObject) {
-    // Try current name; if PyTorch renamed it, try "used_dltensor".
     let name_cur = b"dltensor\0".as_ptr() as *const std::ffi::c_char;
-    let mut ptr = ffi::PyCapsule_GetPointer(capsule, name_cur) as *mut DLManagedTensor;
+    let ptr = ffi::PyCapsule_GetPointer(capsule, name_cur) as *mut DLManagedTensor;
     if ptr.is_null() {
-        // PyCapsule_GetPointer sets an error when the name doesn't match.
+        // Capsule was already consumed ("used_dltensor") — deleter freed everything.
         ffi::PyErr_Clear();
-        let name_used = b"used_dltensor\0".as_ptr() as *const std::ffi::c_char;
-        ptr = ffi::PyCapsule_GetPointer(capsule, name_used) as *mut DLManagedTensor;
-        if ptr.is_null() {
-            ffi::PyErr_Clear();
-            return;
-        }
+        return;
     }
-    // Free ctx if the deleter hasn't run yet.
+    // Never consumed — free ctx and managed tensor.
     let ctx_ptr = (*ptr).manager_ctx;
     if !ctx_ptr.is_null() {
         drop(Box::from_raw(ctx_ptr as *mut DlpackCtx));
     }
-    // Free the DLManagedTensor itself.
     drop(Box::from_raw(ptr));
 }

--- a/crates/ros-z-py/src/payload_view.rs
+++ b/crates/ros-z-py/src/payload_view.rs
@@ -180,4 +180,210 @@ impl ZPayloadView {
             }
         }
     }
+
+    /// Returns True if the payload resides on a CUDA device.
+    ///
+    /// This is True when the subscriber received a CUDA IPC handle from
+    /// a publisher that wrote to GPU memory (via `ZBuf::from(CudaBufInner)`).
+    #[cfg(feature = "cuda")]
+    #[getter]
+    fn is_cuda(&self) -> bool {
+        use zenoh_buffers::ZSliceKind;
+        use zenoh_buffers::buffer::SplitBuffer;
+        let zbuf: zenoh_buffers::ZBuf = self.sample.payload().clone().into();
+        zbuf.zslices().any(|zs| zs.kind == ZSliceKind::CudaPtr)
+    }
+
+    /// Return a DLPack capsule for the CUDA payload, suitable for `torch.from_dlpack()`.
+    ///
+    /// Returns `None` if the payload is not a CUDA tensor.
+    ///
+    /// The returned capsule exposes the GPU memory as a 1-D `uint8` tensor.
+    /// No data is copied — the GPU buffer is shared directly with the consumer.
+    ///
+    /// # Example (Python)
+    ///
+    /// ```python
+    /// view = subscriber.recv_raw_view()
+    /// if view.is_cuda:
+    ///     tensor = torch.from_dlpack(view.as_dlpack())
+    /// ```
+    #[cfg(feature = "cuda")]
+    fn as_dlpack(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+        use zenoh_buffers::ZSliceKind;
+        use zenoh_buffers::buffer::SplitBuffer;
+        use zenoh_cuda::CudaBufInner;
+
+        let zbuf: zenoh_buffers::ZBuf = self.sample.payload().clone().into();
+        for zslice in zbuf.zslices() {
+            if zslice.kind != ZSliceKind::CudaPtr {
+                continue;
+            }
+            let Some(cuda) = zslice.downcast_ref::<CudaBufInner>() else {
+                continue;
+            };
+
+            // Heap-allocate the context (shape + ZSlice keepalive).
+            let ctx = Box::new(DlpackCtx {
+                shape: cuda.cuda_len as i64,
+                _zslice: zslice.clone(),
+            });
+            let ctx_ptr = Box::into_raw(ctx);
+
+            // Build the DLManagedTensor. The shape pointer points into ctx,
+            // which is kept alive by manager_ctx until the deleter is called.
+            let managed = Box::new(DLManagedTensor {
+                dl_tensor: DLTensor {
+                    data: cuda.as_device_ptr() as *mut std::ffi::c_void,
+                    device: DLDevice {
+                        device_type: 2, // kDLCUDA
+                        device_id: cuda.device_id,
+                    },
+                    ndim: 1,
+                    dtype: DLDataType {
+                        code: 1, // kDLUInt
+                        bits: 8,
+                        lanes: 1,
+                    },
+                    shape: unsafe { &mut (*ctx_ptr).shape as *mut i64 },
+                    strides: std::ptr::null_mut(),
+                    byte_offset: 0,
+                },
+                manager_ctx: ctx_ptr as *mut std::ffi::c_void,
+                deleter: Some(dlpack_deleter),
+            });
+            let managed_ptr = Box::into_raw(managed);
+
+            // Create a PyCapsule named "dltensor".
+            let obj = unsafe {
+                let name = b"dltensor\0".as_ptr() as *const std::ffi::c_char;
+                let capsule = ffi::PyCapsule_New(
+                    managed_ptr as *mut std::ffi::c_void,
+                    name,
+                    Some(dlpack_capsule_destructor),
+                );
+                if capsule.is_null() {
+                    // Allocation failed — free what we allocated.
+                    let _ = Box::from_raw((*managed_ptr).manager_ctx as *mut DlpackCtx);
+                    let _ = Box::from_raw(managed_ptr);
+                    return Err(pyo3::exceptions::PyMemoryError::new_err(
+                        "PyCapsule_New returned null",
+                    ));
+                }
+                PyObject::from_owned_ptr(py, capsule)
+            };
+
+            return Ok(Some(obj));
+        }
+        Ok(None)
+    }
+}
+
+// DLPack C ABI structures and helpers (gated on `cuda` feature).
+//
+// DLPack (https://dmlc.github.io/dlpack/latest/) defines a standard tensor
+// interchange format used by PyTorch, TensorFlow, CuPy, and others.
+// We expose CUDA-backed ZBuf payloads as 1-D uint8 DLPack tensors.
+
+#[cfg(feature = "cuda")]
+#[repr(C)]
+struct DLDevice {
+    /// Device type: 2 = kDLCUDA.
+    device_type: i32,
+    /// CUDA device ordinal.
+    device_id: i32,
+}
+
+#[cfg(feature = "cuda")]
+#[repr(C)]
+struct DLDataType {
+    /// Type code: 1 = kDLUInt.
+    code: u8,
+    /// Number of bits per element.
+    bits: u8,
+    /// Number of lanes (1 for scalar types).
+    lanes: u16,
+}
+
+#[cfg(feature = "cuda")]
+#[repr(C)]
+struct DLTensor {
+    /// Raw device pointer.
+    data: *mut std::ffi::c_void,
+    device: DLDevice,
+    ndim: i32,
+    dtype: DLDataType,
+    /// Pointer to shape array (length = ndim).
+    shape: *mut i64,
+    /// Pointer to strides array, or null for compact layout.
+    strides: *mut i64,
+    byte_offset: u64,
+}
+
+#[cfg(feature = "cuda")]
+#[repr(C)]
+struct DLManagedTensor {
+    dl_tensor: DLTensor,
+    /// Opaque context pointer freed by `deleter`.
+    manager_ctx: *mut std::ffi::c_void,
+    /// Called by the consumer to release resources. May be null.
+    deleter: Option<unsafe extern "C" fn(*mut DLManagedTensor)>,
+}
+
+/// Holds the shape value and keeps the ZSlice (and its CudaBufInner Arc) alive.
+#[cfg(feature = "cuda")]
+struct DlpackCtx {
+    shape: i64,
+    _zslice: zenoh_buffers::ZSlice,
+}
+
+// SAFETY: DlpackCtx contains a ZSlice (which holds Arc<CudaBufInner>).
+// CudaBufInner is Send+Sync, so DlpackCtx is too.
+#[cfg(feature = "cuda")]
+unsafe impl Send for DlpackCtx {}
+#[cfg(feature = "cuda")]
+unsafe impl Sync for DlpackCtx {}
+
+/// DLManagedTensor deleter: frees the DlpackCtx, called by the tensor consumer.
+///
+/// The DLManagedTensor itself is freed by `dlpack_capsule_destructor`.
+#[cfg(feature = "cuda")]
+unsafe extern "C" fn dlpack_deleter(managed: *mut DLManagedTensor) {
+    if managed.is_null() {
+        return;
+    }
+    let ctx_ptr = (*managed).manager_ctx;
+    // Set to null so the capsule destructor skips double-free.
+    (*managed).manager_ctx = std::ptr::null_mut();
+    if !ctx_ptr.is_null() {
+        drop(Box::from_raw(ctx_ptr as *mut DlpackCtx));
+    }
+}
+
+/// PyCapsule destructor: frees the DLManagedTensor (and ctx if not yet freed).
+///
+/// Called by the Python GC when the capsule is collected. If PyTorch already
+/// consumed the tensor (calling `deleter`), only the DLManagedTensor box is freed.
+#[cfg(feature = "cuda")]
+unsafe extern "C" fn dlpack_capsule_destructor(capsule: *mut ffi::PyObject) {
+    // Try current name; if PyTorch renamed it, try "used_dltensor".
+    let name_cur = b"dltensor\0".as_ptr() as *const std::ffi::c_char;
+    let mut ptr = ffi::PyCapsule_GetPointer(capsule, name_cur) as *mut DLManagedTensor;
+    if ptr.is_null() {
+        // PyCapsule_GetPointer sets an error when the name doesn't match.
+        ffi::PyErr_Clear();
+        let name_used = b"used_dltensor\0".as_ptr() as *const std::ffi::c_char;
+        ptr = ffi::PyCapsule_GetPointer(capsule, name_used) as *mut DLManagedTensor;
+        if ptr.is_null() {
+            ffi::PyErr_Clear();
+            return;
+        }
+    }
+    // Free ctx if the deleter hasn't run yet.
+    let ctx_ptr = (*ptr).manager_ctx;
+    if !ctx_ptr.is_null() {
+        drop(Box::from_raw(ctx_ptr as *mut DlpackCtx));
+    }
+    // Free the DLManagedTensor itself.
+    drop(Box::from_raw(ptr));
 }

--- a/crates/ros-z-py/src/payload_view.rs
+++ b/crates/ros-z-py/src/payload_view.rs
@@ -189,7 +189,6 @@ impl ZPayloadView {
     #[getter]
     fn is_cuda(&self) -> bool {
         use zenoh_buffers::ZSliceKind;
-        use zenoh_buffers::buffer::SplitBuffer;
         let zbuf: zenoh_buffers::ZBuf = self.sample.payload().clone().into();
         zbuf.zslices().any(|zs| zs.kind == ZSliceKind::CudaPtr)
     }
@@ -211,7 +210,6 @@ impl ZPayloadView {
     #[cfg(feature = "cuda")]
     fn as_dlpack(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
         use zenoh_buffers::ZSliceKind;
-        use zenoh_buffers::buffer::SplitBuffer;
         use zenoh_cuda::CudaBufInner;
 
         let zbuf: zenoh_buffers::ZBuf = self.sample.payload().clone().into();

--- a/crates/ros-z-py/src/payload_view.rs
+++ b/crates/ros-z-py/src/payload_view.rs
@@ -190,7 +190,8 @@ impl ZPayloadView {
     fn is_cuda(&self) -> bool {
         use zenoh_buffers::ZSliceKind;
         let zbuf: zenoh_buffers::ZBuf = self.sample.payload().clone().into();
-        zbuf.zslices().any(|zs| zs.kind == ZSliceKind::CudaPtr)
+        zbuf.zslices()
+            .any(|zs| zs.kind == ZSliceKind::CudaPtr || zs.kind == ZSliceKind::CudaTensor)
     }
 
     /// Return a DLPack capsule for the CUDA payload, suitable for `torch.from_dlpack()`.
@@ -214,21 +215,51 @@ impl ZPayloadView {
 
         let zbuf: zenoh_buffers::ZBuf = self.sample.payload().clone().into();
         for zslice in zbuf.zslices() {
-            if zslice.kind != ZSliceKind::CudaPtr {
+            if zslice.kind != ZSliceKind::CudaPtr && zslice.kind != ZSliceKind::CudaTensor {
                 continue;
             }
             let Some(cuda) = zslice.downcast_ref::<CudaBufInner>() else {
                 continue;
             };
 
-            // Heap-allocate the context (shape + ZSlice keepalive).
+            // Build shape, dtype, strides from TensorMeta (CudaTensor) or fallback (CudaPtr).
+            let (ndim, shape_vec, dtype, strides_vec, byte_offset) =
+                if let Some(meta) = cuda.tensor_meta() {
+                    (
+                        meta.ndim,
+                        meta.shape.clone(),
+                        DLDataType {
+                            code: meta.dtype_code,
+                            bits: meta.dtype_bits,
+                            lanes: meta.dtype_lanes,
+                        },
+                        meta.strides.clone(),
+                        meta.byte_offset,
+                    )
+                } else {
+                    // CudaPtr fallback: 1-D uint8 tensor.
+                    (
+                        1,
+                        vec![cuda.cuda_len as i64],
+                        DLDataType {
+                            code: 1, // kDLUInt
+                            bits: 8,
+                            lanes: 1,
+                        },
+                        None,
+                        0u64,
+                    )
+                };
+
+            // Heap-allocate the context (shape + strides + ZSlice keepalive).
             let ctx = Box::new(DlpackCtx {
-                shape: cuda.cuda_len as i64,
+                shape: shape_vec,
+                strides: strides_vec,
                 _zslice: zslice.clone(),
             });
             let ctx_ptr = Box::into_raw(ctx);
 
-            // Build the DLManagedTensor. The shape pointer points into ctx,
+            // Build the DLManagedTensor. shape/strides pointers live in ctx,
             // which is kept alive by manager_ctx until the deleter is called.
             let managed = Box::new(DLManagedTensor {
                 dl_tensor: DLTensor {
@@ -237,15 +268,16 @@ impl ZPayloadView {
                         device_type: 2, // kDLCUDA
                         device_id: cuda.device_id,
                     },
-                    ndim: 1,
-                    dtype: DLDataType {
-                        code: 1, // kDLUInt
-                        bits: 8,
-                        lanes: 1,
+                    ndim,
+                    dtype,
+                    shape: unsafe { (*ctx_ptr).shape.as_mut_ptr() },
+                    strides: unsafe {
+                        match (*ctx_ptr).strides.as_mut() {
+                            Some(sv) => sv.as_mut_ptr(),
+                            None => std::ptr::null_mut(),
+                        }
                     },
-                    shape: unsafe { &mut (*ctx_ptr).shape as *mut i64 },
-                    strides: std::ptr::null_mut(),
-                    byte_offset: 0,
+                    byte_offset,
                 },
                 manager_ctx: ctx_ptr as *mut std::ffi::c_void,
                 deleter: Some(dlpack_deleter),
@@ -328,10 +360,14 @@ struct DLManagedTensor {
     deleter: Option<unsafe extern "C" fn(*mut DLManagedTensor)>,
 }
 
-/// Holds the shape value and keeps the ZSlice (and its CudaBufInner Arc) alive.
+/// Holds shape/strides arrays and keeps the ZSlice (and its CudaBufInner Arc) alive.
+///
+/// The DLManagedTensor's shape and strides pointers point into these Vecs,
+/// so this struct must not be moved or dropped until the deleter is called.
 #[cfg(feature = "cuda")]
 struct DlpackCtx {
-    shape: i64,
+    shape: Vec<i64>,
+    strides: Option<Vec<i64>>,
     _zslice: zenoh_buffers::ZSlice,
 }
 

--- a/crates/ros-z-py/src/payload_view.rs
+++ b/crates/ros-z-py/src/payload_view.rs
@@ -378,7 +378,7 @@ impl ZPayloadView {
             // cuda → torch → cpu → numpy (device copy)
             let t = self.as_torch(py)?;
             let cpu = t.call_method0(py, "cpu")?;
-            return Ok(cpu.call_method0(py, "numpy")?);
+            return cpu.call_method0(py, "numpy");
         }
         let raw = self.raw_bytes(py)?;
         let np = py.import_bound("numpy")?;

--- a/crates/ros-z-py/src/pubsub.rs
+++ b/crates/ros-z-py/src/pubsub.rs
@@ -40,6 +40,28 @@ impl PyZPublisher {
         self.inner.publish(data.into()).map_err(|e| e.into_pyerr())
     }
 
+    /// Publish a CUDA ZBuf directly (zero-copy GPU transport).
+    ///
+    /// Use this to send a CUDA device buffer via IPC without any CPU copies.
+    /// The subscriber receives a `ZPayloadView` with `is_cuda=True` and can
+    /// extract the GPU tensor via `as_dlpack()`.
+    ///
+    /// Args:
+    ///     zbuf: A `CudaZBuf` returned by `PyCudaBuf.into_zbuf()`.
+    ///
+    /// Example (Python):
+    ///     buf = PyCudaBuf.alloc_device(4 * 1024 * 1024, device_id=0)
+    ///     # ... fill via cupy/torch ...
+    ///     publisher.publish_zbuf(buf.into_zbuf())
+    #[cfg(feature = "cuda")]
+    fn publish_zbuf(&self, zbuf: &crate::cuda_buf::ZBufWrapper) -> PyResult<()> {
+        use zenoh_buffers::ZBuf as ZenohZBuf;
+        let zenoh_zbuf: ZenohZBuf = zbuf.0.clone().into_inner();
+        self.inner
+            .publish(zenoh_zbuf.into())
+            .map_err(|e| e.into_pyerr())
+    }
+
     /// Get the topic name (for debugging)
     unsafe fn get_type_name(&self) -> String {
         self.type_name.clone()

--- a/crates/ros-z-py/src/pubsub.rs
+++ b/crates/ros-z-py/src/pubsub.rs
@@ -56,10 +56,91 @@ impl PyZPublisher {
     #[cfg(feature = "cuda")]
     fn publish_zbuf(&self, zbuf: &crate::cuda_buf::ZBufWrapper) -> PyResult<()> {
         use zenoh_buffers::ZBuf as ZenohZBuf;
-        let zenoh_zbuf: ZenohZBuf = zbuf.0.clone().into_inner();
+        let zenoh_zbuf: ZenohZBuf = zbuf.zbuf.clone().into_inner();
         self.inner
             .publish(zenoh_zbuf.into())
             .map_err(|e| e.into_pyerr())
+    }
+
+    /// Publish raw bytes directly (no CDR framing).
+    ///
+    /// Used internally by `publish_tensor` for the CPU tensor path (numpy NPY format).
+    /// Can also be used for arbitrary byte payloads.
+    fn publish_bytes(&self, data: &[u8]) -> PyResult<()> {
+        self.inner.publish(data.into()).map_err(|e| e.into_pyerr())
+    }
+
+    /// Publish a tensor (torch or numpy) with zero boilerplate.
+    ///
+    /// Dispatches automatically based on device:
+    ///
+    /// - **CUDA tensor** (`tensor.device.type == "cuda"`): wraps via
+    ///   `PyCudaBuf.from_torch()` and sends as a CUDA IPC payload (zero GPU copies).
+    ///   The subscriber receives `is_cuda=True` and can call `as_torch()`.
+    ///
+    /// - **CPU tensor** (`tensor.device.type == "cpu"` or numpy array): serializes
+    ///   using numpy's NPY format (shape + dtype preserved). The subscriber calls
+    ///   `as_torch()` or `as_numpy()` to reconstruct.
+    ///
+    /// **Lifetime note for CUDA tensors:** the source `tensor` must remain live
+    /// until the subscriber calls `cudaIpcOpenMemHandle`. This method keeps `tensor`
+    /// alive until `publish_zbuf` returns (IPC handle serialized on wire), but the
+    /// subscriber process still needs the source allocation to exist when it opens
+    /// the handle. For best results use a short `time.sleep` after publish, or
+    /// keep `tensor` in scope for the expected round-trip window.
+    ///
+    /// Args:
+    ///     tensor: A `torch.Tensor` (any device) or `numpy.ndarray`.
+    ///
+    /// Example:
+    ///     # CUDA:
+    ///     pub.publish_tensor(torch.zeros(480, 640, 3, dtype=torch.float16, device="cuda"))
+    ///     # CPU:
+    ///     pub.publish_tensor(torch.arange(1024, dtype=torch.float32))
+    ///     pub.publish_tensor(np.zeros((256, 256), dtype=np.uint8))
+    #[cfg(feature = "cuda")]
+    fn publish_tensor(&self, py: Python<'_>, tensor: &Bound<'_, PyAny>) -> PyResult<()> {
+        // Detect device type — works for torch.Tensor (has .device) and np.ndarray (no .device)
+        let device_type: Option<String> = tensor
+            .getattr("device")
+            .ok()
+            .and_then(|d| d.getattr("type").ok())
+            .and_then(|t| t.extract().ok());
+
+        match device_type.as_deref() {
+            Some("cuda") => {
+                // CUDA zero-copy path
+                let mut buf = crate::cuda_buf::PyCudaBuf::from_torch(tensor)?;
+                // Pass tensor as keepalive so GC cannot collect it before publish_zbuf returns
+                let keepalive = Some(tensor.clone().into());
+                let zbuf = buf.into_zbuf(keepalive)?;
+                let zenoh_zbuf: zenoh_buffers::ZBuf = zbuf.zbuf.clone().into_inner();
+                self.inner
+                    .publish(zenoh_zbuf.into())
+                    .map_err(|e| e.into_pyerr())
+            }
+            _ => {
+                // CPU path: numpy ndarray or cpu torch.Tensor
+                // Convert torch.Tensor → numpy if needed
+                let np = py.import_bound("numpy")?;
+                let arr = if tensor.hasattr("numpy")? {
+                    // torch.Tensor: call .detach().cpu().numpy()
+                    tensor
+                        .call_method0("detach")?
+                        .call_method0("cpu")?
+                        .call_method0("numpy")?
+                } else {
+                    // Already numpy-like: wrap with np.asarray for uniform handling
+                    np.call_method1("asarray", (tensor,))?
+                };
+                // Serialize as numpy NPY format (contains shape + dtype + strides)
+                let io = py.import_bound("io")?;
+                let buf = io.call_method0("BytesIO")?;
+                np.call_method1("save", (&buf, arr))?;
+                let payload: Vec<u8> = buf.call_method0("getvalue")?.extract()?;
+                self.publish_bytes(&payload)
+            }
+        }
     }
 
     /// Get the topic name (for debugging)

--- a/crates/ros-z/Cargo.toml
+++ b/crates/ros-z/Cargo.toml
@@ -19,6 +19,7 @@ zenoh = { workspace = true, default-features = false, features = [
 ] }
 zenoh-ext = { workspace = true }
 zenoh-buffers = { workspace = true }
+zenoh-codec = { workspace = true, optional = true }
 zenoh-cuda = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 sha2 = { workspace = true }
@@ -63,7 +64,12 @@ prost-build = { workspace = true, optional = true }
 default = ["config-builders", "jazzy", "rmw-zenoh"]
 config-builders = []
 generate-configs = []
-cuda = ["zenoh-buffers/cuda", "dep:zenoh-cuda"]
+cuda = [
+  "zenoh-buffers/cuda",
+  "dep:zenoh-codec",
+  "zenoh-codec/cuda",
+  "dep:zenoh-cuda",
+]
 protobuf = ["prost", "prost-build"]
 flatbuffers = []
 python = ["pyo3"]

--- a/crates/ros-z/Cargo.toml
+++ b/crates/ros-z/Cargo.toml
@@ -19,6 +19,7 @@ zenoh = { workspace = true, default-features = false, features = [
 ] }
 zenoh-ext = { workspace = true }
 zenoh-buffers = { workspace = true }
+zenoh-cuda = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 sha2 = { workspace = true }
 parking_lot = { workspace = true }
@@ -62,6 +63,7 @@ prost-build = { workspace = true, optional = true }
 default = ["config-builders", "jazzy", "rmw-zenoh"]
 config-builders = []
 generate-configs = []
+cuda = ["zenoh-buffers/cuda", "dep:zenoh-cuda"]
 protobuf = ["prost", "prost-build"]
 flatbuffers = []
 python = ["pyo3"]

--- a/crates/ros-z/Cargo.toml
+++ b/crates/ros-z/Cargo.toml
@@ -69,6 +69,7 @@ cuda = [
   "dep:zenoh-codec",
   "zenoh-codec/cuda",
   "dep:zenoh-cuda",
+  "zenoh/cuda",
 ]
 protobuf = ["prost", "prost-build"]
 flatbuffers = []

--- a/crates/ros-z/Cargo.toml
+++ b/crates/ros-z/Cargo.toml
@@ -34,6 +34,9 @@ serde_yaml = { workspace = true }
 dashmap = "5.5"
 prost = { workspace = true, optional = true }
 pyo3 = { workspace = true, optional = true }
+# Only for ort_classifier example (required-features = ["cuda"])
+ort = { workspace = true, optional = true }
+ndarray = { version = "0.17", optional = true }
 ros-z-cdr = { workspace = true }
 ros-z-codegen = { workspace = true, optional = true }
 ros-z-protocol = { path = "../ros-z-protocol", default-features = false, features = [
@@ -48,6 +51,7 @@ paste = "1.0"
 [dev-dependencies]
 ros-z-msgs = { path = "../ros-z-msgs" }
 ros-z-codegen = { path = "../ros-z-codegen" }
+anyhow = { workspace = true }
 
 [build-dependencies]
 serde = { workspace = true, features = ["serde_derive"] }
@@ -70,6 +74,8 @@ cuda = [
   "zenoh-codec/cuda",
   "dep:zenoh-cuda",
   "zenoh/cuda",
+  "dep:ort",
+  "dep:ndarray",
 ]
 protobuf = ["prost", "prost-build"]
 flatbuffers = []
@@ -218,6 +224,11 @@ required-features = []
 name = "shm_pointcloud2"
 path = "examples/shm_pointcloud2.rs"
 required-features = []
+
+[[example]]
+name = "ort_classifier"
+path = "examples/ort_classifier.rs"
+required-features = ["cuda"]
 
 [[example]]
 name = "encoding_demo"

--- a/crates/ros-z/examples/ort_classifier.rs
+++ b/crates/ros-z/examples/ort_classifier.rs
@@ -1,0 +1,166 @@
+//! ort_classifier — receive a CUDA tensor from ort_publisher.py, run SqueezeNet 1.1 via ONNX
+//! Runtime's CUDAExecutionProvider, and print the top-1 ImageNet label.
+//!
+//! # Setup
+//!
+//! 1. Download the model (first time only):
+//!    ```bash
+//!    curl -L https://huggingface.co/onnxmodelzoo/squeezenet1.1-7/resolve/main/squeezenet1.1-7.onnx \
+//!         -o assets/squeezenet1.1-7.onnx
+//!    ```
+//!
+//! 2. Start the Rust subscriber first, then the Python publisher:
+//!    ```bash
+//!    # Terminal 1
+//!    CUDA_PATH=/nix/store/addcyrkwfz2ghah3vrqvda547xafpgsa-cuda_cudart-12.8.90-lib \
+//!      cargo run --example ort_classifier --features jazzy,cuda
+//!
+//!    # Terminal 2
+//!    python crates/ros-z-py/examples/ort_publisher.py assets/test_image.jpg
+//!    ```
+//!
+//! # Data path
+//!
+//! ```text
+//! Python (torch GPU tensor)
+//!   → publish_tensor()           IPC handle on wire (no CPU copy)
+//!   → recv_serialized()          raw zenoh Sample, CUDA ZSlice preserved
+//!   → copy_to_host()             D2H: [1,3,224,224] f32 (one copy for ort input)
+//!   → ort CUDA session           re-uploaded by CUDAExecutionProvider
+//!   → softmaxout_1 argmax        top-1 class label
+//! ```
+//!
+//! # Note on ORT native library
+//!
+//! `ort` downloads ONNX Runtime automatically (ORT_STRATEGY=download).
+//! In a Nix environment set `ORT_LIB_LOCATION` to the system ONNX Runtime path.
+
+use std::time::Duration;
+
+use ndarray::Array4;
+use ort::{
+    execution_providers::CUDAExecutionProvider,
+    session::{Session, builder::GraphOptimizationLevel},
+    value::TensorRef,
+};
+use ros_z::{Builder, ZBuf, context::ZContextBuilder};
+use ros_z_msgs::sensor_msgs::LaserScan;
+use serde_json::json;
+use zenoh_buffers::ZBuf as ZenohZBuf;
+
+const TOPIC: &str = "/ort/image";
+const MODEL: &str = "assets/squeezenet1.1-7.onnx";
+const LABELS: &str = "assets/imagenet_classes.txt";
+
+/// Direct peer: Python publisher connects to us on this address.
+const LISTEN_ADDR: &str = "tcp/127.0.0.1:7449";
+
+fn load_labels(path: &str) -> Result<Vec<String>, std::io::Error> {
+    let content = std::fs::read_to_string(path)?;
+    Ok(content.lines().map(String::from).collect())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    zenoh::init_log_from_env_or("warn");
+
+    // --- ORT session on GPU 0 ---
+    // ort::Error contains raw pointers (not Send+Sync) so we use .expect() here.
+    let mut session = Session::builder()
+        .expect("ort SessionBuilder")
+        .with_execution_providers([CUDAExecutionProvider::default().build()])
+        .expect("ort CUDA EP")
+        .with_optimization_level(GraphOptimizationLevel::Level3)
+        .expect("ort optimization level")
+        .commit_from_file(MODEL)
+        .expect("ort commit_from_file");
+
+    let labels = load_labels(LABELS)?;
+    println!("loaded {} labels, model ready", labels.len());
+
+    // --- ros-z subscriber (direct peer, publisher connects to us) ---
+    let ctx = ZContextBuilder::default()
+        .with_json("listen/endpoints", json!([LISTEN_ADDR]))
+        .with_shm_enabled()?
+        .build()?;
+    let node = ctx.create_node("ort_classifier").build()?;
+    // recv_serialized_timeout() bypasses CDR — CUDA ZSlice kind bits are preserved.
+    let sub = node.create_sub::<LaserScan>(TOPIC).build()?;
+
+    println!("listening on {TOPIC} (peer addr {LISTEN_ADDR})");
+    println!("run: python crates/ros-z-py/examples/ort_publisher.py [image.jpg]");
+
+    loop {
+        let sample = match sub.recv_serialized_timeout(Duration::from_secs(60)) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("recv timeout: {e}");
+                continue;
+            }
+        };
+
+        // Convert zenoh payload → ZBuf (preserves CudaTensor ZSlice kind)
+        let zenoh_zbuf: ZenohZBuf = sample.payload().clone().into();
+        let zbuf = ZBuf::from_zenoh(zenoh_zbuf);
+
+        let Some((cuda_buf, meta)) = zbuf.typed_cuda_slices().next() else {
+            eprintln!("received non-CUDA-tensor message, skipping");
+            continue;
+        };
+        // Validate: [1, 3, 224, 224] f32
+        if meta.shape.len() != 4 {
+            eprintln!(
+                "unexpected ndim {} (expected 4), skipping",
+                meta.shape.len()
+            );
+            continue;
+        }
+        if meta.dtype_bits != 32 || meta.dtype_code != 2 {
+            eprintln!(
+                "unexpected dtype bits={} code={} (expected f32), skipping",
+                meta.dtype_bits, meta.dtype_code
+            );
+            continue;
+        }
+
+        let shape: [usize; 4] = [
+            meta.shape[0] as usize,
+            meta.shape[1] as usize,
+            meta.shape[2] as usize,
+            meta.shape[3] as usize,
+        ];
+        let n_elems: usize = shape.iter().product();
+        let n_bytes = n_elems * 4; // f32
+
+        // Approach B: device → host (one D2H transfer per frame)
+        let mut host_buf = vec![0u8; n_bytes];
+        cuda_buf.copy_to_host(&mut host_buf)?;
+
+        // Reinterpret as little-endian f32
+        let floats: Vec<f32> = host_buf
+            .chunks_exact(4)
+            .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+            .collect();
+
+        // Build ndarray [n, c, h, w] and run inference
+        let arr = Array4::from_shape_vec(shape, floats)?;
+        let inputs = ort::inputs![TensorRef::from_array_view(arr.view()).expect("tensor ref")];
+        let outputs = session.run(inputs).expect("ort run");
+
+        // SqueezeNet output: first output, shape [1, 1000] or [1, 1000, 1, 1]
+        let (_, probs) = outputs[0]
+            .try_extract_tensor::<f32>()
+            .expect("extract tensor");
+
+        let (top1_idx, &top1_score) = probs
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .unwrap();
+
+        let label = labels
+            .get(top1_idx)
+            .map(String::as_str)
+            .unwrap_or("unknown");
+        println!("top-1: {} ({:.1}%)", label, top1_score * 100.0);
+    }
+}

--- a/crates/ros-z/src/context.rs
+++ b/crates/ros-z/src/context.rs
@@ -274,7 +274,13 @@ impl ZContextBuilder {
         let provider = Arc::new(
             crate::shm::ShmProviderBuilder::new(crate::shm::DEFAULT_SHM_POOL_SIZE).build()?,
         );
-        Ok(self.with_shm_config(crate::shm::ShmConfig::new(provider)))
+        // Override the `false` set by common_overrides() so the zenoh transport
+        // advertises the SHM extension in InitSyn/InitAck handshake.  Without
+        // this, `ShmContext::new` returns None and `ext_shm` stays None even
+        // when the `shared-memory` feature is compiled in.
+        Ok(self
+            .with_shm_config(crate::shm::ShmConfig::new(provider))
+            .with_json("transport/shared_memory/enabled", json!(true)))
     }
 
     /// Enable SHM with custom pool size.

--- a/crates/ros-z/src/dynamic/serdes.rs
+++ b/crates/ros-z/src/dynamic/serdes.rs
@@ -54,11 +54,14 @@ impl ZSerializer for DynamicSerdeCdrSerdes {
         Self::serialize_to_zbuf(input)
     }
 
-    fn serialize_to_shm(
+    fn serialize_to_shm<B>(
         input: &DynamicMessage,
         _estimated_size: usize,
-        provider: &zenoh::shm::ShmProvider<zenoh::shm::PosixShmProviderBackend>,
-    ) -> zenoh::Result<(ZBuf, usize)> {
+        provider: &zenoh::shm::ShmProvider<B>,
+    ) -> zenoh::Result<(ZBuf, usize)>
+    where
+        B: zenoh::shm::ShmProviderBackend,
+    {
         // DynamicMessage uses primitives-based serialization, not serde
         // So we serialize to Vec first, then copy to SHM
         // This is similar to the protobuf approach

--- a/crates/ros-z/src/lib.rs
+++ b/crates/ros-z/src/lib.rs
@@ -103,7 +103,6 @@ pub use entity::{TypeHash, TypeInfo};
 pub use ros_msg::{ActionTypeInfo, MessageTypeInfo, ServiceTypeInfo, WithTypeInfo};
 pub use zbuf::ZBuf;
 pub use zenoh::Result;
-
 #[cfg(feature = "cuda")]
 pub use zenoh_cuda::{CudaBufInner, CudaIpcHandle, CudaMemKind};
 

--- a/crates/ros-z/src/lib.rs
+++ b/crates/ros-z/src/lib.rs
@@ -104,6 +104,9 @@ pub use ros_msg::{ActionTypeInfo, MessageTypeInfo, ServiceTypeInfo, WithTypeInfo
 pub use zbuf::ZBuf;
 pub use zenoh::Result;
 
+#[cfg(feature = "cuda")]
+pub use zenoh_cuda::{CudaBufInner, CudaIpcHandle, CudaMemKind};
+
 /// Builds a configured object, consuming the builder.
 ///
 /// All ros-z builders implement this trait. Bring it into scope to call `.build()`:

--- a/crates/ros-z/src/msg.rs
+++ b/crates/ros-z/src/msg.rs
@@ -100,11 +100,13 @@ pub trait ZSerializer {
     /// # Ok(())
     /// # }
     /// ```
-    fn serialize_to_shm(
+    fn serialize_to_shm<B>(
         input: Self::Input<'_>,
         estimated_size: usize,
-        provider: &zenoh::shm::ShmProvider<zenoh::shm::PosixShmProviderBackend>,
-    ) -> zenoh::Result<(ZBuf, usize)>;
+        provider: &zenoh::shm::ShmProvider<B>,
+    ) -> zenoh::Result<(ZBuf, usize)>
+    where
+        B: zenoh::shm::ShmProviderBackend;
 
     /// Serialize to an existing buffer, returning the result as ZBuf.
     ///
@@ -244,7 +246,7 @@ where
         writer.into_zbuf()
     }
 
-    fn serialize_to_shm(
+    fn serialize_to_shm<B>(
         input: &T,
         estimated_size: usize,
         provider: &zenoh::shm::ShmProvider<zenoh::shm::PosixShmProviderBackend>,
@@ -410,11 +412,14 @@ where
         Self::serialize_to_zbuf(input)
     }
 
-    fn serialize_to_shm(
+    fn serialize_to_shm<B>(
         input: &T,
         estimated_size: usize,
-        provider: &zenoh::shm::ShmProvider<zenoh::shm::PosixShmProviderBackend>,
-    ) -> zenoh::Result<(ZBuf, usize)> {
+        provider: &zenoh::shm::ShmProvider<B>,
+    ) -> zenoh::Result<(ZBuf, usize)>
+    where
+        B: zenoh::shm::ShmProviderBackend,
+    {
         // For protobuf, we serialize to Vec first then copy to SHM
         // (protobuf doesn't support custom writers like CDR does)
         let data = input.encode_to_vec();

--- a/crates/ros-z/src/msg.rs
+++ b/crates/ros-z/src/msg.rs
@@ -246,10 +246,10 @@ where
         writer.into_zbuf()
     }
 
-    fn serialize_to_shm<B>(
+    fn serialize_to_shm<B: zenoh::shm::ShmProviderBackend>(
         input: &T,
         estimated_size: usize,
-        provider: &zenoh::shm::ShmProvider<zenoh::shm::PosixShmProviderBackend>,
+        provider: &zenoh::shm::ShmProvider<B>,
     ) -> zenoh::Result<(ZBuf, usize)> {
         let mut writer = crate::shm::ShmWriter::new(provider, estimated_size)?;
         writer.extend_from_slice(&CDR_HEADER_LE);
@@ -333,10 +333,10 @@ where
         writer.into_zbuf()
     }
 
-    fn serialize_to_shm(
+    fn serialize_to_shm<B: zenoh::shm::ShmProviderBackend>(
         input: &T,
         estimated_size: usize,
-        provider: &zenoh::shm::ShmProvider<zenoh::shm::PosixShmProviderBackend>,
+        provider: &zenoh::shm::ShmProvider<B>,
     ) -> zenoh::Result<(ZBuf, usize)> {
         let mut writer = crate::shm::ShmWriter::new(provider, estimated_size)?;
         writer.extend_from_slice(&CDR_HEADER_LE);

--- a/crates/ros-z/src/shm.rs
+++ b/crates/ros-z/src/shm.rs
@@ -80,7 +80,9 @@
 
 use std::sync::Arc;
 use zenoh::Wait;
-use zenoh::shm::{BlockOn, GarbageCollect, PosixShmProviderBackend, ShmProvider, ZShmMut};
+use zenoh::shm::{
+    BlockOn, GarbageCollect, PosixShmProviderBackend, ShmProvider, ShmProviderBackend, ZShmMut,
+};
 use zenoh_buffers::ZBuf;
 
 /// Default shared memory pool size (10 MB).
@@ -110,16 +112,35 @@ pub const DEFAULT_SHM_THRESHOLD: usize = 512;
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone)]
-pub struct ShmConfig {
+/// Configuration for Shared Memory (SHM) support.
+///
+/// Generic over the SHM provider backend `B`. The default backend is
+/// [`PosixShmProviderBackend`], which preserves backwards compatibility for
+/// all existing callsites. Custom backends (e.g., CUDA unified memory) can be
+/// plugged in by specifying `B`.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use ros_z::shm::{ShmConfig, ShmProviderBuilder};
+/// use std::sync::Arc;
+///
+/// # fn main() -> ros_z::Result<()> {
+/// let provider = Arc::new(ShmProviderBuilder::new(50 * 1024 * 1024).build()?);
+/// let config = ShmConfig::new(provider)
+///     .with_threshold(10_000);  // 10KB threshold
+/// # Ok(())
+/// # }
+/// ```
+pub struct ShmConfig<B: ShmProviderBackend = PosixShmProviderBackend> {
     /// The SHM provider for allocating shared memory buffers.
-    pub(crate) provider: Arc<ShmProvider<PosixShmProviderBackend>>,
+    pub(crate) provider: Arc<ShmProvider<B>>,
     /// Minimum message size (in bytes) to use SHM.
     /// Messages smaller than this will use regular memory.
     pub(crate) threshold: usize,
 }
 
-impl ShmConfig {
+impl<B: ShmProviderBackend> ShmConfig<B> {
     /// Create a new SHM configuration with the given provider.
     ///
     /// Uses the default threshold of 512 bytes.
@@ -136,7 +157,7 @@ impl ShmConfig {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new(provider: Arc<ShmProvider<PosixShmProviderBackend>>) -> Self {
+    pub fn new(provider: Arc<ShmProvider<B>>) -> Self {
         Self {
             provider,
             threshold: DEFAULT_SHM_THRESHOLD,
@@ -171,10 +192,13 @@ impl ShmConfig {
     }
 
     /// Get a reference to the SHM provider.
-    pub fn provider(&self) -> &ShmProvider<PosixShmProviderBackend> {
+    pub fn provider(&self) -> &ShmProvider<B> {
         &self.provider
     }
+}
 
+// Concrete impl for the default POSIX backend — from_env() always creates a POSIX provider.
+impl ShmConfig {
     /// Create SHM configuration from environment variables.
     ///
     /// Reads:
@@ -228,7 +252,17 @@ impl ShmConfig {
     }
 }
 
-impl std::fmt::Debug for ShmConfig {
+// Manual Clone so we don't require B: Clone (Arc<ShmProvider<B>> is always Clone).
+impl<B: ShmProviderBackend> Clone for ShmConfig<B> {
+    fn clone(&self) -> Self {
+        Self {
+            provider: Arc::clone(&self.provider),
+            threshold: self.threshold,
+        }
+    }
+}
+
+impl<B: ShmProviderBackend> std::fmt::Debug for ShmConfig<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ShmConfig")
             .field("threshold", &self.threshold)
@@ -343,8 +377,8 @@ impl ShmWriter {
     /// # Errors
     ///
     /// Returns an error if SHM allocation fails.
-    pub fn new(
-        provider: &ShmProvider<PosixShmProviderBackend>,
+    pub fn new<B: ShmProviderBackend>(
+        provider: &ShmProvider<B>,
         capacity: usize,
     ) -> zenoh::Result<Self> {
         let buffer = provider

--- a/crates/ros-z/src/zbuf.rs
+++ b/crates/ros-z/src/zbuf.rs
@@ -51,6 +51,28 @@ impl ZBuf {
         Self(zbuf)
     }
 
+    /// Iterate over CUDA device-memory slices in this buffer.
+    ///
+    /// Returns an iterator over [`zenoh_cuda::CudaBufInner`] references for each
+    /// ZSlice with `kind = ZSliceKind::CudaPtr`. Empty on CPU-only buffers.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// for cuda in msg.data.cuda_slices() {
+    ///     let ptr = cuda.as_device_ptr();  // pass to CUDA kernel
+    ///     let len = cuda.cuda_len;
+    /// }
+    /// ```
+    #[cfg(feature = "cuda")]
+    pub fn cuda_slices(&self) -> impl Iterator<Item = &zenoh_cuda::CudaBufInner> {
+        use zenoh_buffers::ZSliceKind;
+        self.0
+            .zslices()
+            .filter(|zs| zs.kind == ZSliceKind::CudaPtr)
+            .filter_map(|zs| zs.downcast_ref::<zenoh_cuda::CudaBufInner>())
+    }
+
     /// Creates a ZBuf that carries CUDA device memory.
     ///
     /// The resulting `ZBuf` has its ZSlice kind set to `ZSliceKind::CudaPtr`,

--- a/crates/ros-z/src/zbuf.rs
+++ b/crates/ros-z/src/zbuf.rs
@@ -50,6 +50,33 @@ impl ZBuf {
     pub fn from_zenoh(zbuf: ZenohZBuf) -> Self {
         Self(zbuf)
     }
+
+    /// Creates a ZBuf that carries CUDA device memory.
+    ///
+    /// The resulting `ZBuf` has its ZSlice kind set to `ZSliceKind::CudaPtr`,
+    /// which signals the transport layer to send a CUDA IPC handle instead of
+    /// copying the bytes over the network.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use ros_z::{ZBuf, CudaBufInner};
+    ///
+    /// let cuda = CudaBufInner::alloc_device(1024 * 1024, 0)?;
+    /// // ... fill via CUDA kernel ...
+    /// let zbuf = ZBuf::from_cuda(cuda);
+    /// publisher.publish(&PointCloud2 { data: zbuf, .. }).await?;
+    /// ```
+    #[cfg(feature = "cuda")]
+    pub fn from_cuda(buf: zenoh_cuda::CudaBufInner) -> Self {
+        use std::sync::Arc;
+        use zenoh_buffers::{ZSlice, ZSliceKind};
+        let mut zslice = ZSlice::from(Arc::new(buf));
+        zslice.kind = ZSliceKind::CudaPtr;
+        let mut zbuf = ZenohZBuf::default();
+        zbuf.push_zslice(zslice);
+        ZBuf(zbuf)
+    }
 }
 
 // Conversions

--- a/crates/ros-z/src/zbuf.rs
+++ b/crates/ros-z/src/zbuf.rs
@@ -200,6 +200,16 @@ impl<'de> Deserialize<'de> for ZBuf {
                     let v_start = v.as_ptr() as usize;
                     let v_end = v_start + v.len();
                     for zslice in source.zslices() {
+                        // CudaPtr fast path: return the slice directly without pointer
+                        // comparison — device memory has no CPU-accessible bytes to compare.
+                        #[cfg(feature = "cuda")]
+                        if zslice.kind == zenoh_buffers::ZSliceKind::CudaPtr {
+                            let mut zbuf = ZenohZBuf::default();
+                            zbuf.push_zslice(zslice.clone());
+                            return Some(zbuf);
+                        }
+
+                        // CPU zero-copy path: check if v falls within the ZSlice bytes.
                         let s_start = zslice.as_slice().as_ptr() as usize;
                         let s_end = s_start + zslice.len();
                         if v_start >= s_start && v_end <= s_end {

--- a/crates/ros-z/src/zbuf.rs
+++ b/crates/ros-z/src/zbuf.rs
@@ -69,8 +69,44 @@ impl ZBuf {
         use zenoh_buffers::ZSliceKind;
         self.0
             .zslices()
-            .filter(|zs| zs.kind == ZSliceKind::CudaPtr)
+            .filter(|zs| zs.kind == ZSliceKind::CudaPtr || zs.kind == ZSliceKind::CudaTensor)
             .filter_map(|zs| zs.downcast_ref::<zenoh_cuda::CudaBufInner>())
+    }
+
+    /// Iterate over typed CUDA tensor ZSlices (those with DLPack tensor metadata).
+    ///
+    /// Returns an iterator of `(CudaBufInner, TensorMeta)` pairs for each ZSlice
+    /// with `kind = ZSliceKind::CudaTensor` that carries shape/dtype information.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// for (cuda, meta) in msg.data.typed_cuda_slices() {
+    ///     let ptr = cuda.as_device_ptr();
+    ///     println!("shape={:?} dtype_bits={}", meta.shape, meta.dtype_bits);
+    /// }
+    /// ```
+    #[cfg(feature = "cuda")]
+    pub fn typed_cuda_slices(
+        &self,
+    ) -> impl Iterator<Item = (&zenoh_cuda::CudaBufInner, &zenoh_cuda::TensorMeta)> {
+        self.cuda_slices()
+            .filter_map(|c| c.tensor_meta().map(|m| (c, m)))
+    }
+
+    /// Creates a ZBuf that carries a typed CUDA tensor (with DLPack metadata).
+    ///
+    /// The ZSlice kind is set to `ZSliceKind::CudaTensor`. The receiver can call
+    /// `as_dlpack()` to get a correctly-shaped tensor with no out-of-band convention.
+    #[cfg(feature = "cuda")]
+    pub fn from_cuda_tensor(buf: zenoh_cuda::CudaBufInner) -> Self {
+        use std::sync::Arc;
+        use zenoh_buffers::{ZSlice, ZSliceKind};
+        let mut zslice = ZSlice::from(Arc::new(buf));
+        zslice.kind = ZSliceKind::CudaTensor;
+        let mut zbuf = ZenohZBuf::default();
+        zbuf.push_zslice(zslice);
+        ZBuf(zbuf)
     }
 
     /// Creates a ZBuf that carries CUDA device memory.
@@ -249,10 +285,12 @@ impl<'de> Deserialize<'de> for ZBuf {
                     let v_start = v.as_ptr() as usize;
                     let v_end = v_start + v.len();
                     for zslice in source.zslices() {
-                        // CudaPtr fast path: return the slice directly without pointer
+                        // CudaPtr/CudaTensor fast path: return the slice directly without pointer
                         // comparison — device memory has no CPU-accessible bytes to compare.
                         #[cfg(feature = "cuda")]
-                        if zslice.kind == zenoh_buffers::ZSliceKind::CudaPtr {
+                        if zslice.kind == zenoh_buffers::ZSliceKind::CudaPtr
+                            || zslice.kind == zenoh_buffers::ZSliceKind::CudaTensor
+                        {
                             let mut zbuf = ZenohZBuf::default();
                             zbuf.push_zslice(zslice.clone());
                             return Some(zbuf);

--- a/crates/ros-z/tests/cuda_transport.rs
+++ b/crates/ros-z/tests/cuda_transport.rs
@@ -1,0 +1,159 @@
+//! Integration tests for CUDA tensor transport via ZSlice IPC.
+//!
+//! All tests are `#[ignore]` because they require a CUDA-capable GPU.
+//! Run with:
+//!
+//!   cargo test -p ros-z --features jazzy,cuda -- --ignored cuda
+//!
+//! Two-process tests spawn a subscriber child process and communicate via
+//! a unique Zenoh topic derived from `std::process::id()`.
+
+#![cfg(feature = "cuda")]
+
+use ros_z::{Builder, CudaBufInner, ZBuf, context::ZContextBuilder};
+use ros_z_msgs::sensor_msgs::PointCloud2;
+use std::time::Duration;
+use zenoh_buffers::buffer::SplitBuffer;
+
+// ────────────────────────────────────────────────────────────
+// Helper: build a minimal test context (peer mode, no router)
+// ────────────────────────────────────────────────────────────
+fn test_ctx() -> ros_z::context::ZContext {
+    ZContextBuilder::default().build().expect("ZContext::build")
+}
+
+// ────────────────────────────────────────────────────────────
+// Test 1: ZBuf::from_cuda sets ZSliceKind::CudaPtr
+// ────────────────────────────────────────────────────────────
+#[test]
+#[ignore = "requires CUDA device"]
+fn test_from_cuda_sets_kind() {
+    let cuda = CudaBufInner::alloc_device(256, 0).expect("alloc_device");
+    let zbuf = ZBuf::from_cuda(cuda);
+
+    let cuda_count = zbuf.cuda_slices().count();
+    assert_eq!(cuda_count, 1, "expected exactly one CudaPtr ZSlice");
+
+    let inner = zbuf.cuda_slices().next().unwrap();
+    assert_eq!(inner.cuda_len, 256);
+    assert_eq!(inner.device_id, 0);
+}
+
+// ────────────────────────────────────────────────────────────
+// Test 2: from_device_ptr_borrowed does not free on drop
+//
+// We alloc_device, get the ptr, wrap it borrowed, drop the wrapper,
+// then verify the original allocation is still accessible by getting
+// its IPC handle again (would crash/fail if the memory was freed).
+// ────────────────────────────────────────────────────────────
+#[test]
+#[ignore = "requires CUDA device"]
+fn test_borrowed_does_not_free() {
+    let owned = CudaBufInner::alloc_device(512, 0).expect("alloc_device");
+    let ptr = owned.as_device_ptr();
+    let len = owned.cuda_len;
+
+    {
+        let borrowed =
+            CudaBufInner::from_device_ptr_borrowed(ptr, len, 0).expect("from_device_ptr_borrowed");
+        assert_eq!(borrowed.cuda_len, 512);
+        // Drop borrowed here — must NOT call cudaFree
+    }
+
+    // Owned allocation still valid: re-wrap and get IPC handle (would segfault if freed)
+    let rewrap =
+        CudaBufInner::from_device_ptr_borrowed(ptr, len, 0).expect("re-wrap after borrowed drop");
+    assert_ne!(rewrap.ipc_handle, [0u8; 64], "IPC handle must be non-zero");
+
+    // owned drops here — calls cudaFree exactly once
+    drop(owned);
+    drop(rewrap);
+}
+
+// ────────────────────────────────────────────────────────────
+// Test 3: ZBuf::from_cuda (borrowed) round-trip through ZSlice
+// ────────────────────────────────────────────────────────────
+#[test]
+#[ignore = "requires CUDA device"]
+fn test_borrowed_zbuf_roundtrip() {
+    let owned = CudaBufInner::alloc_device(1024, 0).expect("alloc_device");
+    let ptr = owned.as_device_ptr();
+    let len = owned.cuda_len;
+
+    let borrowed =
+        CudaBufInner::from_device_ptr_borrowed(ptr, len, 0).expect("from_device_ptr_borrowed");
+    let zbuf = ZBuf::from_cuda(borrowed);
+
+    // ZBuf should report a CudaPtr slice
+    assert_eq!(zbuf.cuda_slices().count(), 1);
+    let inner = zbuf.cuda_slices().next().unwrap();
+    assert_eq!(
+        inner.as_device_ptr(),
+        ptr,
+        "pointer preserved through ZSlice"
+    );
+    assert_eq!(inner.cuda_len, len);
+
+    drop(zbuf); // drops borrowed — no cudaFree
+    drop(owned); // drops owned — calls cudaFree
+}
+
+// ────────────────────────────────────────────────────────────
+// Test 4: pinned memory pub/sub within one process
+//
+// Pinned memory has a valid CPU address so it serializes as raw bytes.
+// This tests that publish → receive preserves the payload.
+// ────────────────────────────────────────────────────────────
+#[test]
+#[ignore = "requires CUDA device"]
+fn test_pinned_pubsub_inprocess() {
+    let ctx = test_ctx();
+    let node = ctx.create_node("cuda_test_pinned").build().unwrap();
+
+    let topic = format!("cuda_test_pinned_{}", std::process::id());
+    let publisher = node
+        .create_pub::<PointCloud2>(&topic)
+        .build()
+        .expect("create_pub");
+    let subscriber = node
+        .create_sub::<PointCloud2>(&topic)
+        .build()
+        .expect("create_sub");
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Allocate pinned memory and write a pattern from CPU
+    let mut pinned = CudaBufInner::alloc_pinned(64, 0).expect("alloc_pinned");
+    let slice = unsafe { std::slice::from_raw_parts_mut(pinned.as_device_ptr(), pinned.cuda_len) };
+    slice
+        .iter_mut()
+        .enumerate()
+        .for_each(|(i, b)| *b = (i & 0xFF) as u8);
+
+    let zbuf = ZBuf::from_cuda(pinned);
+    let msg = PointCloud2 {
+        data: zbuf,
+        ..Default::default()
+    };
+    publisher.publish(&msg).expect("publish");
+
+    let received = subscriber
+        .recv_timeout(Duration::from_secs(2))
+        .expect("recv_timeout");
+
+    // Pinned memory is CPU-accessible; verify the payload bytes
+    let bytes = received.data.0.contiguous();
+    assert_eq!(bytes.len(), 64);
+    for (i, &b) in bytes.as_ref().iter().enumerate() {
+        assert_eq!(b, (i & 0xFF) as u8, "byte mismatch at index {i}");
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+// Test 5: cuda_slices() is empty for CPU ZBuf
+// ────────────────────────────────────────────────────────────
+#[test]
+fn test_cuda_slices_empty_for_cpu() {
+    let zbuf = ZBuf::from(vec![1u8, 2, 3]);
+    assert_eq!(zbuf.cuda_slices().count(), 0);
+}

--- a/crates/ros-z/tests/cuda_transport.rs
+++ b/crates/ros-z/tests/cuda_transport.rs
@@ -123,7 +123,7 @@ fn test_pinned_pubsub_inprocess() {
     std::thread::sleep(Duration::from_millis(300));
 
     // Allocate pinned memory and write a pattern from CPU
-    let mut pinned = CudaBufInner::alloc_pinned(64, 0).expect("alloc_pinned");
+    let pinned = CudaBufInner::alloc_pinned(64, 0).expect("alloc_pinned");
     let slice = unsafe { std::slice::from_raw_parts_mut(pinned.as_device_ptr(), pinned.cuda_len) };
     slice
         .iter_mut()

--- a/crates/ros-z/tests/cuda_transport.rs
+++ b/crates/ros-z/tests/cuda_transport.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use ros_z::{Builder, CudaBufInner, ZBuf, context::ZContextBuilder};
 use ros_z_msgs::sensor_msgs::PointCloud2;
-use zenoh_buffers::buffer::SplitBuffer;
+use zenoh_buffers::{ZSliceKind, buffer::SplitBuffer};
 
 // ────────────────────────────────────────────────────────────
 // Helper: build a minimal test context (peer mode, no router)
@@ -157,4 +157,107 @@ fn test_pinned_pubsub_inprocess() {
 fn test_cuda_slices_empty_for_cpu() {
     let zbuf = ZBuf::from(vec![1u8, 2, 3]);
     assert_eq!(zbuf.cuda_slices().count(), 0);
+}
+
+// ────────────────────────────────────────────────────────────
+// Test 6: Typed tensor metadata survives ZBuf round-trip
+//
+// Verifies that TensorMeta (shape, dtype) attached via from_cuda_tensor
+// is preserved and retrievable through typed_cuda_slices().
+// ────────────────────────────────────────────────────────────
+#[test]
+#[ignore = "requires CUDA device"]
+fn test_typed_tensor_zbuf() {
+    use zenoh_cuda::TensorMeta;
+
+    let shape = vec![480i64, 640, 3];
+    let meta = TensorMeta {
+        ndim: 3,
+        shape: shape.clone(),
+        dtype_code: 2,  // Float
+        dtype_bits: 16, // float16
+        dtype_lanes: 1,
+        byte_offset: 0,
+        strides: None, // C-contiguous
+    };
+
+    let buf = CudaBufInner::alloc_device(480 * 640 * 3 * 2, 0)
+        .expect("alloc_device")
+        .with_tensor_meta(meta);
+
+    // Verify metadata attached before wrapping
+    assert_eq!(buf.tensor_meta().unwrap().shape, shape);
+
+    let zbuf = ZBuf::from_cuda_tensor(buf);
+
+    // cuda_slices() sees it
+    assert_eq!(zbuf.cuda_slices().count(), 1);
+
+    // typed_cuda_slices() returns the metadata
+    let mut it = zbuf.typed_cuda_slices();
+    let (inner, meta_out) = it.next().expect("typed_cuda_slices must yield one entry");
+    assert!(it.next().is_none(), "only one slice expected");
+
+    assert_eq!(inner.cuda_len, 480 * 640 * 3 * 2);
+    assert_eq!(meta_out.ndim, 3);
+    assert_eq!(meta_out.shape, shape);
+    assert_eq!(meta_out.dtype_code, 2);
+    assert_eq!(meta_out.dtype_bits, 16);
+    assert_eq!(meta_out.dtype_lanes, 1);
+    assert!(meta_out.strides.is_none(), "C-contiguous → no strides");
+
+    // A raw CudaPtr ZBuf must NOT appear in typed_cuda_slices()
+    let raw_buf = CudaBufInner::alloc_device(64, 0).expect("alloc_device");
+    let raw_zbuf = ZBuf::from_cuda(raw_buf);
+    assert_eq!(
+        raw_zbuf.typed_cuda_slices().count(),
+        0,
+        "CudaPtr without metadata must not appear in typed_cuda_slices"
+    );
+}
+
+// ────────────────────────────────────────────────────────────
+// Test 7: Native IPC — device ZBuf encodes a non-zero IPC handle
+//
+// Verifies the publish side of the native IPC path: ZBuf::from_cuda()
+// produces a CudaTensor-or-CudaPtr ZSlice whose embedded IPC handle is
+// non-zero, confirming that cudaIpcGetMemHandle succeeded and that the
+// codec will have valid bytes to write on the wire.
+//
+// The full two-process decode (cudaIpcOpenMemHandle on the subscriber)
+// is exercised by the ORT cross-language demo (ort_publisher / ort_classifier).
+// ────────────────────────────────────────────────────────────
+#[test]
+#[ignore = "requires CUDA device"]
+fn test_native_ipc_handle_non_zero() {
+    const LEN: usize = 1024;
+
+    let buf = CudaBufInner::alloc_device(LEN, 0).expect("alloc_device");
+
+    // The IPC handle must be non-zero for a valid cudaMalloc allocation.
+    assert_ne!(
+        buf.ipc_handle, [0u8; 64],
+        "cudaIpcGetMemHandle must produce a non-zero handle"
+    );
+    assert_eq!(buf.device_id, 0);
+    assert_eq!(buf.cuda_len, LEN);
+
+    let zbuf = ZBuf::from_cuda(buf);
+    let inner = zbuf.cuda_slices().next().expect("must have one CUDA slice");
+
+    // The IPC handle stored in the ZSlice is the one that will be encoded
+    // on the wire and opened by the subscriber.
+    assert_ne!(
+        inner.ipc_handle, [0u8; 64],
+        "IPC handle must survive ZBuf wrapping"
+    );
+    assert_eq!(inner.cuda_len, LEN);
+
+    // ZSlice kind must be CudaPtr (not Raw / ShmPtr).
+    let zs = zbuf.zslices().next().expect("one zslice");
+    assert_eq!(
+        zs.kind,
+        ZSliceKind::CudaPtr,
+        "device ZBuf must have CudaPtr kind"
+    );
 }

--- a/crates/ros-z/tests/cuda_transport.rs
+++ b/crates/ros-z/tests/cuda_transport.rs
@@ -10,9 +10,10 @@
 
 #![cfg(feature = "cuda")]
 
+use std::time::Duration;
+
 use ros_z::{Builder, CudaBufInner, ZBuf, context::ZContextBuilder};
 use ros_z_msgs::sensor_msgs::PointCloud2;
-use std::time::Duration;
 use zenoh_buffers::buffer::SplitBuffer;
 
 // ────────────────────────────────────────────────────────────

--- a/flake.nix
+++ b/flake.nix
@@ -238,7 +238,9 @@
         # and not distributed via the Nix CUDA packages.
         cudaShellHook = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
           export CUDA_PATH="${pkgs.cudaPackages.cuda_cudart.lib}"
-          export LD_LIBRARY_PATH="${pkgs.cudaPackages.cuda_cudart.lib}/lib:/run/opengl-driver/lib:$LD_LIBRARY_PATH"
+          # cudart + host driver (libcuda.so) + gcc libstdc++ for pip-installed torch
+          # (torch wheels are not nix-patched, so they need libstdc++ in LD_LIBRARY_PATH)
+          export LD_LIBRARY_PATH="${pkgs.cudaPackages.cuda_cudart.lib}/lib:/run/opengl-driver/lib:${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH"
           export PATH="/run/current-system/sw/bin:$PATH"
         '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -237,7 +237,7 @@
         # /run/opengl-driver and /run/current-system/sw — the driver is host-managed
         # and not distributed via the Nix CUDA packages.
         cudaShellHook = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
-          export CUDA_PATH="${pkgs.cudaPackages.cuda_cudart}"
+          export CUDA_PATH="${pkgs.cudaPackages.cuda_cudart.lib}"
           export LD_LIBRARY_PATH="${pkgs.cudaPackages.cuda_cudart.lib}/lib:/run/opengl-driver/lib:$LD_LIBRARY_PATH"
           export PATH="/run/current-system/sw/bin:$PATH"
         '';

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,8 @@
 
         pkgs = import nixpkgs {
           inherit system;
+          # allowUnfree is required for CUDA packages (proprietary NVIDIA runtime)
+          config.allowUnfree = true;
           overlays = [
             nix-ros-overlay.overlays.default
             rust-overlay.overlays.default
@@ -225,6 +227,17 @@
           cargo-nextest
         ];
 
+        # CUDA build inputs — only available on Linux; requires allowUnfree = true above.
+        # These packages provide libcudart.so for the zenoh-cuda crate.
+        cudaInputs = pkgs.lib.optionals pkgs.stdenv.isLinux (with pkgs.cudaPackages; [ cuda_cudart ]);
+
+        # Shell-hook fragment that sets CUDA_PATH for the zenoh-cuda build.rs.
+        # build.rs searches $CUDA_PATH/lib64 and $CUDA_PATH/lib for libcudart.so.
+        cudaShellHook = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+          export CUDA_PATH="${pkgs.cudaPackages.cuda_cudart}"
+          export LD_LIBRARY_PATH="${pkgs.cudaPackages.cuda_cudart.lib}/lib:$LD_LIBRARY_PATH"
+        '';
+
         # Environment variables for Rust/C++ interop
         commonEnvVars = rec {
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
@@ -402,6 +415,32 @@
               mdbook-admonish install book/ 2>/dev/null || true
             '';
           };
+
+          # CUDA-enabled shell (no ROS).
+          # Usage: nix develop .#cuda
+          # Provides libcudart so `cargo build --features cuda` works.
+          cuda = mkDevShell {
+            name = "ros-z-cuda";
+            packages = [
+              rustfmt-nightly-bin
+            ]
+            ++ commonBuildInputs
+            ++ devTools
+            ++ pythonTools
+            ++ testTools
+            ++ cudaInputs
+            ++ pre-commit-check.enabledPackages;
+            extraShellHook = ''
+              ${pre-commit-check.shellHook}
+              ${cudaShellHook}
+            '';
+            banner = ''
+              echo "🦀 ros-z CUDA development environment"
+              echo "Rust: $(rustc --version)"
+              echo "CUDA_PATH: $CUDA_PATH"
+              echo "Build with: cargo build --features cuda"
+            '';
+          };
         }
         # Add per-distro dev shells (ros-jazzy, ros-rolling, ...)
         // (builtins.listToAttrs (
@@ -416,6 +455,45 @@
             name = "ros-${distro}-ci";
             value = allDistroShells.${distro}.ci;
           }) distros
+        ))
+        # Add per-distro CUDA shells (ros-jazzy-cuda, ...)
+        // (builtins.listToAttrs (
+          builtins.map (
+            distro:
+            let
+              rosEnv = mkRosEnv distro;
+            in
+            {
+              name = "ros-${distro}-cuda";
+              value = mkDevShell {
+                name = "ros-z-cuda-${distro}";
+                packages = [
+                  rustfmt-nightly-bin
+                ]
+                ++ commonBuildInputs
+                ++ devTools
+                ++ pythonTools
+                ++ testTools
+                ++ cudaInputs
+                ++ [ rosEnv.dev ]
+                ++ pre-commit-check.enabledPackages;
+                rosEnvPath = rosEnv.dev;
+                rosDistro = distro;
+                extraShellHook = ''
+                  ${pre-commit-check.shellHook}
+                  ${cudaShellHook}
+                  mdbook-mermaid install book/ 2>/dev/null || true
+                  mdbook-admonish install book/ 2>/dev/null || true
+                '';
+                banner = ''
+                  echo "🦀 ros-z CUDA + ROS ${distro} environment"
+                  echo "Rust: $(rustc --version)"
+                  echo "CUDA_PATH: $CUDA_PATH"
+                  echo "Build with: cargo build --features cuda,jazzy"
+                '';
+              };
+            }
+          ) distros
         ));
 
         formatter = pkgs.nixfmt-rfc-style;

--- a/flake.nix
+++ b/flake.nix
@@ -233,9 +233,13 @@
 
         # Shell-hook fragment that sets CUDA_PATH for the zenoh-cuda build.rs.
         # build.rs searches $CUDA_PATH/lib64 and $CUDA_PATH/lib for libcudart.so.
+        # Also exposes the host NVIDIA driver (nvidia-smi, libcuda.so) from NixOS's
+        # /run/opengl-driver and /run/current-system/sw — the driver is host-managed
+        # and not distributed via the Nix CUDA packages.
         cudaShellHook = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
           export CUDA_PATH="${pkgs.cudaPackages.cuda_cudart}"
-          export LD_LIBRARY_PATH="${pkgs.cudaPackages.cuda_cudart.lib}/lib:$LD_LIBRARY_PATH"
+          export LD_LIBRARY_PATH="${pkgs.cudaPackages.cuda_cudart.lib}/lib:/run/opengl-driver/lib:$LD_LIBRARY_PATH"
+          export PATH="/run/current-system/sw/bin:$PATH"
         '';
 
         # Environment variables for Rust/C++ interop


### PR DESCRIPTION
## Dependency

Depends on eclipse-zenoh/zenoh#2463 — CUDA IPC transport (`ZSliceKind::CudaPtr`, `zenoh-cuda` crate, `zenoh-mem-transport` CUDA backend). This branch patches the zenoh stack via `Cargo.toml` path overrides until that PR merges.

## Summary

End-to-end zero-copy GPU tensor transport from Python publishers to Rust or Python subscribers, plus a cross-language ML inference demo (Python torchvision → Rust ONNX Runtime).

## Key Changes

- **CUDA IPC transport**: `ZSliceKind::CudaPtr`/`CudaTensor` ZSlices carry GPU memory as a 77-byte IPC handle — no CPU copy of tensor data on the wire
- **`ZBuf` CUDA API**: `ZBuf::from_cuda()`, `typed_cuda_slices()` iterator, `copy_to_host()` for D→H transfer
- **Python bindings** (`ros-z-py`): `PyCudaBuf`, `publish_tensor()`, `publish_zbuf()`, `recv_raw_view()`, `as_torch()`, `as_numpy()`, `as_dlpack()` — full PyO3 + pyi stubs
- **CPU tensor path**: `publish_tensor()` also handles CPU tensors and NumPy arrays via NPY wire format
- **ORT demo**: `ort_publisher.py` (Python/GPU) + `ort_classifier.rs` (Rust/ONNX Runtime) — SqueezeNet 1.1 inference over CUDA IPC
- **Nix**: CUDA dev shells with correct `LD_LIBRARY_PATH` (cudart + host driver + gcc libstdc++ for pip torch)
- **Book**: new `gpu-tensor-transport` chapter covering architecture, API, lifetime contract, and the ORT demo

## Breaking Changes

None