### PR TITLE
fix(ci): exclude file:// URLs from lychee link check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -21,4 +21,7 @@ exclude = [
     "crates\\.io",
     # Jinja2 template expressions in site/overrides/ — unprocessed by MkDocs during build
     "%7B%7B",
+    # file:// URLs are generated when lychee resolves internal links in the built site/ HTML
+    # on the CI runner — they are not real external links and are always false positives
+    "file://",
 ]


### PR DESCRIPTION
## Summary

Fixes the 39 false-positive link errors that lychee reported on every CI run (issue #179).

When lychee scans the built `site/` HTML with `--offline`, internal navigation links resolve to `file://` paths on the CI runner. These are not real external links and were generating noise on every docs build.

## Key Changes

- `.lychee.toml`: add `file://` to the exclude list

## Breaking Changes

None