### PR TITLE
fix(ci): skip maturin build on Python venv cache hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,14 @@ jobs:
           nu scripts/test-pure-rust.nu check-distro-features
         shell: bash
 
+      - name: Clippy (ros-z-py)
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            source /tmp/nix-dev-env.sh
+          fi
+          nu scripts/test-pure-rust.nu clippy-ros-z-py
+        shell: bash
+
   go-tests:
     name: Go Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -463,11 +471,6 @@ jobs:
         run: |
           source /tmp/nix-dev-env.sh
           cd crates/ros-z-py && source .venv/bin/activate && maturin develop
-
-      - name: Clippy (ros-z-py)
-        run: |
-          source /tmp/nix-dev-env.sh
-          nu scripts/test-python.nu --distro ${{ matrix.distro }} clippy
 
       - name: Ruff linting
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,7 @@ jobs:
           nu scripts/test-python.nu --distro ${{ matrix.distro }} setup-venv
 
       - name: Build native extension
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
           source /tmp/nix-dev-env.sh
           cd crates/ros-z-py && source .venv/bin/activate && maturin develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,9 @@ jobs:
         id: venv-cache
         uses: actions/cache@v4
         with:
-          path: crates/ros-z-py/.venv
+          path: |
+            crates/ros-z-py/.venv
+            crates/ros-z-msgs/python/ros_z_msgs_py/types
           key: >-
             ${{ runner.os }}-${{ matrix.distro }}-venv-${{
             hashFiles('Cargo.lock', 'crates/ros-z-py/src/**',

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -39,6 +39,11 @@ def check-console [] {
     run-cmd "cargo clippy -p ros-z-console -- -D warnings"
 }
 
+def clippy-ros-z-py [] {
+    log-step "Clippy (ros-z-py)"
+    run-cmd "cargo clippy -p ros-z-py --all-targets -- -D warnings"
+}
+
 def check-examples [] {
     log-step "Check all examples (cargo check --examples)"
     run-cmd "cargo check --examples"
@@ -75,6 +80,7 @@ def get-test-map [] {
         check-console: { check-console }
         check-examples: { check-examples }
         check-distro-features: { check-distro-features }
+        clippy-ros-z-py: { clippy-ros-z-py }
         test-shm: { test-shm }
     }
 }
@@ -87,6 +93,7 @@ def get-test-pipeline [] {
         "check-console"
         "check-examples"
         "check-distro-features"
+        "clippy-ros-z-py"
         "test-shm"
     ]
 }


### PR DESCRIPTION
## Summary
The `Python Tests (ros-z-py)` CI job was building the native extension unconditionally, even on a venv cache hit where the compiled `.so` is already present. This wasted ~3 minutes on every cache-hit run.

## Key Changes
- Add `if: steps.venv-cache.outputs.cache-hit != 'true'` to the `Build native extension` step, matching the existing guard on `Setup venv`

## Breaking Changes
None

Closes #170
