### PR TITLE
fix(docs): fix two broken links reported by lychee CI

### DIFF
--- a/docs/experimental/keyexpr-formats.md
+++ b/docs/experimental/keyexpr-formats.md
@@ -315,7 +315,7 @@ let lv_ke = format.liveliness_key_expr(&entity, &zid)?;
 let parsed_entity = format.parse_liveliness(&lv_ke)?;
 ```
 
-See the [ros-z-protocol documentation](https://docs.rs/ros-z-protocol) for details.
+See the [ros-z-protocol crate](https://github.com/ZettaScaleLabs/ros-z/tree/main/crates/ros-z-protocol) for details.
 
 ## Troubleshooting
 

--- a/docs/getting-started/nix.md
+++ b/docs/getting-started/nix.md
@@ -136,5 +136,5 @@ Your system environment remains intact — Nix installed nothing globally.
 ## Learning More
 
 - **[Nix Official Guide](https://nixos.org/manual/nix/stable/)** — Introduction to Nix
-- **[Nix Flakes](https://nixos.wiki/wiki/Flakes)** — Understanding flakes
+- **[Nix Flakes](https://wiki.nixos.org/wiki/Flakes)** — Understanding flakes
 - **[ros-z flake.nix](https://github.com/ZettaScaleLabs/ros-z/blob/main/flake.nix)** — Our Nix configuration


### PR DESCRIPTION
## Summary

Fixes 2 real broken links surfaced by the lychee link-check CI job (issue #179). The other 39 errors in that run were false positives — `file://` URLs generated when lychee scans the built `site/` HTML on the CI runner rather than the source `.md` files.

## Key Changes

- `book/src/chapters/keyexpr_formats.md`: replace `https://docs.rs/ros-z-protocol` with the GitHub source path — the crate has not been published to crates.io so docs.rs 404s
- `book/src/chapters/nix.md`: replace `https://nixos.wiki/wiki/Flakes` with `https://wiki.nixos.org/wiki/Flakes` — the old domain is being sunset and returns 403 to non-interactive clients

## Breaking Changes

None