### PR TITLE
fix(codegen): auto-load bundled assets in generate_user_messages for correct RIHS01 hashes

### DIFF
--- a/crates/ros-z-codegen/src/lib.rs
+++ b/crates/ros-z-codegen/src/lib.rs
@@ -56,27 +56,92 @@ impl MessageGenerator {
         Self { config }
     }
 
-    /// Primary generation method - uses pure Rust codegen pipeline
+    /// Primary generation method - uses pure Rust codegen pipeline.
+    ///
+    /// This is a thin wrapper around [`generate_from_msg_files_with_deps`] with no
+    /// dependency-only packages.
+    ///
+    /// [`generate_from_msg_files_with_deps`]: Self::generate_from_msg_files_with_deps
     pub fn generate_from_msg_files(&self, packages: &[&Path]) -> Result<()> {
-        // Discover and parse all messages, services, and actions
-        let (messages, services, actions) = discovery::discover_all(packages)
+        self.generate_from_msg_files_with_deps(packages, &[])
+    }
+
+    /// Generation method that takes additional dependency-only packages.
+    ///
+    /// `packages` are parsed, resolved AND emitted as Rust code. `dep_packages` are
+    /// parsed and resolved (so their type descriptions are available for hash
+    /// computation of types in `packages` that reference them) but no Rust code is
+    /// emitted for them — these typically come from another crate (e.g. `ros_z_msgs`).
+    ///
+    /// This is the mechanism that lets [`generate_user_messages`] compute correct
+    /// RIHS01 hashes for user messages that reference bundled types like
+    /// `std_msgs/Header` without the user having to manually add bundled paths to
+    /// `ROS_Z_MSG_PATH`.
+    pub fn generate_from_msg_files_with_deps(
+        &self,
+        packages: &[&Path],
+        dep_packages: &[&Path],
+    ) -> Result<()> {
+        // Discover and parse all messages, services, and actions for the user
+        // packages.
+        let (user_messages, user_services, user_actions) = discovery::discover_all(packages)
             .context("Failed to discover messages, services, and actions")?;
 
-        // Filter out problematic messages
-        let messages = Self::filter_messages(messages);
-        let services = Self::filter_services(services);
+        let user_messages = Self::filter_messages(user_messages);
+        let user_services = Self::filter_services(user_services);
+
+        // Track which packages belong to the "user" (emit-code) set so we can
+        // filter the resolver's combined output later.
+        let user_package_names: std::collections::HashSet<String> = user_messages
+            .iter()
+            .map(|m| m.package.clone())
+            .chain(user_services.iter().map(|s| s.package.clone()))
+            .chain(user_actions.iter().map(|a| a.package.clone()))
+            .collect();
 
         println!(
-            "cargo:info=Discovered {} messages, {} services, and {} actions",
-            messages.len(),
-            services.len(),
-            actions.len()
+            "cargo:info=Discovered {} user messages, {} user services, and {} user actions",
+            user_messages.len(),
+            user_services.len(),
+            user_actions.len()
         );
 
-        // Resolve dependencies and calculate type hashes
-        // If external_crate is set, determine which packages are external (not local)
+        // Discover dependency-only packages (parsed for hash resolution but not emitted).
+        let (dep_messages, dep_services, dep_actions) = discovery::discover_all(dep_packages)
+            .context("Failed to discover dependency messages, services, and actions")?;
+        let dep_messages = Self::filter_messages(dep_messages);
+        let dep_services = Self::filter_services(dep_services);
+
+        if !dep_packages.is_empty() {
+            println!(
+                "cargo:info=Discovered {} dependency messages, {} dependency services, and {} dependency actions",
+                dep_messages.len(),
+                dep_services.len(),
+                dep_actions.len()
+            );
+        }
+
+        // Track which packages have been loaded as actual TypeDescriptions — these
+        // do NOT need the resolver's "external_packages" shortcut.
+        let mut loaded_packages: std::collections::HashSet<String> =
+            self.config.local_packages.clone();
+        for m in &dep_messages {
+            loaded_packages.insert(m.package.clone());
+        }
+        for s in &dep_services {
+            loaded_packages.insert(s.package.clone());
+        }
+        for a in &dep_actions {
+            loaded_packages.insert(a.package.clone());
+        }
+
+        // Resolve dependencies and calculate type hashes.
+        // The resolver's "external_packages" set is a fallback that lets references
+        // to types we don't actually have descriptions for be treated as resolved
+        // (with a wrong hash). With this set populated we never trigger that path
+        // for any package whose definitions we've actually loaded.
         let external_packages = if self.config.external_crate.is_some() {
-            // Standard ROS2 packages that are provided by ros_z_msgs
+            // Standard ROS 2 packages that are provided by `ros_z_msgs`.
             let standard_packages: std::collections::HashSet<String> = [
                 "builtin_interfaces",
                 "std_msgs",
@@ -94,9 +159,8 @@ impl MessageGenerator {
             .map(|s| s.to_string())
             .collect();
 
-            // External packages = standard packages - local packages
             standard_packages
-                .difference(&self.config.local_packages)
+                .difference(&loaded_packages)
                 .cloned()
                 .collect()
         } else {
@@ -105,18 +169,48 @@ impl MessageGenerator {
 
         let mut resolver =
             resolver::Resolver::with_external_packages(self.config.is_humble, external_packages);
-        let resolved_messages = resolver
-            .resolve_messages(messages)
+
+        // Resolve dependency messages first so their type descriptions are
+        // registered before any user message that references them.
+        if !dep_messages.is_empty() {
+            resolver
+                .resolve_messages(dep_messages)
+                .context("Failed to resolve dependency message hashes")?;
+        }
+        if !dep_services.is_empty() {
+            resolver
+                .resolve_services(dep_services)
+                .context("Failed to resolve dependency service hashes")?;
+        }
+        if !dep_actions.is_empty() {
+            resolver
+                .resolve_actions(dep_actions)
+                .context("Failed to resolve dependency action hashes")?;
+        }
+
+        // Now resolve the user messages — their hashes will be computed using the
+        // dependency type descriptions registered above.
+        //
+        // `Resolver::resolve_messages` returns *all* messages currently registered
+        // in the resolver (including the dependency messages resolved above), so we
+        // filter the returned vector to keep only types in the user package set —
+        // those are the ones we want to emit Rust code for.
+        let all_resolved = resolver
+            .resolve_messages(user_messages)
             .context("Failed to resolve message dependencies")?;
+        let resolved_messages: Vec<_> = all_resolved
+            .into_iter()
+            .filter(|m| user_package_names.contains(&m.parsed.package))
+            .collect();
         let resolved_services = resolver
-            .resolve_services(services)
+            .resolve_services(user_services)
             .context("Failed to resolve service dependencies")?;
         let resolved_actions = resolver
-            .resolve_actions(actions)
+            .resolve_actions(user_actions)
             .context("Failed to resolve action dependencies")?;
 
         println!(
-            "cargo:info=Resolved {} messages, {} services, and {} actions",
+            "cargo:info=Resolved {} user messages, {} user services, and {} user actions for codegen",
             resolved_messages.len(),
             resolved_services.len(),
             resolved_actions.len()
@@ -133,7 +227,9 @@ impl MessageGenerator {
             println!("cargo:info=Exported JSON manifest to {:?}", json_path);
         }
 
-        // Generate CDR-compatible types (using pure Rust codegen with ZBuf support)
+        // Generate CDR-compatible types (using pure Rust codegen with ZBuf support).
+        // Only user messages are emitted — dependency packages are assumed to be
+        // generated by another crate (e.g. `ros_z_msgs`).
         if self.config.generate_cdr {
             self.generate_cdr_types(&resolved_messages, &resolved_services, &resolved_actions)?;
         }
@@ -432,6 +528,56 @@ impl MessageGenerator {
     }
 }
 
+/// Return the path to the bundled message assets directory for the given distro.
+///
+/// `ros-z-codegen` ships its own copies of the standard ROS 2 interface packages
+/// (`std_msgs`, `geometry_msgs`, `builtin_interfaces`, ...) under `assets/{distro}`.
+/// These are included in the published crate (see the `include` field in
+/// `Cargo.toml`), so this path resolves correctly whether `ros-z-codegen` is
+/// consumed via a path/git dependency or from `crates.io`.
+pub fn bundled_assets_dir(is_humble: bool) -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let distro = if is_humble { "humble" } else { "jazzy" };
+    manifest_dir.join("assets").join(distro)
+}
+
+/// Discover all bundled standard-package message paths shipped with `ros-z-codegen`.
+///
+/// Returns one path per package directory (e.g. `.../assets/jazzy/std_msgs`) for
+/// every subdirectory of the bundled assets that contains `msg/`, `srv/`, or
+/// `action/`. Returns an empty vector if the bundled assets directory does not
+/// exist for some reason.
+pub fn discover_bundled_packages(is_humble: bool) -> Result<Vec<PathBuf>> {
+    let assets_dir = bundled_assets_dir(is_humble);
+    if !assets_dir.exists() {
+        println!(
+            "cargo:warning=Bundled assets directory does not exist: {:?}",
+            assets_dir
+        );
+        return Ok(Vec::new());
+    }
+
+    let mut packages = Vec::new();
+    for entry in std::fs::read_dir(&assets_dir)
+        .with_context(|| format!("Failed to read bundled assets dir {:?}", assets_dir))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let has_messages =
+            path.join("msg").exists() || path.join("srv").exists() || path.join("action").exists();
+
+        if has_messages {
+            packages.push(path);
+        }
+    }
+
+    Ok(packages)
+}
+
 /// Discover user message packages from the ROS_Z_MSG_PATH environment variable.
 ///
 /// The environment variable should contain a colon-separated list of paths,
@@ -483,15 +629,20 @@ pub fn discover_user_packages() -> Result<Vec<PathBuf>> {
     Ok(packages)
 }
 
-/// High-level API for user crates to generate messages from ROS_Z_MSG_PATH.
+/// High-level API for user crates to generate messages from `ROS_Z_MSG_PATH`.
 ///
 /// This function:
-/// 1. Discovers packages from ROS_Z_MSG_PATH environment variable
-/// 2. Generates Rust code with external references to ros_z_msgs for standard types
+/// 1. Discovers user packages from the `ROS_Z_MSG_PATH` environment variable.
+/// 2. Loads the bundled standard ROS 2 packages shipped with `ros-z-codegen`
+///    (`std_msgs`, `geometry_msgs`, `builtin_interfaces`, ...) so that user
+///    messages referencing them get correct RIHS01 type hashes — without users
+///    having to manually add bundled paths to `ROS_Z_MSG_PATH`.
+/// 3. Generates Rust code only for the user packages, with references to standard
+///    types resolved as `::ros_z_msgs::ros::{package}::{Type}`.
 ///
 /// # Arguments
-/// * `output_dir` - Directory where generated.rs will be written
-/// * `is_humble` - Set to true for ROS2 Humble compatibility mode
+/// * `output_dir` - Directory where `generated.rs` will be written
+/// * `is_humble` - Set to true for ROS 2 Humble compatibility mode
 ///
 /// # Example
 /// ```rust,ignore
@@ -506,7 +657,8 @@ pub fn discover_user_packages() -> Result<Vec<PathBuf>> {
 pub fn generate_user_messages(output_dir: &Path, is_humble: bool) -> Result<()> {
     let packages = discover_user_packages()?;
 
-    // Collect local package names
+    // Collect local package names (used to determine which generated code paths
+    // refer to local types vs. types from `ros_z_msgs`).
     let local_packages: std::collections::HashSet<String> = packages
         .iter()
         .filter_map(|p| discovery::discover_package_name(p).ok())
@@ -516,6 +668,32 @@ pub fn generate_user_messages(output_dir: &Path, is_humble: bool) -> Result<()> 
         "cargo:info=Generating user messages for packages: {:?}",
         local_packages
     );
+
+    // Discover bundled standard packages — passed to the resolver as
+    // dependency-only inputs so user messages referencing `std_msgs/Header`,
+    // `builtin_interfaces/Time`, etc. get correct RIHS01 hashes. We do NOT add
+    // them to `local_packages` because we don't want to emit Rust code for them
+    // (the user's crate depends on `ros_z_msgs` for that).
+    let dep_packages = discover_bundled_packages(is_humble)?;
+
+    // Filter out any bundled package whose name collides with a user package —
+    // user definitions take precedence.
+    let dep_packages: Vec<PathBuf> = dep_packages
+        .into_iter()
+        .filter(|p| {
+            discovery::discover_package_name(p)
+                .ok()
+                .is_none_or(|name| !local_packages.contains(&name))
+        })
+        .collect();
+
+    if !dep_packages.is_empty() {
+        println!(
+            "cargo:info=Loading {} bundled standard packages from {:?} for hash resolution",
+            dep_packages.len(),
+            bundled_assets_dir(is_humble)
+        );
+    }
 
     let config = GeneratorConfig {
         generate_cdr: true,
@@ -530,7 +708,8 @@ pub fn generate_user_messages(output_dir: &Path, is_humble: bool) -> Result<()> 
 
     let generator = MessageGenerator::new(config);
     let package_refs: Vec<&Path> = packages.iter().map(|p| p.as_path()).collect();
-    generator.generate_from_msg_files(&package_refs)
+    let dep_refs: Vec<&Path> = dep_packages.iter().map(|p| p.as_path()).collect();
+    generator.generate_from_msg_files_with_deps(&package_refs, &dep_refs)
 }
 
 #[cfg(test)]

--- a/crates/ros-z-codegen/tests/action_hash_check.rs
+++ b/crates/ros-z-codegen/tests/action_hash_check.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+
+fn assets_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/jazzy")
+}
+
+#[test]
+fn test_fibonacci_get_result_hash() {
+    use ros_z_codegen::{
+        discovery::{discover_actions, discover_messages},
+        resolver::Resolver,
+    };
+
+    let assets = assets_dir();
+    let packages = [
+        "builtin_interfaces",
+        "unique_identifier_msgs",
+        "action_msgs",
+        "service_msgs",
+        "action_tutorials_interfaces",
+    ];
+    let mut all_messages = Vec::new();
+    for pkg in &packages {
+        let pkg_path = assets.join(pkg);
+        let msgs = discover_messages(&pkg_path, pkg).unwrap_or_default();
+        all_messages.extend(msgs);
+    }
+
+    let mut resolver = Resolver::new(false);
+    resolver
+        .resolve_messages(all_messages)
+        .expect("resolve messages");
+
+    let pkg_path = assets.join("action_tutorials_interfaces");
+    let actions =
+        discover_actions(&pkg_path, "action_tutorials_interfaces").expect("discover actions");
+    let resolved = resolver.resolve_actions(actions).expect("resolve actions");
+    let fib = resolved
+        .iter()
+        .find(|a| a.parsed.name == "Fibonacci")
+        .expect("Fibonacci action");
+
+    println!("get_result_hash: {}", fib.get_result_hash.to_rihs_string());
+    println!("status_hash:     {}", fib.status_hash.to_rihs_string());
+    println!("send_goal_hash:  {}", fib.send_goal_hash.to_rihs_string());
+
+    // Expected hash from rmw_zenoh_cpp interop test verification
+    assert_eq!(
+        fib.get_result_hash.to_rihs_string(),
+        "RIHS01_8b47e383f1e31f6d8df6417ab54957e7d5ea24dad315646ad711ac3fdea81d58",
+        "get_result hash mismatch"
+    );
+    assert_eq!(
+        fib.status_hash.to_rihs_string(),
+        "RIHS01_6c1684b00f177d37438febe6e709fc4e2b0d4248dca4854946f9ed8b30cda83e",
+        "status hash mismatch"
+    );
+}

--- a/crates/ros-z-codegen/tests/hash_regression.rs
+++ b/crates/ros-z-codegen/tests/hash_regression.rs
@@ -339,6 +339,85 @@ fn test_expected_hash_set_parameters_atomically() {
     );
 }
 
+// --- generate_user_messages regression (issue #168) ---
+//
+// `generate_user_messages` is the public API used by user crates from build.rs.
+// Before issue #168 was fixed, it computed wrong hashes for user messages that
+// referenced bundled types like `std_msgs/Header`, because the resolver had no
+// access to those bundled type descriptions. Now `generate_user_messages` loads
+// the bundled assets shipped with `ros-z-codegen` automatically, so user
+// messages get the canonical RIHS01 hash without callers having to manually
+// add bundled package paths to `ROS_Z_MSG_PATH`.
+
+mod issue_168 {
+    use std::fs;
+
+    use ros_z_codegen::generate_user_messages;
+    use serial_test::serial;
+
+    /// Canonical hash for `test_messages/msg/MsgWithHeader` defined as
+    /// `std_msgs/Header header` + `float64 member_1`, computed by
+    /// `rosidl_generator_type_description`.
+    const EXPECTED_MSG_WITH_HEADER_HASH: &str =
+        "RIHS01_0be811aef59cf675e4afdd9dca7f4e5d70fc4a8dee741e2e8ada6003e46a966c";
+
+    fn set_env(k: &str, v: &str) {
+        // SAFETY: tests are #[serial] to prevent data races on env vars.
+        unsafe { std::env::set_var(k, v) };
+    }
+
+    fn remove_env(k: &str) {
+        unsafe { std::env::remove_var(k) };
+    }
+
+    #[test]
+    #[serial]
+    fn generate_user_messages_msg_with_header_matches_canonical_hash() {
+        let temp = tempfile::tempdir().unwrap();
+        let pkg = temp.path().join("test_messages");
+        let msg_dir = pkg.join("msg");
+        fs::create_dir_all(&msg_dir).unwrap();
+        fs::write(
+            msg_dir.join("MsgWithHeader.msg"),
+            "std_msgs/Header header\nfloat64 member_1\n",
+        )
+        .unwrap();
+
+        let out = temp.path().join("out");
+        fs::create_dir_all(&out).unwrap();
+
+        // ROS_Z_MSG_PATH points only at the user package — the bundled
+        // `std_msgs` and `builtin_interfaces` paths must be picked up
+        // automatically by `generate_user_messages`.
+        set_env("ROS_Z_MSG_PATH", pkg.to_str().unwrap());
+        let result = generate_user_messages(&out, false);
+        remove_env("ROS_Z_MSG_PATH");
+        assert!(result.is_ok(), "generate_user_messages failed: {result:?}");
+
+        let generated = fs::read_to_string(out.join("generated.rs")).unwrap();
+        assert!(
+            generated.contains(EXPECTED_MSG_WITH_HEADER_HASH),
+            "Generated code did not contain expected hash {EXPECTED_MSG_WITH_HEADER_HASH}.\n\
+             Full generated code:\n{generated}"
+        );
+
+        // Bundled types must NOT be re-emitted as user code — they come from
+        // the `ros_z_msgs` crate.
+        assert!(
+            !generated.contains("pub struct Header"),
+            "Generated code unexpectedly contains bundled std_msgs::Header"
+        );
+        assert!(
+            !generated.contains("pub mod std_msgs"),
+            "Generated code unexpectedly contains bundled std_msgs module"
+        );
+        assert!(
+            generated.contains("pub mod test_messages"),
+            "Generated code missing user package module test_messages"
+        );
+    }
+}
+
 #[test]
 #[ignore = "utility: prints current service hash values for comparison with wire_types.rs"]
 fn print_service_hashes() {


### PR DESCRIPTION
## Summary

- `generate_user_messages()` now automatically loads the bundled standard ROS 2 packages (`std_msgs`, `geometry_msgs`, `builtin_interfaces`, etc.) shipped with `ros-z-codegen` when resolving type hashes, so user messages referencing those types get correct RIHS01 values.
- Adds `generate_from_msg_files_with_deps()` — a new lower-level API that accepts dependency-only packages (resolved for hashing, not emitted as Rust code).
- Adds `discover_bundled_packages()` and `bundled_assets_dir()` as public helpers for callers that need direct access to the bundled asset paths.

## Key Changes

- `crates/ros-z-codegen/src/lib.rs`: refactor `generate_from_msg_files` into `generate_from_msg_files_with_deps`; update `generate_user_messages` to load bundled deps automatically.
- `crates/ros-z-codegen/tests/hash_regression.rs`: regression test for issue #168 verifying the canonical `RIHS01_0be811...` hash is produced without manual `ROS_Z_MSG_PATH` additions.

## Breaking Changes

None. `generate_from_msg_files` delegates to the new method with an empty dep list, preserving existing behaviour.