### PR TITLE
fix(graph): make graph format explicit

### DIFF
--- a/crates/ros-z-protocol/src/format/ros2dds.rs
+++ b/crates/ros-z-protocol/src/format/ros2dds.rs
@@ -131,7 +131,11 @@ impl KeyExprFormatter for Ros2DdsFormatter {
 
         // Topic key expression (escaped)
         let topic_escaped = iter.next().ok_or(MissingTopicName)?;
-        let topic = Self::demangle_name(topic_escaped);
+        let topic = match Self::demangle_name(topic_escaped) {
+            topic if topic.is_empty() => "/".to_string(),
+            topic if topic.starts_with('/') => topic,
+            topic => format!("/{}", topic),
+        };
 
         // Type name (escaped)
         let type_escaped = iter.next().ok_or(MissingTopicType)?;

--- a/crates/ros-z/src/context.rs
+++ b/crates/ros-z/src/context.rs
@@ -95,7 +95,7 @@ impl ZContextBuilder {
         self
     }
 
-    /// Set the key expression format for ROS 2 entity mapping.
+    /// Set the key expression format for ROS 2 entity mapping and graph discovery.
     ///
     /// # Example
     /// ```ignore
@@ -533,7 +533,7 @@ impl Builder for ZContextBuilder {
         }
 
         let domain_id = builder.domain_id;
-        let graph = Arc::new(Graph::new(&session, domain_id)?);
+        let graph = Arc::new(Graph::new(&session, domain_id, builder.keyexpr_format)?);
 
         Ok(ZContext {
             session: Arc::new(session),

--- a/crates/ros-z/src/dynamic/tests/pubsub_tests.rs
+++ b/crates/ros-z/src/dynamic/tests/pubsub_tests.rs
@@ -164,7 +164,9 @@ fn test_zpub_builder_with_dyn_schema() {
 
     // Create a mock builder to test with_dyn_schema
     let session = zenoh::Wait::wait(zenoh::open(zenoh::Config::default())).unwrap();
-    let graph = std::sync::Arc::new(crate::graph::Graph::new(&session, 0).unwrap());
+    let graph = std::sync::Arc::new(
+        crate::graph::Graph::new(&session, 0, ros_z_protocol::KeyExprFormat::default()).unwrap(),
+    );
     let builder: ZPubBuilder<DynamicMessage> = ZPubBuilder {
         entity: crate::entity::EndpointEntity {
             id: 0,
@@ -204,7 +206,9 @@ fn test_zpub_builder_with_serdes_preserves_schema() {
 
     // Create builder with schema
     let session = zenoh::Wait::wait(zenoh::open(zenoh::Config::default())).unwrap();
-    let graph = std::sync::Arc::new(crate::graph::Graph::new(&session, 0).unwrap());
+    let graph = std::sync::Arc::new(
+        crate::graph::Graph::new(&session, 0, ros_z_protocol::KeyExprFormat::default()).unwrap(),
+    );
     let builder: ZPubBuilder<DynamicMessage> = ZPubBuilder {
         entity: crate::entity::EndpointEntity {
             id: 0,

--- a/crates/ros-z/src/graph.rs
+++ b/crates/ros-z/src/graph.rs
@@ -445,6 +445,12 @@ impl Graph {
                 format!("{ADMIN_SPACE}/{domain_id}/**")
             }
             ros_z_protocol::KeyExprFormat::Ros2Dds => "@/*/@ros2_lv/**".to_string(),
+            _ => {
+                return Err(zenoh::Error::from(format!(
+                    "unsupported key expression format for graph construction: {:?}",
+                    format
+                )));
+            }
         };
 
         Self::new_with_pattern(session, domain_id, liveliness_pattern, move |ke| {

--- a/crates/ros-z/src/graph.rs
+++ b/crates/ros-z/src/graph.rs
@@ -445,12 +445,6 @@ impl Graph {
                 format!("{ADMIN_SPACE}/{domain_id}/**")
             }
             ros_z_protocol::KeyExprFormat::Ros2Dds => "@/*/@ros2_lv/**".to_string(),
-            _ => {
-                return Err(zenoh::Error::from(format!(
-                    "unsupported key expression format for graph construction: {:?}",
-                    format
-                )));
-            }
         };
 
         Self::new_with_pattern(session, domain_id, liveliness_pattern, move |ke| {

--- a/crates/ros-z/src/graph.rs
+++ b/crates/ros-z/src/graph.rs
@@ -431,6 +431,33 @@ impl std::fmt::Debug for Graph {
 }
 
 impl Graph {
+    /// Create a new Graph using an explicit key expression format.
+    ///
+    /// The format determines both the liveliness subscription pattern and the
+    /// parser used to turn liveliness keys back into ROS entities.
+    pub fn new(
+        session: &Session,
+        domain_id: usize,
+        format: ros_z_protocol::KeyExprFormat,
+    ) -> Result<Self> {
+        let liveliness_pattern = match format {
+            ros_z_protocol::KeyExprFormat::RmwZenoh => {
+                format!("{ADMIN_SPACE}/{domain_id}/**")
+            }
+            ros_z_protocol::KeyExprFormat::Ros2Dds => "@/*/@ros2_lv/**".to_string(),
+            _ => {
+                return Err(zenoh::Error::from(format!(
+                    "unsupported key expression format for graph construction: {:?}",
+                    format
+                )));
+            }
+        };
+
+        Self::new_with_pattern(session, domain_id, liveliness_pattern, move |ke| {
+            format.parse_liveliness(ke)
+        })
+    }
+
     async fn wait_until<F>(&self, timeout: Duration, predicate: F) -> bool
     where
         F: Fn(&Self) -> bool,
@@ -456,17 +483,6 @@ impl Graph {
                 return predicate(self);
             }
         }
-    }
-
-    pub fn new(session: &Session, domain_id: usize) -> Result<Self> {
-        // Default to RmwZenoh format
-        let format = ros_z_protocol::KeyExprFormat::default();
-        Self::new_with_pattern(
-            session,
-            domain_id,
-            format!("{ADMIN_SPACE}/{domain_id}/**"),
-            move |ke| format.parse_liveliness(ke),
-        )
     }
 
     /// Create a new Graph with a custom liveliness subscription pattern and parser

--- a/crates/ros-z/tests/graph.rs
+++ b/crates/ros-z/tests/graph.rs
@@ -704,11 +704,11 @@ mod tests {
 
         let graph = ctx.graph();
         assert!(
-            graph.count(EntityKind::Publisher, topic_name) >= 1,
+            graph.count(EndpointKind::Publisher, topic_name) >= 1,
             "Expected Ros2Dds graph to discover local publisher"
         );
         assert!(
-            graph.count(EntityKind::Subscription, topic_name) >= 1,
+            graph.count(EndpointKind::Subscription, topic_name) >= 1,
             "Expected Ros2Dds graph to discover local subscriber"
         );
 

--- a/crates/ros-z/tests/graph.rs
+++ b/crates/ros-z/tests/graph.rs
@@ -677,6 +677,44 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that a Ros2Dds context uses a Ros2Dds graph for introspection and matching.
+    #[cfg(feature = "ros2dds")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_ros2dds_context_graph_tracks_local_entities() -> Result<()> {
+        let ctx = ZContextBuilder::default()
+            .keyexpr_format(ros_z_protocol::KeyExprFormat::Ros2Dds)
+            .build()?;
+        let pub_node = ctx.create_node("test_graph_pub_dds").build()?;
+        let sub_node = ctx.create_node("test_graph_sub_dds").build()?;
+        let topic_name = "/test_ros2dds_context_graph";
+
+        let publisher = pub_node.create_pub::<RosString>(topic_name).build()?;
+        let subscriber = sub_node.create_sub::<RosString>(topic_name).build()?;
+
+        assert!(
+            publisher
+                .wait_for_subscription(1, Duration::from_secs(2))
+                .await
+        );
+        assert!(
+            subscriber
+                .wait_for_publisher(1, Duration::from_secs(2))
+                .await
+        );
+
+        let graph = ctx.graph();
+        assert!(
+            graph.count(EntityKind::Publisher, topic_name) >= 1,
+            "Expected Ros2Dds graph to discover local publisher"
+        );
+        assert!(
+            graph.count(EntityKind::Subscription, topic_name) >= 1,
+            "Expected Ros2Dds graph to discover local subscriber"
+        );
+
+        Ok(())
+    }
+
     /// Tests getting action names and types from the graph
     #[tokio::test(flavor = "multi_thread")]
     async fn test_action_names_and_types() -> Result<()> {


### PR DESCRIPTION
## Description

GitHub shows this PR against `main`, but the intended review base is #161.

Make graph backend selection explicit by changing `Graph::new` to require a `KeyExprFormat`, and align `ZContextBuilder` so the context-owned graph uses the same format selected via `.keyexpr_format(...)`.

This fixes an inconsistency where nodes, publishers, subscribers, and services respected the context format, but the internal graph always used the default `RmwZenoh` parser and pattern.

It also restores correct behavior for graph-backed helpers under `Ros2Dds`, including publisher and subscriber matching via the context-owned graph.

## Checklist

- [x] Ran `./scripts/check-local.sh` successfully
- [x] Added or updated tests and documentation when applicable
