### PR TITLE
feat(dynamic): add derive macro for message schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,7 @@ dependencies = [
  "pyo3",
  "ros-z-cdr",
  "ros-z-codegen",
+ "ros-z-derive",
  "ros-z-msgs",
  "ros-z-protocol",
  "ros-z-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,6 +2859,7 @@ dependencies = [
  "pyo3",
  "ros-z-cdr",
  "ros-z-codegen",
+ "ros-z-derive",
  "ros-z-msgs",
  "ros-z-protocol",
  "ros-z-schema",

--- a/book/src/chapters/custom_messages.md
+++ b/book/src/chapters/custom_messages.md
@@ -2,10 +2,10 @@
 
 ros-z supports two approaches for defining custom message types:
 
-| Approach | Definition | Best For |
-|----------|------------|----------|
-| **Rust-Native** | Write Rust structs directly | Prototyping, ros-z-only systems |
-| **Schema-Generated** | Write `.msg`/`.srv` files, generate Rust | Production, ROS 2 interop |
+| Approach             | Definition                               | Best For                        |
+| -------------------- | ---------------------------------------- | ------------------------------- |
+| **Rust-Native**      | Write Rust structs directly              | Prototyping, ros-z-only systems |
+| **Schema-Generated** | Write `.msg`/`.srv` files, generate Rust | Production, ROS 2 interop       |
 
 ```mermaid
 flowchart TD
@@ -21,7 +21,7 @@ flowchart TD
 
 ## Rust-Native Messages
 
-**Define messages directly in Rust by implementing required traits.** This approach is fast for prototyping but only works between ros-z nodes.
+**Define messages directly in Rust and derive their schema metadata.** This approach is fast for prototyping but only works between ros-z nodes.
 
 ```admonish warning
 Rust-Native messages use `TypeHash::zero()` and won't interoperate with ROS 2 C++/Python nodes.
@@ -31,28 +31,28 @@ Rust-Native messages use `TypeHash::zero()` and won't interoperate with ROS 2 C+
 
 ```mermaid
 graph LR
-    A[Define Struct] --> B[Impl MessageTypeInfo]
+    A[Define Struct] --> B[Derive MessageTypeInfo]
     B --> C[Add Serde Traits]
-    C --> D[Impl WithTypeInfo]
+    C --> D[Impl ZMessage]
     D --> E[Use in Pub/Sub]
 ```
 
 ### Required Traits
 
-| Trait | Purpose | Key Method |
-|-------|---------|------------|
-| **MessageTypeInfo** | Type identification | `type_name()`, `type_hash()` |
-| **WithTypeInfo** | ros-z integration | `type_info()` |
-| **Serialize/Deserialize** | Data encoding | From `serde` |
+| Trait                     | Purpose                              | Key Method                                       |
+| ------------------------- | ------------------------------------ | ------------------------------------------------ |
+| **MessageTypeInfo**       | Type identification + runtime schema | `type_name()`, `type_hash()`, `message_schema()` |
+| **Serialize/Deserialize** | Data encoding                        | From `serde`                                     |
+| **ZMessage**              | ros-z serialization path             | `type Serdes = SerdeCdrSerdes<Self>`             |
 
 ### Message Example
 
 ```rust,ignore
-use ros_z::{MessageTypeInfo, entity::TypeHash};
-use ros_z::ros_msg::WithTypeInfo;
+use ros_z::MessageTypeInfo;
 use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, MessageTypeInfo)]
+#[ros_msg(type_name = "my_msgs/msg/RobotStatus")]
 struct RobotStatus {
     battery_level: f32,
     position_x: f32,
@@ -60,18 +60,14 @@ struct RobotStatus {
     is_moving: bool,
 }
 
-impl MessageTypeInfo for RobotStatus {
-    fn type_name() -> &'static str {
-        "my_msgs::msg::dds_::RobotStatus_"
-    }
-
-    fn type_hash() -> TypeHash {
-        TypeHash::zero()  // ros-z-to-ros-z only
-    }
+impl ros_z::msg::ZMessage for RobotStatus {
+    type Serdes = ros_z::msg::SerdeCdrSerdes<Self>;
 }
-
-impl WithTypeInfo for RobotStatus {}
 ```
+
+`MessageTypeInfo` derive currently supports named structs with deterministic ROS field mappings:
+primitive numeric/bool types, `String`, `Vec<T>`, fixed arrays `[T; N]`, and nested message structs.
+Tuple structs, unit structs, enums, `Option`, maps, and other richer Rust-only shapes are not yet supported.
 
 ### Service Example
 
@@ -104,6 +100,9 @@ impl ZService for NavigateTo {
 ```
 
 See the `z_custom_message` example:
+
+When a publisher node enables the type description service, derived custom message types
+automatically register their runtime schema so dynamic subscribers can discover them.
 
 ```bash
 # Terminal 1: Router
@@ -272,14 +271,14 @@ ROS_Z_MSG_PATH="./my_robot_msgs" cargo build
 
 ## Comparison
 
-| Feature | Rust-Native | Schema-Generated |
-|---------|-------------|------------------|
-| **Definition** | Rust structs | `.msg`/`.srv` files |
-| **Type Hashes** | `TypeHash::zero()` | Proper RIHS01 hashes |
-| **Standard Type Refs** | Manual | Automatic (`geometry_msgs`, etc.) |
-| **ROS 2 Interop** | No | Partial (messages yes, services limited) |
-| **Setup Complexity** | Low | Medium (build.rs required) |
-| **Best For** | Prototyping | Production |
+| Feature                | Rust-Native        | Schema-Generated                         |
+| ---------------------- | ------------------ | ---------------------------------------- |
+| **Definition**         | Rust structs       | `.msg`/`.srv` files                      |
+| **Type Hashes**        | `TypeHash::zero()` | Proper RIHS01 hashes                     |
+| **Standard Type Refs** | Manual             | Automatic (`geometry_msgs`, etc.)        |
+| **ROS 2 Interop**      | No                 | Partial (messages yes, services limited) |
+| **Setup Complexity**   | Low                | Medium (build.rs required)               |
+| **Best For**           | Prototyping        | Production                               |
 
 ---
 

--- a/crates/ros-z-derive/src/lib.rs
+++ b/crates/ros-z-derive/src/lib.rs
@@ -127,45 +127,40 @@ fn impl_message_type_info(input: &DeriveInput) -> syn::Result<TokenStream2> {
             }
 
             fn type_hash() -> ::ros_z::entity::TypeHash {
-                let zero = ::ros_z::entity::TypeHash::zero();
-                if zero.to_rihs_string() == "TypeHashNotSupported" {
-                    return zero;
+                if !::ros_z::entity::TypeHash::is_supported() {
+                    return ::ros_z::entity::TypeHash::zero();
                 }
 
-                static TYPE_HASH: ::std::sync::OnceLock<::ros_z::entity::TypeHash> =
-                    ::std::sync::OnceLock::new();
-
-                TYPE_HASH
-                    .get_or_init(|| {
-                        use ::ros_z::dynamic::MessageSchemaTypeDescription;
-
-                        let schema = Self::message_schema()
-                            .expect("derived message schema must be available");
-                        let rihs = schema
-                            .compute_type_hash()
-                            .expect("derived message schema must produce a type hash")
-                            .to_rihs_string();
-
-                        ::ros_z::entity::TypeHash::from_rihs_string(&rihs)
-                            .expect("derived message hash must be a valid RIHS01 string")
-                    })
-                    .clone()
+                Self::message_schema()
+                    .and_then(|s| s.type_hash.as_deref().map(str::to_owned))
+                    .and_then(|rihs| ::ros_z::entity::TypeHash::from_rihs_string(&rihs))
+                    .unwrap_or_else(|| ::ros_z::entity::TypeHash::zero())
             }
 
             fn message_schema() -> Option<::std::sync::Arc<::ros_z::dynamic::MessageSchema>> {
-                static SCHEMA: ::std::sync::OnceLock<::std::sync::Arc<::ros_z::dynamic::MessageSchema>> =
-                    ::std::sync::OnceLock::new();
+                static SCHEMA: ::std::sync::OnceLock<
+                    ::std::sync::Arc<::ros_z::dynamic::MessageSchema>,
+                > = ::std::sync::OnceLock::new();
 
                 Some(
                     SCHEMA
                         .get_or_init(|| {
-                            ::std::sync::Arc::new(::ros_z::dynamic::MessageSchema {
+                            let mut schema = ::ros_z::dynamic::MessageSchema {
                                 type_name: #type_name_lit.to_string(),
                                 package: #package_lit.to_string(),
                                 name: #message_name_lit.to_string(),
                                 fields: ::std::vec![#(#schema_fields),*],
                                 type_hash: None,
-                            })
+                            };
+
+                            if ::ros_z::entity::TypeHash::is_supported() {
+                                use ::ros_z::dynamic::MessageSchemaTypeDescription;
+                                if let Ok(hash) = schema.compute_type_hash() {
+                                    schema.type_hash = Some(hash.to_rihs_string());
+                                }
+                            }
+
+                            ::std::sync::Arc::new(schema)
                         })
                         .clone(),
                 )
@@ -397,14 +392,19 @@ fn parse_canonical_type_name(type_name: &str) -> syn::Result<(String, String, St
     }
 
     match parts[1] {
-        "msg" | "srv" | "action" => Ok((
+        "msg" | "srv" => Ok((
             parts[0].to_string(),
             parts[1].to_string(),
             parts[2].to_string(),
         )),
+        "action" => Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "ros_msg type_name does not support \"action\" — derive each constituent message type \
+             directly (e.g. \"my_pkg/msg/MyAction_Goal\", \"my_pkg/msg/MyAction_Result\")",
+        )),
         _ => Err(syn::Error::new(
             proc_macro2::Span::call_site(),
-            "ros_msg type_name kind must be one of: msg, srv, action",
+            "ros_msg type_name kind must be one of: msg, srv",
         )),
     }
 }

--- a/crates/ros-z-derive/src/lib.rs
+++ b/crates/ros-z-derive/src/lib.rs
@@ -1,18 +1,41 @@
-//! Derive macros for Python message bridge traits
+//! Derive macros for ros-z traits.
 //!
-//! Provides `FromPyMessage` and `IntoPyMessage` derive macros for automatic
-//! conversion between Python msgspec structs and Rust ROS message types.
+//! Provides:
+//! - `MessageTypeInfo` for Rust-native message schema generation
+//! - `FromPyMessage` and `IntoPyMessage` for Python bridge conversion
 
 #![allow(clippy::collapsible_if)]
 
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    Attribute, Data, DeriveInput, Fields, GenericArgument, Ident, Lit, Meta, PathArguments, Type,
-    parse_macro_input,
+    Attribute, Data, DeriveInput, Expr, Fields, GenericArgument, Ident, LitStr, PathArguments,
+    Type, parse_macro_input,
 };
 
-/// Derive macro for extracting Rust messages from Python objects
+type TokenStream2 = proc_macro2::TokenStream;
+
+/// Derive macro for implementing ros-z message metadata and dynamic schema generation.
+///
+/// # Example
+/// ```ignore
+/// #[derive(MessageTypeInfo)]
+/// #[ros_msg(type_name = "custom_msgs/msg/RobotStatus")]
+/// pub struct RobotStatus {
+///     pub battery_percentage: f64,
+///     pub is_moving: bool,
+/// }
+/// ```
+#[proc_macro_derive(MessageTypeInfo, attributes(ros_msg))]
+pub fn derive_message_type_info(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match impl_message_type_info(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+/// Derive macro for extracting Rust messages from Python objects.
 ///
 /// # Example
 /// ```ignore
@@ -31,7 +54,7 @@ pub fn derive_from_py_message(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Derive macro for constructing Python objects from Rust messages
+/// Derive macro for constructing Python objects from Rust messages.
 ///
 /// # Example
 /// ```ignore
@@ -50,7 +73,110 @@ pub fn derive_into_py_message(input: TokenStream) -> TokenStream {
     }
 }
 
-fn impl_from_py_message(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+fn impl_message_type_info(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let name = &input.ident;
+
+    if !input.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &input.generics,
+            "MessageTypeInfo derive does not support generic types in v1",
+        ));
+    }
+
+    let attrs = parse_ros_msg_args(&input.attrs)?;
+    let canonical_type_name = attrs.type_name.ok_or_else(|| {
+        syn::Error::new_spanned(
+            input,
+            "MessageTypeInfo derive requires #[ros_msg(type_name = \"my_pkg/msg/MyType\")]",
+        )
+    })?;
+    let type_name_lit = LitStr::new(&canonical_type_name, proc_macro2::Span::call_site());
+    let (package, _kind, message_name) = parse_canonical_type_name(&canonical_type_name)?;
+    let dds_type_name = canonical_to_dds_name(&canonical_type_name)?;
+
+    let Data::Struct(data) = &input.data else {
+        return Err(syn::Error::new_spanned(
+            input,
+            "MessageTypeInfo derive only supports named structs in v1",
+        ));
+    };
+
+    let Fields::Named(fields) = &data.fields else {
+        let message = match &data.fields {
+            Fields::Unnamed(_) => "MessageTypeInfo derive does not support tuple structs in v1",
+            Fields::Unit => "MessageTypeInfo derive does not support unit structs in v1",
+            Fields::Named(_) => unreachable!(),
+        };
+        return Err(syn::Error::new_spanned(input, message));
+    };
+
+    let schema_fields = fields
+        .named
+        .iter()
+        .map(generate_message_field_schema_tokens)
+        .collect::<syn::Result<Vec<_>>>()?;
+
+    let package_lit = LitStr::new(&package, proc_macro2::Span::call_site());
+    let message_name_lit = LitStr::new(&message_name, proc_macro2::Span::call_site());
+    let dds_type_name_lit = LitStr::new(&dds_type_name, proc_macro2::Span::call_site());
+
+    Ok(quote! {
+        impl ::ros_z::MessageTypeInfo for #name {
+            fn type_name() -> &'static str {
+                #dds_type_name_lit
+            }
+
+            fn type_hash() -> ::ros_z::entity::TypeHash {
+                let zero = ::ros_z::entity::TypeHash::zero();
+                if zero.to_rihs_string() == "TypeHashNotSupported" {
+                    return zero;
+                }
+
+                static TYPE_HASH: ::std::sync::OnceLock<::ros_z::entity::TypeHash> =
+                    ::std::sync::OnceLock::new();
+
+                TYPE_HASH
+                    .get_or_init(|| {
+                        use ::ros_z::dynamic::MessageSchemaTypeDescription;
+
+                        let schema = Self::message_schema()
+                            .expect("derived message schema must be available");
+                        let rihs = schema
+                            .compute_type_hash()
+                            .expect("derived message schema must produce a type hash")
+                            .to_rihs_string();
+
+                        ::ros_z::entity::TypeHash::from_rihs_string(&rihs)
+                            .expect("derived message hash must be a valid RIHS01 string")
+                    })
+                    .clone()
+            }
+
+            fn message_schema() -> Option<::std::sync::Arc<::ros_z::dynamic::MessageSchema>> {
+                static SCHEMA: ::std::sync::OnceLock<::std::sync::Arc<::ros_z::dynamic::MessageSchema>> =
+                    ::std::sync::OnceLock::new();
+
+                Some(
+                    SCHEMA
+                        .get_or_init(|| {
+                            ::std::sync::Arc::new(::ros_z::dynamic::MessageSchema {
+                                type_name: #type_name_lit.to_string(),
+                                package: #package_lit.to_string(),
+                                name: #message_name_lit.to_string(),
+                                fields: ::std::vec![#(#schema_fields),*],
+                                type_hash: None,
+                            })
+                        })
+                        .clone(),
+                )
+            }
+        }
+
+        impl ::ros_z::WithTypeInfo for #name {}
+    })
+}
+
+fn impl_from_py_message(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let name = &input.ident;
 
     let Data::Struct(ref data) = input.data else {
@@ -67,17 +193,14 @@ fn impl_from_py_message(input: &DeriveInput) -> syn::Result<proc_macro2::TokenSt
         ));
     };
 
-    let field_extractions: Vec<proc_macro2::TokenStream> = fields
+    let field_extractions: Vec<TokenStream2> = fields
         .named
         .iter()
         .map(|f| {
             let field_name = f.ident.as_ref().unwrap();
-            let field_name_str = field_name_to_py_attr(field_name);
+            let field_name_str = field_name_to_attr(field_name);
             let field_type = &f.ty;
-
-            // Check for #[ros_msg(zbuf)] attribute
-            let use_zbuf = has_ros_msg_attr(&f.attrs, "zbuf");
-
+            let use_zbuf = parse_ros_msg_args(&f.attrs)?.zbuf;
             generate_field_extraction(field_name, &field_name_str, field_type, use_zbuf)
         })
         .collect::<syn::Result<Vec<_>>>()?;
@@ -94,7 +217,7 @@ fn impl_from_py_message(input: &DeriveInput) -> syn::Result<proc_macro2::TokenSt
     })
 }
 
-fn impl_into_py_message(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+fn impl_into_py_message(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let name = &input.ident;
 
     let Data::Struct(ref data) = input.data else {
@@ -111,20 +234,16 @@ fn impl_into_py_message(input: &DeriveInput) -> syn::Result<proc_macro2::TokenSt
         ));
     };
 
-    // Extract module path from #[ros_msg(module = "...")] attribute
     let module_path = extract_module_path(&input.attrs)?;
 
-    let field_constructions: Vec<proc_macro2::TokenStream> = fields
+    let field_constructions: Vec<TokenStream2> = fields
         .named
         .iter()
         .map(|f| {
             let field_name = f.ident.as_ref().unwrap();
-            let field_name_str = field_name_to_py_attr(field_name);
+            let field_name_str = field_name_to_attr(field_name);
             let field_type = &f.ty;
-
-            // Check for #[ros_msg(zbuf)] attribute
-            let use_zbuf = has_ros_msg_attr(&f.attrs, "zbuf");
-
+            let use_zbuf = parse_ros_msg_args(&f.attrs)?.zbuf;
             generate_field_construction(field_name, &field_name_str, field_type, use_zbuf)
         })
         .collect::<syn::Result<Vec<_>>>()?;
@@ -147,29 +266,173 @@ fn impl_into_py_message(input: &DeriveInput) -> syn::Result<proc_macro2::TokenSt
     })
 }
 
-/// Generate extraction code for a single field
+fn generate_message_field_schema_tokens(field: &syn::Field) -> syn::Result<TokenStream2> {
+    let field_name = field
+        .ident
+        .as_ref()
+        .ok_or_else(|| syn::Error::new_spanned(field, "named fields are required"))?;
+    let field_name_str = field_name_to_attr(field_name);
+    let field_type = generate_message_field_type_tokens(&field.ty)?;
+
+    Ok(quote! {
+        ::ros_z::dynamic::FieldSchema::new(#field_name_str, #field_type)
+    })
+}
+
+fn generate_message_field_type_tokens(ty: &Type) -> syn::Result<TokenStream2> {
+    match ty {
+        Type::Path(type_path) => {
+            if type_path.qself.is_some() {
+                return unsupported_message_type(
+                    ty,
+                    "qualified self types are not supported in v1",
+                );
+            }
+
+            let last_segment = type_path.path.segments.last().ok_or_else(|| {
+                syn::Error::new_spanned(ty, "unsupported field type for MessageTypeInfo derive")
+            })?;
+            let ident_str = last_segment.ident.to_string();
+
+            match ident_str.as_str() {
+                "bool" => Ok(quote! { ::ros_z::dynamic::FieldType::Bool }),
+                "i8" => Ok(quote! { ::ros_z::dynamic::FieldType::Int8 }),
+                "u8" => Ok(quote! { ::ros_z::dynamic::FieldType::Uint8 }),
+                "i16" => Ok(quote! { ::ros_z::dynamic::FieldType::Int16 }),
+                "u16" => Ok(quote! { ::ros_z::dynamic::FieldType::Uint16 }),
+                "i32" => Ok(quote! { ::ros_z::dynamic::FieldType::Int32 }),
+                "u32" => Ok(quote! { ::ros_z::dynamic::FieldType::Uint32 }),
+                "i64" => Ok(quote! { ::ros_z::dynamic::FieldType::Int64 }),
+                "u64" => Ok(quote! { ::ros_z::dynamic::FieldType::Uint64 }),
+                "f32" => Ok(quote! { ::ros_z::dynamic::FieldType::Float32 }),
+                "f64" => Ok(quote! { ::ros_z::dynamic::FieldType::Float64 }),
+                "String" => Ok(quote! { ::ros_z::dynamic::FieldType::String }),
+                "usize" | "isize" => unsupported_message_type(
+                    ty,
+                    "usize and isize are not supported by MessageTypeInfo derive in v1",
+                ),
+                "Option" => unsupported_message_type(
+                    ty,
+                    "Option fields are not supported by MessageTypeInfo derive in v1",
+                ),
+                "HashMap" | "BTreeMap" => unsupported_message_type(
+                    ty,
+                    "map fields are not supported by MessageTypeInfo derive in v1",
+                ),
+                "Vec" => {
+                    let PathArguments::AngleBracketed(args) = &last_segment.arguments else {
+                        return unsupported_message_type(
+                            ty,
+                            "Vec fields must specify an element type",
+                        );
+                    };
+                    let Some(GenericArgument::Type(inner)) = args.args.first() else {
+                        return unsupported_message_type(
+                            ty,
+                            "Vec fields must specify an element type",
+                        );
+                    };
+                    let inner_tokens = generate_message_field_type_tokens(inner)?;
+                    Ok(quote! {
+                        ::ros_z::dynamic::FieldType::Sequence(::std::boxed::Box::new(#inner_tokens))
+                    })
+                }
+                _ => Ok(quote! {
+                    ::ros_z::dynamic::FieldType::Message(
+                        <#ty as ::ros_z::MessageTypeInfo>::message_schema()
+                            .expect("derived nested message schema must be available")
+                    )
+                }),
+            }
+        }
+        Type::Array(array) => {
+            let len = match &array.len {
+                Expr::Lit(expr_lit) => match &expr_lit.lit {
+                    syn::Lit::Int(value) => value.base10_parse::<usize>()?,
+                    _ => {
+                        return unsupported_message_type(
+                            ty,
+                            "array lengths must be integer literals for MessageTypeInfo derive",
+                        );
+                    }
+                },
+                _ => {
+                    return unsupported_message_type(
+                        ty,
+                        "array lengths must be integer literals for MessageTypeInfo derive",
+                    );
+                }
+            };
+
+            let inner_tokens = generate_message_field_type_tokens(&array.elem)?;
+            Ok(quote! {
+                ::ros_z::dynamic::FieldType::Array(::std::boxed::Box::new(#inner_tokens), #len)
+            })
+        }
+        Type::Tuple(_) => unsupported_message_type(
+            ty,
+            "tuple fields are not supported by MessageTypeInfo derive in v1",
+        ),
+        _ => unsupported_message_type(
+            ty,
+            "unsupported field type for MessageTypeInfo derive in v1",
+        ),
+    }
+}
+
+fn unsupported_message_type<T>(node: &T, message: &str) -> syn::Result<TokenStream2>
+where
+    T: quote::ToTokens,
+{
+    Err(syn::Error::new_spanned(node, message))
+}
+
+fn parse_canonical_type_name(type_name: &str) -> syn::Result<(String, String, String)> {
+    let parts: Vec<_> = type_name.split('/').collect();
+    if parts.len() != 3 {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "ros_msg type_name must look like \"my_pkg/msg/MyType\"",
+        ));
+    }
+
+    match parts[1] {
+        "msg" | "srv" | "action" => Ok((
+            parts[0].to_string(),
+            parts[1].to_string(),
+            parts[2].to_string(),
+        )),
+        _ => Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "ros_msg type_name kind must be one of: msg, srv, action",
+        )),
+    }
+}
+
+fn canonical_to_dds_name(type_name: &str) -> syn::Result<String> {
+    let (package, kind, name) = parse_canonical_type_name(type_name)?;
+    Ok(format!("{package}::{kind}::dds_::{name}_"))
+}
+
+/// Generate extraction code for a single field.
 fn generate_field_extraction(
     field_name: &Ident,
     field_name_str: &str,
     field_type: &Type,
     use_zbuf: bool,
-) -> syn::Result<proc_macro2::TokenStream> {
-    // Handle ZBuf fields specially - try zero-copy paths first
+) -> syn::Result<TokenStream2> {
     if use_zbuf {
         return Ok(quote! {
             #field_name: {
-                use ::pyo3::types::{PyBytesMethods, PyByteArrayMethods};
+                use ::pyo3::types::{PyByteArrayMethods, PyBytesMethods};
                 let py_attr = obj.getattr(#field_name_str)?;
-                // Try ZBufView first - clone is cheap (ref-counted ZSlices)
                 if let Ok(view) = py_attr.downcast::<::ros_z::zbuf_view::ZBufView>() {
                     view.borrow().zbuf().clone()
                 } else if let Ok(bytes) = py_attr.downcast::<::pyo3::types::PyBytes>() {
                     ::ros_z::ZBuf::from(bytes.as_bytes().to_vec())
                 } else if let Ok(bytearray) = py_attr.downcast::<::pyo3::types::PyByteArray>() {
-                    // SAFETY: We immediately copy the data
                     ::ros_z::ZBuf::from(unsafe { bytearray.as_bytes() }.to_vec())
                 } else {
-                    // Fallback for lists (slow path)
                     let bytes: Vec<u8> = py_attr.extract()?;
                     ::ros_z::ZBuf::from(bytes)
                 }
@@ -177,32 +440,22 @@ fn generate_field_extraction(
         });
     }
 
-    // Analyze the type
     match classify_type(field_type) {
-        TypeClass::Primitive => Ok(quote! {
+        TypeClass::Primitive | TypeClass::String => Ok(quote! {
             #field_name: obj.getattr(#field_name_str)?.extract()?
         }),
-
-        TypeClass::String => Ok(quote! {
-            #field_name: obj.getattr(#field_name_str)?.extract()?
-        }),
-
         TypeClass::Vec(inner) => {
             let inner_class = classify_type(&inner);
             match inner_class {
-                // Special case for Vec<u8> - use buffer protocol for performance
                 TypeClass::Primitive if is_u8_type(&inner) => Ok(quote! {
                     #field_name: {
-                        use ::pyo3::types::{PyBytesMethods, PyByteArrayMethods};
+                        use ::pyo3::types::{PyByteArrayMethods, PyBytesMethods};
                         let py_attr = obj.getattr(#field_name_str)?;
-                        // Try bytes/bytearray first (fast path - buffer protocol)
                         if let Ok(bytes) = py_attr.downcast::<::pyo3::types::PyBytes>() {
                             bytes.as_bytes().to_vec()
                         } else if let Ok(bytearray) = py_attr.downcast::<::pyo3::types::PyByteArray>() {
-                            // SAFETY: We immediately copy the data
                             unsafe { bytearray.as_bytes() }.to_vec()
                         } else {
-                            // Fallback for lists (slow path)
                             py_attr.extract()?
                         }
                     }
@@ -210,84 +463,63 @@ fn generate_field_extraction(
                 TypeClass::Primitive | TypeClass::String => Ok(quote! {
                     #field_name: obj.getattr(#field_name_str)?.extract()?
                 }),
-                _ => {
-                    // Vec of nested messages - recursively extract
-                    Ok(quote! {
-                        #field_name: {
-                            use ::pyo3::types::PyListMethods;
-                            let py_list = obj.getattr(#field_name_str)?;
-                            let mut vec = Vec::new();
-                            for item in py_list.iter()? {
-                                vec.push(<#inner as ::ros_z::python_bridge::FromPyMessage>::from_py(&item?)?);
-                            }
-                            vec
+                _ => Ok(quote! {
+                    #field_name: {
+                        use ::pyo3::types::PyListMethods;
+                        let py_list = obj.getattr(#field_name_str)?;
+                        let mut vec = Vec::new();
+                        for item in py_list.iter()? {
+                            vec.push(<#inner as ::ros_z::python_bridge::FromPyMessage>::from_py(&item?)?);
                         }
-                    })
-                }
+                        vec
+                    }
+                }),
             }
         }
-
         TypeClass::Array(inner, size) => {
             let inner_class = classify_type(&inner);
             match inner_class {
-                TypeClass::Primitive | TypeClass::String => {
-                    // For primitive arrays, use zeroed memory for initialization
-                    // This works for any array size
-                    Ok(quote! {
-                        #field_name: {
-                            let v: Vec<_> = obj.getattr(#field_name_str)?.extract()?;
-                            // Use zeroed memory for arrays larger than 32 elements
-                            // SAFETY: All primitive numeric types and bool are valid when zeroed
-                            let mut arr: #field_type = unsafe { ::std::mem::zeroed() };
-                            let len = ::std::cmp::min(v.len(), #size);
-                            arr[..len].copy_from_slice(&v[..len]);
-                            arr
+                TypeClass::Primitive | TypeClass::String => Ok(quote! {
+                    #field_name: {
+                        let v: Vec<_> = obj.getattr(#field_name_str)?.extract()?;
+                        let mut arr: #field_type = unsafe { ::std::mem::zeroed() };
+                        let len = ::std::cmp::min(v.len(), #size);
+                        arr[..len].copy_from_slice(&v[..len]);
+                        arr
+                    }
+                }),
+                _ => Ok(quote! {
+                    #field_name: {
+                        use ::pyo3::types::PyListMethods;
+                        let py_list = obj.getattr(#field_name_str)?;
+                        let mut arr: #field_type = ::std::array::from_fn(|_| Default::default());
+                        for (i, item) in py_list.iter()?.enumerate().take(#size) {
+                            arr[i] = <#inner as ::ros_z::python_bridge::FromPyMessage>::from_py(&item?)?;
                         }
-                    })
-                }
-                _ => {
-                    // Fixed array of nested messages
-                    Ok(quote! {
-                        #field_name: {
-                            use ::pyo3::types::PyListMethods;
-                            let py_list = obj.getattr(#field_name_str)?;
-                            let mut arr: #field_type = ::std::array::from_fn(|_| Default::default());
-                            for (i, item) in py_list.iter()?.enumerate().take(#size) {
-                                arr[i] = <#inner as ::ros_z::python_bridge::FromPyMessage>::from_py(&item?)?;
-                            }
-                            arr
-                        }
-                    })
-                }
+                        arr
+                    }
+                }),
             }
         }
-
-        TypeClass::Nested => {
-            // Nested message - check for None and use Default if None
-            Ok(quote! {
-                #field_name: {
-                    let py_attr = obj.getattr(#field_name_str)?;
-                    if py_attr.is_none() {
-                        Default::default()
-                    } else {
-                        <#field_type as ::ros_z::python_bridge::FromPyMessage>::from_py(&py_attr)?
-                    }
+        TypeClass::Nested => Ok(quote! {
+            #field_name: {
+                let py_attr = obj.getattr(#field_name_str)?;
+                if py_attr.is_none() {
+                    Default::default()
+                } else {
+                    <#field_type as ::ros_z::python_bridge::FromPyMessage>::from_py(&py_attr)?
                 }
-            })
-        }
-
+            }
+        }),
         TypeClass::ZBuf => Ok(quote! {
             #field_name: {
-                use ::pyo3::types::{PyBytesMethods, PyByteArrayMethods};
+                use ::pyo3::types::{PyByteArrayMethods, PyBytesMethods};
                 let py_attr = obj.getattr(#field_name_str)?;
-                // Try bytes/bytearray first (fast path - buffer protocol)
                 let bytes: Vec<u8> = if let Ok(bytes) = py_attr.downcast::<::pyo3::types::PyBytes>() {
                     bytes.as_bytes().to_vec()
                 } else if let Ok(bytearray) = py_attr.downcast::<::pyo3::types::PyByteArray>() {
-                    // SAFETY: We immediately copy the data
                     unsafe { bytearray.as_bytes() }.to_vec()
                 } else {
-                    // Fallback for lists (slow path)
                     py_attr.extract()?
                 };
                 ::ros_z::ZBuf::from(bytes)
@@ -296,19 +528,16 @@ fn generate_field_extraction(
     }
 }
 
-/// Generate construction code for a single field (Rust -> Python)
+/// Generate construction code for a single field (Rust -> Python).
 fn generate_field_construction(
     field_name: &Ident,
     field_name_str: &str,
     field_type: &Type,
     use_zbuf: bool,
-) -> syn::Result<proc_macro2::TokenStream> {
-    // Handle ZBuf fields specially - create zero-copy view using buffer protocol
+) -> syn::Result<TokenStream2> {
     if use_zbuf {
         return Ok(quote! {
             {
-                // Create a ZBufView which implements buffer protocol for zero-copy access
-                // Python can use memoryview(zbuf_view) to get zero-copy access to the data
                 let zbuf_view = ::ros_z::zbuf_view::ZBufView::new(self.#field_name.clone());
                 let py_view = ::pyo3::Py::new(py, zbuf_view)?;
                 kwargs.set_item(#field_name_str, py_view)?;
@@ -320,15 +549,12 @@ fn generate_field_construction(
         TypeClass::Primitive => Ok(quote! {
             kwargs.set_item(#field_name_str, self.#field_name)?;
         }),
-
         TypeClass::String => Ok(quote! {
             kwargs.set_item(#field_name_str, &self.#field_name)?;
         }),
-
         TypeClass::Vec(inner) => {
             let inner_class = classify_type(&inner);
             match inner_class {
-                // Special case for Vec<u8> - output as bytes for performance
                 TypeClass::Primitive if is_u8_type(&inner) => Ok(quote! {
                     {
                         let py_bytes = ::pyo3::types::PyBytes::new_bound(py, &self.#field_name);
@@ -338,58 +564,46 @@ fn generate_field_construction(
                 TypeClass::Primitive | TypeClass::String => Ok(quote! {
                     kwargs.set_item(#field_name_str, &self.#field_name)?;
                 }),
-                _ => {
-                    // Vec of nested messages
-                    Ok(quote! {
-                        {
-                            use ::pyo3::types::PyListMethods;
-                            let py_list = ::pyo3::types::PyList::empty_bound(py);
-                            for item in &self.#field_name {
-                                py_list.append(
-                                    <#inner as ::ros_z::python_bridge::IntoPyMessage>::into_py_message(item, py)?
-                                )?;
-                            }
-                            kwargs.set_item(#field_name_str, py_list)?;
+                _ => Ok(quote! {
+                    {
+                        use ::pyo3::types::PyListMethods;
+                        let py_list = ::pyo3::types::PyList::empty_bound(py);
+                        for item in &self.#field_name {
+                            py_list.append(
+                                <#inner as ::ros_z::python_bridge::IntoPyMessage>::into_py_message(item, py)?
+                            )?;
                         }
-                    })
-                }
+                        kwargs.set_item(#field_name_str, py_list)?;
+                    }
+                }),
             }
         }
-
         TypeClass::Array(inner, _) => {
             let inner_class = classify_type(&inner);
             match inner_class {
                 TypeClass::Primitive | TypeClass::String => Ok(quote! {
                     kwargs.set_item(#field_name_str, self.#field_name.to_vec())?;
                 }),
-                _ => {
-                    // Array of nested messages
-                    Ok(quote! {
-                        {
-                            use ::pyo3::types::PyListMethods;
-                            let py_list = ::pyo3::types::PyList::empty_bound(py);
-                            for item in &self.#field_name {
-                                py_list.append(
-                                    <#inner as ::ros_z::python_bridge::IntoPyMessage>::into_py_message(item, py)?
-                                )?;
-                            }
-                            kwargs.set_item(#field_name_str, py_list)?;
+                _ => Ok(quote! {
+                    {
+                        use ::pyo3::types::PyListMethods;
+                        let py_list = ::pyo3::types::PyList::empty_bound(py);
+                        for item in &self.#field_name {
+                            py_list.append(
+                                <#inner as ::ros_z::python_bridge::IntoPyMessage>::into_py_message(item, py)?
+                            )?;
                         }
-                    })
-                }
+                        kwargs.set_item(#field_name_str, py_list)?;
+                    }
+                }),
             }
         }
-
-        TypeClass::Nested => {
-            // Nested message - convert using trait
-            Ok(quote! {
-                kwargs.set_item(
-                    #field_name_str,
-                    <#field_type as ::ros_z::python_bridge::IntoPyMessage>::into_py_message(&self.#field_name, py)?
-                )?;
-            })
-        }
-
+        TypeClass::Nested => Ok(quote! {
+            kwargs.set_item(
+                #field_name_str,
+                <#field_type as ::ros_z::python_bridge::IntoPyMessage>::into_py_message(&self.#field_name, py)?
+            )?;
+        }),
         TypeClass::ZBuf => Ok(quote! {
             {
                 use ::zenoh_buffers::buffer::SplitBuffer;
@@ -401,7 +615,7 @@ fn generate_field_construction(
     }
 }
 
-/// Type classification for code generation
+/// Type classification for Python conversion code generation.
 #[derive(Debug)]
 enum TypeClass {
     Primitive,
@@ -412,15 +626,13 @@ enum TypeClass {
     ZBuf,
 }
 
-/// Classify a type for code generation purposes
+/// Classify a type for Python conversion code generation purposes.
 fn classify_type(ty: &Type) -> TypeClass {
     if let Type::Path(type_path) = ty {
         let segments = &type_path.path.segments;
         if let Some(last_segment) = segments.last() {
-            let ident = &last_segment.ident;
-            let ident_str = ident.to_string();
+            let ident_str = last_segment.ident.to_string();
 
-            // Check for primitives
             if matches!(
                 ident_str.as_str(),
                 "bool"
@@ -438,17 +650,14 @@ fn classify_type(ty: &Type) -> TypeClass {
                 return TypeClass::Primitive;
             }
 
-            // Check for String
             if ident_str == "String" {
                 return TypeClass::String;
             }
 
-            // Check for ZBuf
             if ident_str == "ZBuf" {
                 return TypeClass::ZBuf;
             }
 
-            // Check for Vec
             if ident_str == "Vec" {
                 if let PathArguments::AngleBracketed(args) = &last_segment.arguments {
                     if let Some(GenericArgument::Type(inner)) = args.args.first() {
@@ -459,10 +668,9 @@ fn classify_type(ty: &Type) -> TypeClass {
         }
     }
 
-    // Check for arrays
     if let Type::Array(arr) = ty {
-        if let syn::Expr::Lit(lit) = &arr.len {
-            if let Lit::Int(int_lit) = &lit.lit {
+        if let Expr::Lit(lit) = &arr.len {
+            if let syn::Lit::Int(int_lit) = &lit.lit {
                 if let Ok(size) = int_lit.base10_parse::<usize>() {
                     return TypeClass::Array(Box::new((*arr.elem).clone()), size);
                 }
@@ -470,44 +678,56 @@ fn classify_type(ty: &Type) -> TypeClass {
         }
     }
 
-    // Default to nested message
     TypeClass::Nested
 }
 
-/// Check if a field has a specific ros_msg attribute
-fn has_ros_msg_attr(attrs: &[Attribute], attr_name: &str) -> bool {
-    for attr in attrs {
-        if attr.path().is_ident("ros_msg") {
-            if let Ok(meta) = attr.parse_args::<Ident>() {
-                if meta == attr_name {
-                    return true;
-                }
-            }
-        }
-    }
-    false
+#[derive(Default)]
+struct RosMsgArgs {
+    module: Option<String>,
+    type_name: Option<String>,
+    zbuf: bool,
 }
 
-/// Extract module path from #[ros_msg(module = "...")] attribute
+fn parse_ros_msg_args(attrs: &[Attribute]) -> syn::Result<RosMsgArgs> {
+    let mut parsed = RosMsgArgs::default();
+
+    for attr in attrs {
+        if !attr.path().is_ident("ros_msg") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("module") {
+                let value = meta.value()?.parse::<LitStr>()?;
+                parsed.module = Some(value.value());
+                return Ok(());
+            }
+
+            if meta.path.is_ident("type_name") {
+                let value = meta.value()?.parse::<LitStr>()?;
+                parsed.type_name = Some(value.value());
+                return Ok(());
+            }
+
+            if meta.path.is_ident("zbuf") {
+                parsed.zbuf = true;
+                return Ok(());
+            }
+
+            Err(meta
+                .error("unsupported ros_msg attribute, expected one of: module, type_name, zbuf"))
+        })?;
+    }
+
+    Ok(parsed)
+}
+
 fn extract_module_path(attrs: &[Attribute]) -> syn::Result<String> {
-    for attr in attrs {
-        if attr.path().is_ident("ros_msg") {
-            if let Ok(Meta::NameValue(nv)) = attr.parse_args() {
-                if nv.path.is_ident("module") {
-                    if let syn::Expr::Lit(lit) = &nv.value {
-                        if let Lit::Str(s) = &lit.lit {
-                            return Ok(s.value());
-                        }
-                    }
-                }
-            }
-        }
-    }
-    // Default module path
-    Ok("ros_z_msgs_py.types".to_string())
+    Ok(parse_ros_msg_args(attrs)?
+        .module
+        .unwrap_or_else(|| "ros_z_msgs_py.types".to_string()))
 }
 
-/// Check if a type is u8
 fn is_u8_type(ty: &Type) -> bool {
     if let Type::Path(type_path) = ty {
         if let Some(last_segment) = type_path.path.segments.last() {
@@ -517,11 +737,8 @@ fn is_u8_type(ty: &Type) -> bool {
     false
 }
 
-/// Convert Rust field name to Python attribute name
-/// Handles r#type -> type conversion for Rust keywords
-fn field_name_to_py_attr(ident: &Ident) -> String {
+fn field_name_to_attr(ident: &Ident) -> String {
     let name = ident.to_string();
-    // Strip r# prefix used for Rust keywords
     if let Some(stripped) = name.strip_prefix("r#") {
         stripped.to_string()
     } else {

--- a/crates/ros-z-protocol/src/entity.rs
+++ b/crates/ros-z-protocol/src/entity.rs
@@ -213,6 +213,11 @@ impl TypeHash {
         None
     }
 
+    /// Returns true when RIHS01 type hashing is available (not the case on ROS 2 Humble).
+    pub fn is_supported() -> bool {
+        cfg!(not(feature = "no-type-hash"))
+    }
+
     pub fn to_rihs_string(&self) -> String {
         #[cfg(feature = "no-type-hash")]
         {

--- a/crates/ros-z/Cargo.toml
+++ b/crates/ros-z/Cargo.toml
@@ -34,6 +34,7 @@ prost = { workspace = true, optional = true }
 pyo3 = { workspace = true, optional = true }
 ros-z-cdr = { workspace = true }
 ros-z-codegen = { workspace = true, optional = true }
+ros-z-derive = { path = "../ros-z-derive" }
 ros-z-protocol = { path = "../ros-z-protocol", default-features = false, features = [
   "std",
 ] }

--- a/crates/ros-z/examples/z_custom_message.rs
+++ b/crates/ros-z/examples/z_custom_message.rs
@@ -9,7 +9,8 @@ use ros_z::{
 use serde::{Deserialize, Serialize};
 
 // Custom message for pub/sub example
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, MessageTypeInfo)]
+#[ros_msg(type_name = "custom_msgs/msg/RobotStatus")]
 pub struct RobotStatus {
     pub robot_id: String,
     pub battery_percentage: f64,
@@ -18,65 +19,31 @@ pub struct RobotStatus {
     pub is_moving: bool,
 }
 
-impl MessageTypeInfo for RobotStatus {
-    fn type_name() -> &'static str {
-        "custom_msgs::msg::dds_::RobotStatus_"
-    }
-
-    fn type_hash() -> TypeHash {
-        TypeHash::zero()
-    }
-}
-
-impl ros_z::WithTypeInfo for RobotStatus {}
-
 impl ros_z::msg::ZMessage for RobotStatus {
     type Serdes = ros_z::msg::SerdeCdrSerdes<RobotStatus>;
 }
 
 // Custom service request
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, MessageTypeInfo)]
+#[ros_msg(type_name = "custom_msgs/srv/NavigateTo_Request")]
 pub struct NavigateToRequest {
     pub target_x: f64,
     pub target_y: f64,
     pub max_speed: f64,
 }
 
-impl MessageTypeInfo for NavigateToRequest {
-    fn type_name() -> &'static str {
-        "custom_msgs::srv::dds_::NavigateTo_Request_"
-    }
-
-    fn type_hash() -> TypeHash {
-        TypeHash::zero()
-    }
-}
-
-impl ros_z::WithTypeInfo for NavigateToRequest {}
-
 impl ros_z::msg::ZMessage for NavigateToRequest {
     type Serdes = ros_z::msg::SerdeCdrSerdes<NavigateToRequest>;
 }
 
 // Custom service response
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, MessageTypeInfo)]
+#[ros_msg(type_name = "custom_msgs/srv/NavigateTo_Response")]
 pub struct NavigateToResponse {
     pub success: bool,
     pub estimated_duration: f64,
     pub message: String,
 }
-
-impl MessageTypeInfo for NavigateToResponse {
-    fn type_name() -> &'static str {
-        "custom_msgs::srv::dds_::NavigateTo_Response_"
-    }
-
-    fn type_hash() -> TypeHash {
-        TypeHash::zero()
-    }
-}
-
-impl ros_z::WithTypeInfo for NavigateToResponse {}
 
 impl ros_z::msg::ZMessage for NavigateToResponse {
     type Serdes = ros_z::msg::SerdeCdrSerdes<NavigateToResponse>;
@@ -153,8 +120,13 @@ async fn run_status_publisher(robot_id: String) -> Result<()> {
     println!("Starting robot status publisher for robot: {robot_id}");
 
     let ctx = ZContextBuilder::default().build()?;
-    let node = ctx.create_node("robot_status_publisher").build()?;
+    let node = ctx
+        .create_node("robot_status_publisher")
+        .with_type_description_service()
+        .build()?;
     let zpub = node.create_pub::<RobotStatus>("/robot_status").build()?;
+
+    println!("Type description service enabled for automatic schema registration");
 
     let mut position_x = 0.0;
     let mut position_y = 0.0;

--- a/crates/ros-z/examples/z_custom_message.rs
+++ b/crates/ros-z/examples/z_custom_message.rs
@@ -23,7 +23,8 @@ impl ros_z::msg::ZMessage for RobotStatus {
     type Serdes = ros_z::msg::SerdeCdrSerdes<RobotStatus>;
 }
 
-// Custom service request
+// Custom service request/response: use the `_Request`/`_Response` suffix in type_name.
+// There is no "action" kind — derive each action sub-message (Goal, Result, Feedback) directly.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, MessageTypeInfo)]
 #[ros_msg(type_name = "custom_msgs/srv/NavigateTo_Request")]
 pub struct NavigateToRequest {

--- a/crates/ros-z/src/lib.rs
+++ b/crates/ros-z/src/lib.rs
@@ -103,6 +103,7 @@ pub mod parameter;
 pub use attachment::GidArray;
 pub use entity::{TypeHash, TypeInfo};
 pub use ros_msg::{ActionTypeInfo, MessageTypeInfo, ServiceTypeInfo, WithTypeInfo};
+pub use ros_z_derive::MessageTypeInfo;
 pub use zbuf::ZBuf;
 pub use zenoh::Result;
 

--- a/crates/ros-z/tests/message_type_info_derive.rs
+++ b/crates/ros-z/tests/message_type_info_derive.rs
@@ -124,19 +124,20 @@ fn derive_generates_type_info_and_schema() {
         other => panic!("expected byte sequence field, got {:?}", other),
     }
 
-    let expected_hash = TypeHash::from_rihs_string(
-        &schema
+    if TypeHash::is_supported() {
+        let expected_rihs = schema
             .compute_type_hash()
             .expect("schema hash")
-            .to_rihs_string(),
-    )
-    .expect("valid entity type hash");
-
-    let reported_hash = RobotTelemetry::type_hash();
-    if TypeHash::zero().to_rihs_string() == "TypeHashNotSupported" {
-        assert_eq!(reported_hash, TypeHash::zero());
+            .to_rihs_string();
+        assert_eq!(RobotTelemetry::type_hash().to_rihs_string(), expected_rihs);
+        assert_eq!(
+            schema.type_hash.as_deref(),
+            Some(expected_rihs.as_str()),
+            "message_schema() must carry the computed type_hash"
+        );
     } else {
-        assert_eq!(reported_hash, expected_hash);
+        assert_eq!(RobotTelemetry::type_hash(), TypeHash::zero());
+        assert!(schema.type_hash.is_none());
     }
 }
 
@@ -188,9 +189,7 @@ async fn derived_message_schema_is_auto_registered_and_discoverable() {
     let subscriber = sub_node
         .create_dyn_sub_auto("/derived_topic", Duration::from_secs(10))
         .await
-        .expect("dynamic subscriber with auto-discovery")
-        .build()
-        .expect("subscriber build");
+        .expect("dynamic subscriber with auto-discovery");
     let discovered_schema = subscriber.schema().expect("discovered schema");
 
     assert_eq!(

--- a/crates/ros-z/tests/message_type_info_derive.rs
+++ b/crates/ros-z/tests/message_type_info_derive.rs
@@ -1,0 +1,213 @@
+use std::time::Duration;
+
+use ros_z::{
+    Builder, MessageTypeInfo, TypeHash,
+    context::ZContextBuilder,
+    dynamic::{FieldType, MessageSchemaTypeDescription},
+};
+use serde::{Deserialize, Serialize};
+use zenoh::Wait;
+use zenoh::config::WhatAmI;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ros_z::MessageTypeInfo)]
+#[ros_msg(type_name = "custom_msgs/msg/Position2D")]
+struct Position2D {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ros_z::MessageTypeInfo)]
+#[ros_msg(type_name = "custom_msgs/msg/RobotTelemetry")]
+struct RobotTelemetry {
+    label: String,
+    pose: Position2D,
+    temperatures: Vec<f32>,
+    flags: [bool; 2],
+    payload: Vec<u8>,
+}
+
+impl ros_z::msg::ZMessage for RobotTelemetry {
+    type Serdes = ros_z::msg::SerdeCdrSerdes<Self>;
+}
+
+struct TestRouter {
+    endpoint: String,
+    _session: zenoh::Session,
+}
+
+impl TestRouter {
+    fn new() -> Self {
+        let port = {
+            let listener =
+                std::net::TcpListener::bind("127.0.0.1:0").expect("failed to bind port 0");
+            listener.local_addr().unwrap().port()
+        };
+
+        let endpoint = format!("tcp/127.0.0.1:{port}");
+        let mut config = zenoh::Config::default();
+        config.set_mode(Some(WhatAmI::Router)).unwrap();
+        config
+            .insert_json5("listen/endpoints", &format!("[\"{endpoint}\"]"))
+            .unwrap();
+        config
+            .insert_json5("scouting/multicast/enabled", "false")
+            .unwrap();
+
+        let session = zenoh::open(config)
+            .wait()
+            .expect("failed to open test router");
+        std::thread::sleep(Duration::from_millis(300));
+
+        Self {
+            endpoint,
+            _session: session,
+        }
+    }
+
+    fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+fn create_context_with_router(router: &TestRouter) -> ros_z::Result<ros_z::context::ZContext> {
+    ZContextBuilder::default()
+        .disable_multicast_scouting()
+        .with_connect_endpoints([router.endpoint()])
+        .build()
+}
+
+#[test]
+fn derive_generates_type_info_and_schema() {
+    let schema = RobotTelemetry::message_schema().expect("schema should be generated");
+
+    assert_eq!(
+        RobotTelemetry::type_name(),
+        "custom_msgs::msg::dds_::RobotTelemetry_"
+    );
+    assert_eq!(schema.type_name, "custom_msgs/msg/RobotTelemetry");
+    assert_eq!(schema.field_count(), 5);
+
+    let label = schema.field("label").expect("label field");
+    assert!(matches!(label.field_type, FieldType::String));
+
+    let pose = schema.field("pose").expect("pose field");
+    match &pose.field_type {
+        FieldType::Message(nested) => {
+            assert_eq!(nested.type_name, "custom_msgs/msg/Position2D");
+            assert_eq!(nested.field_count(), 2);
+        }
+        other => panic!("expected nested message field, got {:?}", other),
+    }
+
+    let temperatures = schema.field("temperatures").expect("temperatures field");
+    match &temperatures.field_type {
+        FieldType::Sequence(inner) => {
+            assert!(matches!(inner.as_ref(), FieldType::Float32));
+        }
+        other => panic!("expected sequence field, got {:?}", other),
+    }
+
+    let flags = schema.field("flags").expect("flags field");
+    match &flags.field_type {
+        FieldType::Array(inner, len) => {
+            assert_eq!(*len, 2);
+            assert!(matches!(inner.as_ref(), FieldType::Bool));
+        }
+        other => panic!("expected fixed array field, got {:?}", other),
+    }
+
+    let payload = schema.field("payload").expect("payload field");
+    match &payload.field_type {
+        FieldType::Sequence(inner) => {
+            assert!(matches!(inner.as_ref(), FieldType::Uint8));
+        }
+        other => panic!("expected byte sequence field, got {:?}", other),
+    }
+
+    let expected_hash = TypeHash::from_rihs_string(
+        &schema
+            .compute_type_hash()
+            .expect("schema hash")
+            .to_rihs_string(),
+    )
+    .expect("valid entity type hash");
+
+    let reported_hash = RobotTelemetry::type_hash();
+    if TypeHash::zero().to_rihs_string() == "TypeHashNotSupported" {
+        assert_eq!(reported_hash, TypeHash::zero());
+    } else {
+        assert_eq!(reported_hash, expected_hash);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn derived_message_schema_is_auto_registered_and_discoverable() {
+    let router = TestRouter::new();
+
+    let pub_ctx = create_context_with_router(&router).expect("publisher context");
+    let pub_node = pub_ctx
+        .create_node("derived_talker")
+        .with_type_description_service()
+        .build()
+        .expect("publisher node");
+
+    let publisher = pub_node
+        .create_pub::<RobotTelemetry>("/derived_topic")
+        .build()
+        .expect("publisher");
+
+    let registered = pub_node
+        .type_description_service()
+        .expect("type description service")
+        .get_schema("custom_msgs/msg/RobotTelemetry")
+        .expect("query registered schema");
+    assert!(registered.is_some(), "schema should be auto-registered");
+
+    let sub_ctx = create_context_with_router(&router).expect("subscriber context");
+    let sub_node = sub_ctx
+        .create_node("derived_listener")
+        .build()
+        .expect("subscriber node");
+
+    let publish_task = tokio::spawn(async move {
+        for _ in 0..25 {
+            let msg = RobotTelemetry {
+                label: "robot-1".to_string(),
+                pose: Position2D { x: 1.25, y: -2.5 },
+                temperatures: vec![20.5, 21.0, 21.5],
+                flags: [true, false],
+                payload: vec![1, 2, 3, 4],
+            };
+            publisher.publish(&msg).expect("publish");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let subscriber = sub_node
+        .create_dyn_sub_auto("/derived_topic", Duration::from_secs(10))
+        .await
+        .expect("dynamic subscriber with auto-discovery")
+        .build()
+        .expect("subscriber build");
+    let discovered_schema = subscriber.schema().expect("discovered schema");
+
+    assert_eq!(
+        discovered_schema.type_name,
+        "custom_msgs/msg/RobotTelemetry"
+    );
+    assert_eq!(discovered_schema.field_count(), 5);
+
+    let msg = subscriber
+        .recv_timeout(Duration::from_secs(3))
+        .expect("received dynamic message");
+    assert_eq!(
+        msg.get::<String>("label").expect("label field"),
+        "robot-1".to_string()
+    );
+    assert_eq!(msg.get::<f64>("pose.x").expect("nested pose.x"), 1.25);
+    assert_eq!(msg.get::<f64>("pose.y").expect("nested pose.y"), -2.5);
+
+    publish_task.await.expect("publisher task");
+}


### PR DESCRIPTION
## Description

This PR adds a `#[derive(MessageTypeInfo)]` macro for Rust-native message structs, so custom types can participate in ros-z schema registration and dynamic schema discovery without handwritten `MessageTypeInfo` and `WithTypeInfo` impls.

The derive stays intentionally narrow in scope: named, non-generic structs with explicit ROS canonical type names and field shapes that map directly to the existing schema model.

This keeps typed publisher metadata aligned with what the type description service exposes to dynamic subscribers while removing the common boilerplate path.

## Review Notes

This PR is intended to be reviewed independently against `main`.
The local integration branch `next` carries the combined stack used for downstream preview work.

## Checklist

- [x] Ran `./scripts/check-local.sh` successfully
- [x] Added or updated tests and documentation when applicable
