### PR TITLE
fix(ignore): only ignore `core` directories top level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ ros-z-msgs/python/uv.lock
 /crates/ros-z-go/generated/
 
 # Core dumps
-core
+/core
 
 # Build cache
 .cache/


### PR DESCRIPTION
## Description

The `.gitignore` ignored all directories and files named `core`. This includes for example the `crates/ros-z-console/src/core` directory. Now only top level entries called `core` are ignored.

## Checklist

- [x] Ran `./scripts/check-local.sh` successfully
- [x] Added/updated tests/documentation (if applicable)
