### PR TITLE
feat(pubsub-use-advanced): use AdvancedPublisher/AdvancedSubscriber to interoperate with rmw_zenoh_cpp transient_local topics

### DIFF
--- a/crates/ros-z/src/ffi/publisher.rs
+++ b/crates/ros-z/src/ffi/publisher.rs
@@ -5,11 +5,11 @@ use crate::attachment::{Attachment, GidArray};
 use std::ffi::c_char;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use zenoh::Wait;
-use zenoh::pubsub::Publisher;
+use zenoh_ext::AdvancedPublisher;
 
 /// Raw publisher for FFI (no type parameters)
 pub struct RawPublisher {
-    pub inner: Publisher<'static>,
+    pub inner: AdvancedPublisher<'static>,
     sn: AtomicUsize,
     gid: GidArray,
     /// Liveliness token — kept alive so that rmw_zenoh_cpp subscribers can
@@ -19,7 +19,7 @@ pub struct RawPublisher {
 
 impl RawPublisher {
     pub fn new(
-        publisher: Publisher<'static>,
+        publisher: AdvancedPublisher<'static>,
         gid: GidArray,
         lv_token: zenoh::liveliness::LivelinessToken,
     ) -> Self {

--- a/crates/ros-z/src/ffi/subscriber.rs
+++ b/crates/ros-z/src/ffi/subscriber.rs
@@ -2,14 +2,14 @@ use super::node::{CNode, get_node_ref};
 use super::qos::CQosProfile;
 use super::{ErrorCode, cstr_to_str};
 use std::ffi::c_char;
-use zenoh::pubsub::Subscriber;
+use zenoh_ext::AdvancedSubscriber;
 
 /// Callback type for receiving messages
 pub type MessageCallback = extern "C" fn(user_data: usize, data: *const u8, len: usize);
 
 /// Raw subscriber wrapper that keeps the zenoh subscriber alive
 pub struct RawSubscriber {
-    pub inner: Subscriber<()>,
+    pub inner: AdvancedSubscriber<()>,
 }
 
 /// Opaque subscriber handle for FFI

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -535,9 +535,7 @@ impl ZNode {
         qos: Option<crate::qos::QosProfile>,
     ) -> Result<RawPublisher> {
         use zenoh::qos::CongestionControl;
-        use zenoh_ext::{
-            AdvancedPublisherBuilderExt, CacheConfig, MissDetectionConfig,
-        };
+        use zenoh_ext::{AdvancedPublisherBuilderExt, CacheConfig, MissDetectionConfig};
 
         use crate::{
             entity::{EndpointEntity, EndpointKind},

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -535,13 +535,13 @@ impl ZNode {
         qos: Option<crate::qos::QosProfile>,
     ) -> Result<RawPublisher> {
         use zenoh::qos::CongestionControl;
-        use zenoh_ext::{AdvancedPublisherBuilderExt, CacheConfig, MissDetectionConfig};
+        use zenoh_ext::AdvancedPublisherBuilderExt;
 
         use crate::{
             entity::{EndpointEntity, EndpointKind},
+            pubsub::apply_transient_local_pub,
             topic_name,
         };
-        use ros_z_protocol::qos::{QosDurability, QosHistory, QosReliability};
 
         let qualified_topic =
             topic_name::qualify_topic_name(topic, &self.entity.namespace, &self.entity.name)
@@ -564,27 +564,12 @@ impl ZNode {
         let topic_ke = self.keyexpr_format.topic_key_expr(&entity)?;
         let gid =
             crate::entity::endpoint_gid(&entity).expect("local endpoint always has node identity");
-        let mut publisher = self
+        let publisher = self
             .session
             .declare_publisher((*topic_ke).clone())
             .congestion_control(CongestionControl::Block)
             .advanced();
-        if matches!(entity.qos.durability, QosDurability::TransientLocal) {
-            let depth = match entity.qos.history {
-                QosHistory::KeepLast(d) => d,
-                QosHistory::KeepAll => 1,
-            };
-            publisher = publisher
-                .publisher_detection()
-                .cache(CacheConfig::default().max_samples(depth));
-            if matches!(entity.qos.reliability, QosReliability::Reliable) {
-                publisher = publisher.sample_miss_detection(
-                    MissDetectionConfig::default()
-                        .sporadic_heartbeat(std::time::Duration::from_millis(500)),
-                );
-            }
-        }
-        let publisher = publisher.wait()?;
+        let publisher = apply_transient_local_pub(publisher, &entity.qos).wait()?;
 
         // Declare liveliness token so rmw_zenoh_cpp can discover this publisher.
         let lv_ke = self
@@ -630,10 +615,10 @@ impl ZNode {
     {
         use crate::{
             entity::{EndpointEntity, EndpointKind},
+            pubsub::apply_transient_local_sub,
             topic_name,
         };
-        use ros_z_protocol::qos::{QosDurability, QosHistory, QosReliability};
-        use zenoh_ext::{AdvancedSubscriberBuilderExt, HistoryConfig, RecoveryConfig};
+        use zenoh_ext::AdvancedSubscriberBuilderExt;
 
         let qualified_topic =
             topic_name::qualify_topic_name(topic, &self.entity.namespace, &self.entity.name)
@@ -654,7 +639,7 @@ impl ZNode {
         };
 
         let topic_ke = self.keyexpr_format.topic_key_expr(&entity)?;
-        let mut subscriber = self
+        let subscriber = self
             .session
             .declare_subscriber((*topic_ke).clone())
             .callback(move |sample| {
@@ -662,24 +647,7 @@ impl ZNode {
                 callback(&payload);
             })
             .advanced();
-        if matches!(entity.qos.durability, QosDurability::TransientLocal) {
-            let depth = match entity.qos.history {
-                QosHistory::KeepLast(d) => d,
-                QosHistory::KeepAll => 1,
-            };
-            subscriber = subscriber
-                .history(
-                    HistoryConfig::default()
-                        .detect_late_publishers()
-                        .max_samples(depth),
-                )
-                .query_timeout(std::time::Duration::MAX)
-                .subscriber_detection();
-            if matches!(entity.qos.reliability, QosReliability::Reliable) {
-                subscriber = subscriber.recovery(RecoveryConfig::default().heartbeat());
-            }
-        }
-        let subscriber = subscriber.wait()?;
+        let subscriber = apply_transient_local_sub(subscriber, &entity.qos).wait()?;
 
         Ok(crate::ffi::subscriber::RawSubscriber { inner: subscriber })
     }

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -535,11 +535,15 @@ impl ZNode {
         qos: Option<crate::qos::QosProfile>,
     ) -> Result<RawPublisher> {
         use zenoh::qos::CongestionControl;
+        use zenoh_ext::{
+            AdvancedPublisherBuilderExt, CacheConfig, MissDetectionConfig,
+        };
 
         use crate::{
             entity::{EndpointEntity, EndpointKind},
             topic_name,
         };
+        use ros_z_protocol::qos::{QosDurability, QosHistory, QosReliability};
 
         let qualified_topic =
             topic_name::qualify_topic_name(topic, &self.entity.namespace, &self.entity.name)
@@ -562,11 +566,27 @@ impl ZNode {
         let topic_ke = self.keyexpr_format.topic_key_expr(&entity)?;
         let gid =
             crate::entity::endpoint_gid(&entity).expect("local endpoint always has node identity");
-        let publisher = self
+        let mut publisher = self
             .session
             .declare_publisher((*topic_ke).clone())
             .congestion_control(CongestionControl::Block)
-            .wait()?;
+            .advanced();
+        if matches!(entity.qos.durability, QosDurability::TransientLocal) {
+            let depth = match entity.qos.history {
+                QosHistory::KeepLast(d) => d,
+                QosHistory::KeepAll => 1,
+            };
+            publisher = publisher
+                .publisher_detection()
+                .cache(CacheConfig::default().max_samples(depth));
+            if matches!(entity.qos.reliability, QosReliability::Reliable) {
+                publisher = publisher.sample_miss_detection(
+                    MissDetectionConfig::default()
+                        .sporadic_heartbeat(std::time::Duration::from_millis(500)),
+                );
+            }
+        }
+        let publisher = publisher.wait()?;
 
         // Declare liveliness token so rmw_zenoh_cpp can discover this publisher.
         let lv_ke = self
@@ -614,6 +634,8 @@ impl ZNode {
             entity::{EndpointEntity, EndpointKind},
             topic_name,
         };
+        use ros_z_protocol::qos::{QosDurability, QosHistory, QosReliability};
+        use zenoh_ext::{AdvancedSubscriberBuilderExt, HistoryConfig, RecoveryConfig};
 
         let qualified_topic =
             topic_name::qualify_topic_name(topic, &self.entity.namespace, &self.entity.name)
@@ -634,14 +656,32 @@ impl ZNode {
         };
 
         let topic_ke = self.keyexpr_format.topic_key_expr(&entity)?;
-        let subscriber = self
+        let mut subscriber = self
             .session
             .declare_subscriber((*topic_ke).clone())
             .callback(move |sample| {
                 let payload = sample.payload().to_bytes();
                 callback(&payload);
             })
-            .wait()?;
+            .advanced();
+        if matches!(entity.qos.durability, QosDurability::TransientLocal) {
+            let depth = match entity.qos.history {
+                QosHistory::KeepLast(d) => d,
+                QosHistory::KeepAll => 1,
+            };
+            subscriber = subscriber
+                .history(
+                    HistoryConfig::default()
+                        .detect_late_publishers()
+                        .max_samples(depth),
+                )
+                .query_timeout(std::time::Duration::MAX)
+                .subscriber_detection();
+            if matches!(entity.qos.reliability, QosReliability::Reliable) {
+                subscriber = subscriber.recovery(RecoveryConfig::default().heartbeat());
+            }
+        }
+        let subscriber = subscriber.wait()?;
 
         Ok(crate::ffi::subscriber::RawSubscriber { inner: subscriber })
     }

--- a/crates/ros-z/src/pubsub.rs
+++ b/crates/ros-z/src/pubsub.rs
@@ -270,8 +270,7 @@ where
                 .cache(CacheConfig::default().max_samples(depth));
             if matches!(self.entity.qos.reliability, QosReliability::Reliable) {
                 pub_builder = pub_builder.sample_miss_detection(
-                    MissDetectionConfig::default()
-                        .sporadic_heartbeat(Duration::from_millis(500)),
+                    MissDetectionConfig::default().sporadic_heartbeat(Duration::from_millis(500)),
                 );
             }
             debug!("[PUB] Durability: TransientLocal (cache, depth={})", depth);

--- a/crates/ros-z/src/pubsub.rs
+++ b/crates/ros-z/src/pubsub.rs
@@ -20,6 +20,10 @@ use crate::msg::{SerdeCdrSerdes, ZDeserializer, ZMessage, ZSerializer};
 use crate::qos::QosProfile;
 use ros_z_protocol::qos::{QosDurability, QosHistory, QosReliability};
 use std::sync::Mutex;
+use zenoh_ext::{
+    AdvancedPublisher, AdvancedPublisherBuilderExt, AdvancedSubscriber,
+    AdvancedSubscriberBuilderExt, CacheConfig, HistoryConfig, MissDetectionConfig, RecoveryConfig,
+};
 
 /// A typed ROS 2-style publisher. Send messages with [`publish`](ZPub::publish)
 /// (synchronous) or [`async_publish`](ZPub::async_publish) (async).
@@ -31,7 +35,7 @@ pub struct ZPub<T: ZMessage, S: ZSerializer> {
     sn: AtomicUsize,
     // TODO: replace this with zenoh's global entity id
     gid: GidArray,
-    inner: zenoh::pubsub::Publisher<'static>,
+    inner: AdvancedPublisher<'static>,
     _lv_token: LivelinessToken,
     with_attachment: bool,
     clock: crate::time::ZClock,
@@ -254,18 +258,26 @@ where
             }
         }
 
-        // Map durability: TransientLocal uses express=true for caching
-        match self.entity.qos.durability {
-            QosDurability::TransientLocal => {
-                pub_builder = pub_builder.express(true);
-                debug!("[PUB] Durability: TransientLocal (express)");
+        // Build an AdvancedPublisher and configure based on durability
+        let mut pub_builder = pub_builder.advanced();
+        if matches!(self.entity.qos.durability, QosDurability::TransientLocal) {
+            let depth = match self.entity.qos.history {
+                QosHistory::KeepLast(d) => d,
+                QosHistory::KeepAll => 1,
+            };
+            pub_builder = pub_builder
+                .publisher_detection()
+                .cache(CacheConfig::default().max_samples(depth));
+            if matches!(self.entity.qos.reliability, QosReliability::Reliable) {
+                pub_builder = pub_builder.sample_miss_detection(
+                    MissDetectionConfig::default()
+                        .sporadic_heartbeat(Duration::from_millis(500)),
+                );
             }
-            QosDurability::Volatile => {
-                pub_builder = pub_builder.express(false);
-                debug!("[PUB] Durability: Volatile");
-            }
+            debug!("[PUB] Durability: TransientLocal (cache, depth={})", depth);
+        } else {
+            debug!("[PUB] Durability: Volatile");
         }
-
         let inner = pub_builder.wait()?;
         debug!("[PUB] Publisher ready: topic={}", self.entity.topic);
 
@@ -750,10 +762,12 @@ where
             handler.handle(sample)
         };
 
+        // Build an AdvancedSubscriber and configure based on durability
         let mut sub_builder = self
             .session
             .declare_subscriber(key_expr)
-            .callback(validated_handler);
+            .callback(validated_handler)
+            .advanced();
 
         // Apply locality restriction if specified
         if let Some(locality) = self.locality {
@@ -761,6 +775,23 @@ where
             debug!("[SUB] Locality restriction: {:?}", locality);
         }
 
+        if matches!(self.entity.qos.durability, QosDurability::TransientLocal) {
+            let depth = match self.entity.qos.history {
+                QosHistory::KeepLast(d) => d,
+                QosHistory::KeepAll => 1,
+            };
+            sub_builder = sub_builder
+                .history(
+                    HistoryConfig::default()
+                        .detect_late_publishers()
+                        .max_samples(depth),
+                )
+                .query_timeout(Duration::MAX)
+                .subscriber_detection();
+            if matches!(self.entity.qos.reliability, QosReliability::Reliable) {
+                sub_builder = sub_builder.recovery(RecoveryConfig::default().heartbeat());
+            }
+        }
         let inner = sub_builder.wait()?;
 
         let gid = crate::entity::endpoint_gid(&self.entity)
@@ -892,7 +923,7 @@ where
 pub struct ZSub<T: ZMessage, Q, S: ZDeserializer> {
     pub entity: EndpointEntity,
     pub queue: Option<Arc<BoundedQueue<Q>>>,
-    _inner: zenoh::pubsub::Subscriber<()>,
+    _inner: AdvancedSubscriber<()>,
     _lv_token: LivelinessToken,
     events_mgr: Arc<Mutex<EventsManager>>,
     graph: Arc<Graph>,

--- a/crates/ros-z/src/pubsub.rs
+++ b/crates/ros-z/src/pubsub.rs
@@ -21,9 +21,85 @@ use crate::qos::QosProfile;
 use ros_z_protocol::qos::{QosDurability, QosHistory, QosReliability};
 use std::sync::Mutex;
 use zenoh_ext::{
-    AdvancedPublisher, AdvancedPublisherBuilderExt, AdvancedSubscriber,
-    AdvancedSubscriberBuilderExt, CacheConfig, HistoryConfig, MissDetectionConfig, RecoveryConfig,
+    AdvancedPublisher, AdvancedPublisherBuilder, AdvancedPublisherBuilderExt, AdvancedSubscriber,
+    AdvancedSubscriberBuilder, AdvancedSubscriberBuilderExt, CacheConfig, HistoryConfig,
+    MissDetectionConfig, RecoveryConfig,
 };
+
+/// Sporadic heartbeat period for TransientLocal+Reliable publishers.
+/// Matches rmw_zenoh_cpp's `SAMPLE_MISS_DETECTION_HEARTBEAT_PERIOD`.
+const SAMPLE_MISS_HEARTBEAT_PERIOD: Duration = Duration::from_millis(500);
+
+/// Query timeout for TransientLocal subscribers' initial history fetch.
+/// Matches rmw_zenoh_cpp's `query_timeout_ms = u64::max()` literally
+/// (`Duration::from_millis(u64::MAX)`, not `Duration::MAX`, to avoid any
+/// truncation surprises inside zenoh-ext's internal `as_millis()` paths).
+const TRANSIENT_LOCAL_QUERY_TIMEOUT: Duration = Duration::from_millis(u64::MAX);
+
+fn cache_depth_from_history(history: QosHistory) -> usize {
+    // Mirrors rmw_zenoh_cpp's `QoS::best_available_qos` (`qos.cpp:107`):
+    // a zero-valued depth (the rmw representation of "unspecified" or
+    // KEEP_ALL) is rewritten to `RMW_ZENOH_DEFAULT_HISTORY_DEPTH` (42)
+    // before being passed to `cache.max_samples`. The cap value lives
+    // alongside ros-z's other QoS constants — see `crate::qos`.
+    match history {
+        QosHistory::KeepLast(d) if d > 0 => d,
+        QosHistory::KeepLast(_) => crate::qos::KEEP_ALL_CACHE_DEPTH,
+        QosHistory::KeepAll => crate::qos::KEEP_ALL_CACHE_DEPTH,
+    }
+}
+
+/// Apply ros-z TransientLocal QoS to an `AdvancedPublisherBuilder`.
+///
+/// Mirrors rmw_zenoh_cpp's `rmw_publisher_data.cpp`: enables
+/// `publisher_detection` + `cache`, and `sample_miss_detection` when
+/// `Reliable`. No-op for `Volatile`.
+pub(crate) fn apply_transient_local_pub<'a, 'b, 'c>(
+    mut builder: AdvancedPublisherBuilder<'a, 'b, 'c>,
+    qos: &ros_z_protocol::qos::QosProfile,
+) -> AdvancedPublisherBuilder<'a, 'b, 'c> {
+    if !matches!(qos.durability, QosDurability::TransientLocal) {
+        return builder;
+    }
+    let depth = cache_depth_from_history(qos.history);
+    builder = builder
+        .publisher_detection()
+        .cache(CacheConfig::default().max_samples(depth));
+    if matches!(qos.reliability, QosReliability::Reliable) {
+        builder = builder.sample_miss_detection(
+            MissDetectionConfig::default().sporadic_heartbeat(SAMPLE_MISS_HEARTBEAT_PERIOD),
+        );
+    }
+    builder
+}
+
+/// Apply ros-z TransientLocal QoS to an `AdvancedSubscriberBuilder`.
+///
+/// Mirrors rmw_zenoh_cpp's `rmw_subscription_data.cpp`: enables history
+/// query with late-publisher detection, `subscriber_detection`, a
+/// `u64::MAX`-millisecond query timeout, and heartbeat recovery when
+/// `Reliable`. No-op for `Volatile`.
+pub(crate) fn apply_transient_local_sub<'a, 'b, 'c, H>(
+    mut builder: AdvancedSubscriberBuilder<'a, 'b, 'c, H>,
+    qos: &ros_z_protocol::qos::QosProfile,
+) -> AdvancedSubscriberBuilder<'a, 'b, 'c, H> {
+    if !matches!(qos.durability, QosDurability::TransientLocal) {
+        return builder;
+    }
+    let depth = cache_depth_from_history(qos.history);
+    builder = builder
+        .history(
+            HistoryConfig::default()
+                .detect_late_publishers()
+                .max_samples(depth),
+        )
+        .query_timeout(TRANSIENT_LOCAL_QUERY_TIMEOUT)
+        .subscriber_detection();
+    if matches!(qos.reliability, QosReliability::Reliable) {
+        builder = builder.recovery(RecoveryConfig::default().heartbeat());
+    }
+    builder
+}
 
 /// A typed ROS 2-style publisher. Send messages with [`publish`](ZPub::publish)
 /// (synchronous) or [`async_publish`](ZPub::async_publish) (async).
@@ -258,25 +334,13 @@ where
             }
         }
 
-        // Build an AdvancedPublisher and configure based on durability
-        let mut pub_builder = pub_builder.advanced();
-        if matches!(self.entity.qos.durability, QosDurability::TransientLocal) {
-            let depth = match self.entity.qos.history {
-                QosHistory::KeepLast(d) => d,
-                QosHistory::KeepAll => 1,
-            };
-            pub_builder = pub_builder
-                .publisher_detection()
-                .cache(CacheConfig::default().max_samples(depth));
-            if matches!(self.entity.qos.reliability, QosReliability::Reliable) {
-                pub_builder = pub_builder.sample_miss_detection(
-                    MissDetectionConfig::default().sporadic_heartbeat(Duration::from_millis(500)),
-                );
-            }
-            debug!("[PUB] Durability: TransientLocal (cache, depth={})", depth);
-        } else {
-            debug!("[PUB] Durability: Volatile");
-        }
+        // Build an AdvancedPublisher and apply TransientLocal config if needed.
+        let pub_builder = pub_builder.advanced();
+        debug!(
+            "[PUB] Durability: {:?}, history: {:?}",
+            self.entity.qos.durability, self.entity.qos.history
+        );
+        let pub_builder = apply_transient_local_pub(pub_builder, &self.entity.qos);
         let inner = pub_builder.wait()?;
         debug!("[PUB] Publisher ready: topic={}", self.entity.topic);
 
@@ -774,23 +838,7 @@ where
             debug!("[SUB] Locality restriction: {:?}", locality);
         }
 
-        if matches!(self.entity.qos.durability, QosDurability::TransientLocal) {
-            let depth = match self.entity.qos.history {
-                QosHistory::KeepLast(d) => d,
-                QosHistory::KeepAll => 1,
-            };
-            sub_builder = sub_builder
-                .history(
-                    HistoryConfig::default()
-                        .detect_late_publishers()
-                        .max_samples(depth),
-                )
-                .query_timeout(Duration::MAX)
-                .subscriber_detection();
-            if matches!(self.entity.qos.reliability, QosReliability::Reliable) {
-                sub_builder = sub_builder.recovery(RecoveryConfig::default().heartbeat());
-            }
-        }
+        let sub_builder = apply_transient_local_sub(sub_builder, &self.entity.qos);
         let inner = sub_builder.wait()?;
 
         let gid = crate::entity::endpoint_gid(&self.entity)

--- a/crates/ros-z/src/qos.rs
+++ b/crates/ros-z/src/qos.rs
@@ -18,9 +18,25 @@ impl fmt::Display for QosReliability {
     }
 }
 
-/// Default depth for KEEP_LAST when SYSTEM_DEFAULT (depth=0) is used
-/// This matches ROS 2 and rmw_zenoh_cpp behavior
+/// Default depth for `KeepLast` when SYSTEM_DEFAULT (depth=0) is used.
+/// Matches rclcpp's default of 10. Note this is distinct from
+/// [`KEEP_ALL_CACHE_DEPTH`] below, which is the rmw_zenoh-aligned cap
+/// applied to `KeepAll` when mapped to zenoh-ext's `cache.max_samples`.
 pub const DEFAULT_HISTORY_DEPTH: usize = 10;
+
+/// Cache/history depth used when a TransientLocal endpoint carries
+/// `QosHistory::KeepAll` (no inherent depth) or `KeepLast(0)`.
+///
+/// Matches rmw_zenoh_cpp's `RMW_ZENOH_DEFAULT_HISTORY_DEPTH = 42`
+/// (`rmw_zenoh_cpp/src/detail/qos.cpp:27`), which is the value
+/// rmw_zenoh's `best_available_qos` substitutes for a zero-valued
+/// `qos.depth` before passing it to
+/// `AdvancedPublisherOptions::CacheOptions::max_samples`.
+///
+/// This is intentionally a *finite* cap that mirrors rmw_zenoh's
+/// pragmatic behaviour rather than the DDS KEEP_ALL spec's "keep
+/// everything" semantics.
+pub const KEEP_ALL_CACHE_DEPTH: usize = 42;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum QosHistory {

--- a/crates/ros-z/tests/pubsub_qos.rs
+++ b/crates/ros-z/tests/pubsub_qos.rs
@@ -737,6 +737,23 @@ mod tests {
         Ok(())
     }
 
+    /// Poll the received-buffer length until it reaches `expected` or
+    /// `timeout` elapses. Returns the final length.
+    async fn wait_for_count(
+        received: &Arc<std::sync::Mutex<Vec<String>>>,
+        expected: usize,
+        timeout: Duration,
+    ) -> usize {
+        let start = std::time::Instant::now();
+        loop {
+            let len = received.lock().unwrap().len();
+            if len >= expected || start.elapsed() >= timeout {
+                return len;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
     /// Verify that a TransientLocal publisher replays its history to a
     /// late-joining subscriber.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -778,17 +795,12 @@ mod tests {
                 received_clone.lock().unwrap().push(msg.data);
             })?;
 
-        // Wait for the history query to complete and replay to land.
-        tokio::time::sleep(Duration::from_millis(2000)).await;
-
+        let final_len = wait_for_count(&received, depth, Duration::from_secs(5)).await;
         let got = received.lock().unwrap().clone();
         assert_eq!(
-            got.len(),
-            depth,
+            final_len, depth,
             "Expected {} replayed history messages, got {}: {:?}",
-            depth,
-            got.len(),
-            got
+            depth, final_len, got
         );
         for (i, msg) in got.iter().enumerate() {
             assert_eq!(msg, &format!("history-{}", i));
@@ -839,15 +851,18 @@ mod tests {
                 received_clone.lock().unwrap().push(msg.data);
             })?;
 
-        tokio::time::sleep(Duration::from_millis(2000)).await;
-
+        let final_len = wait_for_count(&received, depth, Duration::from_secs(5)).await;
+        // Give any extra (unexpected) samples a chance to arrive so we can
+        // assert the cache really stopped at `depth`.
+        tokio::time::sleep(Duration::from_millis(500)).await;
         let got = received.lock().unwrap().clone();
         assert_eq!(
             got.len(),
             depth,
-            "Expected exactly {} cached samples (most recent), got {}: {:?}",
+            "Expected exactly {} cached samples (most recent), got {} (waited until {}): {:?}",
             depth,
             got.len(),
+            final_len,
             got
         );
         // The cache holds the last `depth` samples, so the replay must
@@ -855,6 +870,206 @@ mod tests {
         for (i, msg) in got.iter().enumerate() {
             let expected = format!("sample-{}", total - depth + i);
             assert_eq!(msg, &expected, "Unexpected replayed sample at index {}", i);
+        }
+
+        Ok(())
+    }
+
+    /// TransientLocal + BestEffort: the late subscriber must still receive
+    /// the publisher's cached history. Recovery (heartbeat) is not enabled
+    /// for BestEffort, so this exercises the non-heartbeat code path
+    /// end-to-end.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_transient_local_best_effort_replays_to_late_subscriber() -> Result<()> {
+        let (_ctx, pub_node) = setup_test_node("test_tl_be_pub").await?;
+        let sub_node = _ctx.create_node("test_tl_be_sub").build()?;
+
+        let topic = "/test_tl_be_replay";
+        let depth = 4;
+        let qos = create_qos(
+            QosDurability::TransientLocal,
+            QosReliability::BestEffort,
+            QosHistory::KeepLast(NonZeroUsize::new(depth).unwrap()),
+        );
+
+        let pub_handle = pub_node
+            .create_pub::<RosString>(topic)
+            .with_qos(qos)
+            .build()?;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        for i in 0..depth {
+            pub_handle.publish(&RosString {
+                data: format!("be-{}", i),
+            })?;
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let received = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let received_clone = received.clone();
+        let _sub_handle = sub_node
+            .create_sub::<RosString>(topic)
+            .with_qos(qos)
+            .build_with_callback(move |msg: RosString| {
+                received_clone.lock().unwrap().push(msg.data);
+            })?;
+
+        let final_len = wait_for_count(&received, depth, Duration::from_secs(5)).await;
+        let got = received.lock().unwrap().clone();
+        assert_eq!(
+            final_len, depth,
+            "Expected {} replayed BestEffort history messages, got {}: {:?}",
+            depth, final_len, got
+        );
+        for (i, msg) in got.iter().enumerate() {
+            assert_eq!(msg, &format!("be-{}", i));
+        }
+
+        Ok(())
+    }
+
+    /// TransientLocal + KeepAll: pins the rmw_zenoh-aligned cap
+    /// `ros_z::qos::KEEP_ALL_CACHE_DEPTH` (= rmw_zenoh's
+    /// `RMW_ZENOH_DEFAULT_HISTORY_DEPTH = 42`). Publishes more than the
+    /// cap, then late-subscribes, and asserts the cache replayed exactly
+    /// the last `cap` samples — proving both that `KeepAll` is NOT
+    /// silently truncated to 1 (the previous bug) and that it does NOT
+    /// grow unbounded (which would diverge from rmw_zenoh_cpp).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_transient_local_keep_all_caps_at_keep_all_cache_depth() -> Result<()> {
+        use ros_z::qos::KEEP_ALL_CACHE_DEPTH;
+
+        let (_ctx, pub_node) = setup_test_node("test_tl_keepall_pub").await?;
+        let sub_node = _ctx.create_node("test_tl_keepall_sub").build()?;
+
+        let topic = "/test_tl_keepall";
+        let total = KEEP_ALL_CACHE_DEPTH + 8;
+        let qos = create_qos(
+            QosDurability::TransientLocal,
+            QosReliability::Reliable,
+            QosHistory::KeepAll,
+        );
+
+        let pub_handle = pub_node
+            .create_pub::<RosString>(topic)
+            .with_qos(qos)
+            .build()?;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        for i in 0..total {
+            pub_handle.publish(&RosString {
+                data: format!("all-{}", i),
+            })?;
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let received = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let received_clone = received.clone();
+        let _sub_handle = sub_node
+            .create_sub::<RosString>(topic)
+            .with_qos(qos)
+            .build_with_callback(move |msg: RosString| {
+                received_clone.lock().unwrap().push(msg.data);
+            })?;
+
+        let final_len =
+            wait_for_count(&received, KEEP_ALL_CACHE_DEPTH, Duration::from_secs(5)).await;
+        // Give any extra samples beyond the cap a chance to arrive so we
+        // can assert the cache really stopped at KEEP_ALL_CACHE_DEPTH.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let got = received.lock().unwrap().clone();
+        assert_eq!(
+            got.len(),
+            KEEP_ALL_CACHE_DEPTH,
+            "KeepAll must cap at KEEP_ALL_CACHE_DEPTH ({}), got {} (saw {} during wait): {:?}",
+            KEEP_ALL_CACHE_DEPTH,
+            got.len(),
+            final_len,
+            got,
+        );
+        // Cap holds the last KEEP_ALL_CACHE_DEPTH samples, so replay
+        // starts at `total - KEEP_ALL_CACHE_DEPTH`.
+        for (i, msg) in got.iter().enumerate() {
+            let expected = format!("all-{}", total - KEEP_ALL_CACHE_DEPTH + i);
+            assert_eq!(msg, &expected, "Unexpected sample at index {}", i);
+        }
+
+        Ok(())
+    }
+
+    /// TransientLocal with two subscribers — one early (matched before
+    /// publishing) and one late (joined after all samples were emitted).
+    /// Both must end up with the full history; the first subscriber must
+    /// not "consume" the cache.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_transient_local_two_subscribers_early_and_late() -> Result<()> {
+        let (_ctx, pub_node) = setup_test_node("test_tl_two_subs_pub").await?;
+        let early_node = _ctx.create_node("test_tl_two_subs_early").build()?;
+        let late_node = _ctx.create_node("test_tl_two_subs_late").build()?;
+
+        let topic = "/test_tl_two_subs";
+        let depth = 5;
+        let qos = create_qos(
+            QosDurability::TransientLocal,
+            QosReliability::Reliable,
+            QosHistory::KeepLast(NonZeroUsize::new(depth).unwrap()),
+        );
+
+        // Early subscriber, then publisher, then samples, then late subscriber.
+        let early_received = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let early_clone = early_received.clone();
+        let _early_handle = early_node
+            .create_sub::<RosString>(topic)
+            .with_qos(qos)
+            .build_with_callback(move |msg: RosString| {
+                early_clone.lock().unwrap().push(msg.data);
+            })?;
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let pub_handle = pub_node
+            .create_pub::<RosString>(topic)
+            .with_qos(qos)
+            .build()?;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        for i in 0..depth {
+            pub_handle.publish(&RosString {
+                data: format!("two-{}", i),
+            })?;
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Wait for the early subscriber to drain live delivery.
+        let early_len = wait_for_count(&early_received, depth, Duration::from_secs(5)).await;
+        assert_eq!(
+            early_len,
+            depth,
+            "Early subscriber missed live samples: {:?}",
+            early_received.lock().unwrap()
+        );
+
+        // Now attach the late subscriber. Must still get the full replay
+        // even though the early subscriber already consumed the live path.
+        let late_received = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let late_clone = late_received.clone();
+        let _late_handle = late_node
+            .create_sub::<RosString>(topic)
+            .with_qos(qos)
+            .build_with_callback(move |msg: RosString| {
+                late_clone.lock().unwrap().push(msg.data);
+            })?;
+
+        let late_len = wait_for_count(&late_received, depth, Duration::from_secs(5)).await;
+        let got = late_received.lock().unwrap().clone();
+        assert_eq!(
+            late_len, depth,
+            "Late subscriber expected {} replayed samples, got {}: {:?}",
+            depth, late_len, got
+        );
+        for (i, msg) in got.iter().enumerate() {
+            assert_eq!(msg, &format!("two-{}", i));
         }
 
         Ok(())

--- a/crates/ros-z/tests/pubsub_qos.rs
+++ b/crates/ros-z/tests/pubsub_qos.rs
@@ -736,4 +736,127 @@ mod tests {
 
         Ok(())
     }
+
+    /// Verify that a TransientLocal publisher replays its history to a
+    /// late-joining subscriber.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_transient_local_history_replays_to_late_subscriber() -> Result<()> {
+        let (_ctx, pub_node) = setup_test_node("test_tl_history_pub").await?;
+        let sub_node = _ctx.create_node("test_tl_history_sub").build()?;
+
+        let topic = "/test_tl_history_replay";
+        let depth = 5;
+        let qos = create_qos(
+            QosDurability::TransientLocal,
+            QosReliability::Reliable,
+            QosHistory::KeepLast(NonZeroUsize::new(depth).unwrap()),
+        );
+
+        // Publish BEFORE any subscriber exists, so anything the late
+        // subscriber receives must have come from the publisher's cache.
+        let pub_handle = pub_node
+            .create_pub::<RosString>(topic)
+            .with_qos(qos)
+            .build()?;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        for i in 0..depth {
+            pub_handle.publish(&RosString {
+                data: format!("history-{}", i),
+            })?;
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Now create the late-joining subscriber.
+        let received = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let received_clone = received.clone();
+        let _sub_handle = sub_node
+            .create_sub::<RosString>(topic)
+            .with_qos(qos)
+            .build_with_callback(move |msg: RosString| {
+                received_clone.lock().unwrap().push(msg.data);
+            })?;
+
+        // Wait for the history query to complete and replay to land.
+        tokio::time::sleep(Duration::from_millis(2000)).await;
+
+        let got = received.lock().unwrap().clone();
+        assert_eq!(
+            got.len(),
+            depth,
+            "Expected {} replayed history messages, got {}: {:?}",
+            depth,
+            got.len(),
+            got
+        );
+        for (i, msg) in got.iter().enumerate() {
+            assert_eq!(msg, &format!("history-{}", i));
+        }
+
+        Ok(())
+    }
+
+    /// Verify that a TransientLocal publisher's cache honours the
+    /// `KeepLast(depth)` config. When more than `depth` samples have
+    /// been published before a late subscriber arrives, only the most recent
+    /// `depth` are replayed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_transient_local_cache_respects_keep_last_depth() -> Result<()> {
+        let (_ctx, pub_node) = setup_test_node("test_tl_depth_pub").await?;
+        let sub_node = _ctx.create_node("test_tl_depth_sub").build()?;
+
+        let topic = "/test_tl_cache_depth";
+        let depth = 3;
+        let total = 10;
+        let qos = create_qos(
+            QosDurability::TransientLocal,
+            QosReliability::Reliable,
+            QosHistory::KeepLast(NonZeroUsize::new(depth).unwrap()),
+        );
+
+        let pub_handle = pub_node
+            .create_pub::<RosString>(topic)
+            .with_qos(qos)
+            .build()?;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Publish more samples than the cache can hold.
+        for i in 0..total {
+            pub_handle.publish(&RosString {
+                data: format!("sample-{}", i),
+            })?;
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let received = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let received_clone = received.clone();
+        let _sub_handle = sub_node
+            .create_sub::<RosString>(topic)
+            .with_qos(qos)
+            .build_with_callback(move |msg: RosString| {
+                received_clone.lock().unwrap().push(msg.data);
+            })?;
+
+        tokio::time::sleep(Duration::from_millis(2000)).await;
+
+        let got = received.lock().unwrap().clone();
+        assert_eq!(
+            got.len(),
+            depth,
+            "Expected exactly {} cached samples (most recent), got {}: {:?}",
+            depth,
+            got.len(),
+            got
+        );
+        // The cache holds the last `depth` samples, so the replay must
+        // begin at `total - depth`.
+        for (i, msg) in got.iter().enumerate() {
+            let expected = format!("sample-{}", total - depth + i);
+            assert_eq!(msg, &expected, "Unexpected replayed sample at index {}", i);
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Hi folks – opening this one for discussion as I think it's the right approach but would be interested in seeing if this is actually correct. When testing the interop of ros-z with rmw_zenoh, we noticed that messages published with transient_local using rmw_zenoh were not being received by ros-z subscribers. I think this mirrors the fix that @evshary and @JEnoch added to `zenoh-mcap-writer` here – https://github.com/ZettaScaleLabs/rmw-zenoh-mcap-writer/pull/3

The goal of this change is to bring the ros-z pubsub implementation closer to that of rmw_zenoh. That approach always declares `zenoh::ext::AdvancedPublisher`/`AdvancedSubscriber` (see `rmw_publisher_data.cpp:114` and `rmw_subscription_data.cpp:178`). Previously, a plain `zenoh::pubsub::Publisher` and `Subscriber` were used for every endpoint. That means we don't have:

- Cache queryables: `AdvancedSubscriber.history(...)` issues a Zenoh queryable-get against a derived key (`@adv/...`) that the `AdvancedPublisher`'s cache serves. A plain publisher doesn't expose this and a plain subscriber doesn't issue the get.
- Liveliness-based late-publisher detection: `AdvancedPublisher.publisher_detection()` declares a liveliness token; an `AdvancedSubscriber` with `subscriber_detection`/`detect_late_publishers` watches that namespace and triggers a history query whenever a publisher appears.
- Heartbeat-driven sample-miss recovery: for `RELIABLE`, `AdvancedPublisher.sample_miss_detection(...)` emits sporadic heartbeats carrying the latest seqnum; an `AdvancedSubscriber.recovery(heartbeat())` notices seqnum gaps and re-queries the cache to backfill.

The code previously flagged for publishers that "TransientLocal uses express=true for caching" using `express(true)`. However, `express` is a transport-level option that disables batching and does not seem that it would affect caching. Testing shows that this approach retains zero samples and a late subscriber gets nothing to replay.

I tried in this PR to mirror rmw_zenoh_cpp's approach. Every publisher and subscriber created by ros-z is declared as an `AdvancedPublisher` / `AdvancedSubscriber`, and the per-QoS options are added in the same way rmw_zenoh does. There are no behavioural changes for `Volatile` topics beyond switching to the Advanced variants with no extra options enabled (which is what rmw_zenoh does too).

Summary of changes:

- `ZPub` and the FFI raw publisher declare an `AdvancedPublisher<'static>`. For `TransientLocal` the builder adds `publisher_detection()` and `cache(CacheConfig::default().max_samples(qos.depth))`. For `TransientLocal + Reliable` it additionally adds `sample_miss_detection(MissDetectionConfig::default().sporadic_heartbeat(500ms))` — the same 500ms sporadic period rmw_zenoh uses (`SAMPLE_MISS_DETECTION_HEARTBEAT_PERIOD`). The previous `express(true/false)` configuration is removed.
- `ZSub` and the FFI raw subscriber declare an `AdvancedSubscriber<()>`. For `TransientLocal` the builder adds `history(HistoryConfig::default().detect_late_publishers().max_samples(qos.depth))`, `subscriber_detection()`, and `query_timeout(Duration::MAX)` - the last one matches rmw_zenoh's `query_timeout_ms = u64::max()` (`rmw_subscripti_data.cpp:195`). For `TransientLocal` plus `Reliable`, it additionally adds `recovery(RecoveryConfig::default().heartbeat())` to pair with the publisher's `sample_miss_detection`.

Tests:

- All existing `ros-z` unit and integration tests pass unchanged.
- Two new integration tests in `crates/ros-z/tests/pubsub_qos.rs`:
    - `test_transient_local_history_replays_to_late_subscriber` creates a `TransientLocal / Reliable` publisher, publishes 5 samples, *then* connects a subscriber, and asserts all 5 samples are replayed in order. This exercises the publisher's cache and the subscriber's history query end-to-end; it would fail without the new configuration because the plain publisher had no cache to replay from.
    - `test_transient_local_cache_respects_keep_last_depth` publishes 10 samples through a `KeepLast(3)` `TransientLocal` publisher before any subscriber exists, and asserts the late-joining subscriber receives exactly the most recent 3 (`sample-7..sample-9`).
- Manual validation by running a ros-z publisher/subscriber against an rmw_zenoh node on a `TRANSIENT_LOCAL` topic in both directions; the receiver now sees the publisher's history and live samples as expected.

## Checklist

- [ ] Ran `./scripts/check-local.sh` successfully
- [ ] Added/updated tests/documentation (if applicable)
