### PR TITLE
chore: prepare core crates for crates.io publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -509,3 +509,25 @@ jobs:
 
       - name: Import test
         run: .venv/bin/python -c "import hiroz_py; print('hiroz_py install-from-release ok')"
+
+  publish-crates:
+    name: Publish core crates to crates.io
+    needs: [smoke-test-release-install]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate with crates.io (trusted publishing)
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish core crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --workspace -j4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ version = "0.1.0"
 edition = "2024"
 description = "Native Rust ROS 2 implementation using Zenoh"
 homepage = "https://github.com/ZettaScaleLabs/hiroz"
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/ZettaScaleLabs/hiroz"
 
 [workspace]
 resolver = "2"
@@ -29,14 +31,15 @@ default-members = ["crates/hiroz", "crates/hiroz-codegen"]
 
 [workspace.dependencies]
 # Workspace members
-hiroz = { version = "*", path = "crates/hiroz" }
-hiroz-codegen = { version = "*", path = "crates/hiroz-codegen" }
-hiroz-protocol = { version = "*", path = "crates/hiroz-protocol" }
-rmw-zenoh-rs = { version = "*", path = "crates/rmw-zenoh-rs" }
-hiroz-schema = { version = "*", path = "crates/hiroz-schema" }
+hiroz = { version = "0.1.0", path = "crates/hiroz" }
+hiroz-codegen = { version = "0.1.0", path = "crates/hiroz-codegen" }
+hiroz-protocol = { version = "0.1.0", path = "crates/hiroz-protocol" }
+rmw-zenoh-rs = { version = "0.1.0", path = "crates/rmw-zenoh-rs" }
+hiroz-schema = { version = "0.1.0", path = "crates/hiroz-schema" }
 
 # Serialization
-hiroz-cdr = { path = "crates/hiroz-cdr" }
+hiroz-cdr = { version = "0.1.0", path = "crates/hiroz-cdr" }
+hiroz-derive = { version = "0.1.0", path = "crates/hiroz-derive" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"

--- a/crates/hiroz-bridge/Cargo.toml
+++ b/crates/hiroz-bridge/Cargo.toml
@@ -3,6 +3,7 @@ name = "hiroz-bridge"
 version.workspace = true
 edition.workspace = true
 description = "Bridge between ROS 2 Humble and Jazzy Zenoh networks via key expression translation"
+publish = false
 
 [[bin]]
 name = "hiroz-bridge"

--- a/crates/hiroz-cdr/Cargo.toml
+++ b/crates/hiroz-cdr/Cargo.toml
@@ -3,6 +3,11 @@ name = "hiroz-cdr"
 version.workspace = true
 edition.workspace = true
 description = "CDR serialization for hiroz"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["ros2", "zenoh", "cdr", "serialization", "robotics"]
+categories = ["encoding", "network-programming"]
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/hiroz-codegen/Cargo.toml
+++ b/crates/hiroz-codegen/Cargo.toml
@@ -2,9 +2,16 @@
 name = "hiroz-codegen"
 version.workspace = true
 edition.workspace = true
+description = "Build-time code generator for ROS 2 message, service, and action types"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["ros2", "zenoh", "codegen", "build", "robotics"]
+categories = ["development-tools::build-utils"]
 
 # Include vendored assets in published crate
 include = [
+  "build.rs",
   "src/**/*",
   "assets/**/*.msg",
   "assets/**/*.srv",

--- a/crates/hiroz-console/Cargo.toml
+++ b/crates/hiroz-console/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 description = "ROS 2 Graph Inspector & Dataflow Monitor TUI"
 homepage = "https://github.com/ZettaScaleLabs/hiroz"
 default-run = "hiroz-console"
+publish = false
 
 [dependencies]
 hiroz = { path = "../hiroz", features = ["ros2dds"] }

--- a/crates/hiroz-derive/Cargo.toml
+++ b/crates/hiroz-derive/Cargo.toml
@@ -3,6 +3,11 @@ name = "hiroz-derive"
 version.workspace = true
 edition.workspace = true
 description = "Derive macros for hiroz Python bindings"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["ros2", "zenoh", "derive", "macros", "robotics"]
+categories = ["development-tools::procedural-macro-helpers"]
 
 [lib]
 proc-macro = true

--- a/crates/hiroz-msgs/Cargo.toml
+++ b/crates/hiroz-msgs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hiroz-msgs"
 version.workspace = true
 edition.workspace = true
+publish = false
 
 [dependencies]
 hiroz = { path = "../hiroz", default-features = false, features = [

--- a/crates/hiroz-protocol/Cargo.toml
+++ b/crates/hiroz-protocol/Cargo.toml
@@ -8,7 +8,7 @@ description = "ROS 2 over Zenoh protocol: entity types and key expression format
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/ZettaScaleLabs/hiroz"
 keywords = ["ros2", "zenoh", "robotics", "middleware", "protocol"]
-categories = ["network-programming", "robotics"]
+categories = ["network-programming", "science::robotics"]
 
 [features]
 default = ["std", "rmw-zenoh"]

--- a/crates/hiroz-py/Cargo.toml
+++ b/crates/hiroz-py/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hiroz-py"
 version.workspace = true
 edition.workspace = true
+publish = false
 
 [lib]
 name = "_native"

--- a/crates/hiroz-schema/Cargo.toml
+++ b/crates/hiroz-schema/Cargo.toml
@@ -3,7 +3,11 @@ name = "hiroz-schema"
 version.workspace = true
 edition.workspace = true
 description = "ROS 2 type description schema types for hiroz"
+license.workspace = true
+repository.workspace = true
 homepage.workspace = true
+keywords = ["ros2", "zenoh", "schema", "type-description", "robotics"]
+categories = ["encoding", "network-programming"]
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/crates/hiroz/Cargo.toml
+++ b/crates/hiroz/Cargo.toml
@@ -2,6 +2,16 @@
 name = "hiroz"
 version = "0.1.0"
 edition = "2024"
+description = "Native Rust ROS 2 implementation using Zenoh"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["ros2", "zenoh", "robotics", "middleware", "rclrs"]
+categories = ["network-programming", "science::robotics"]
+
+[package.metadata.docs.rs]
+features = ["jazzy", "rmw-zenoh", "dynamic-schema-loader"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 crate-type = ["lib", "staticlib"]
@@ -34,8 +44,8 @@ prost = { workspace = true, optional = true }
 pyo3 = { workspace = true, optional = true }
 hiroz-cdr = { workspace = true }
 hiroz-codegen = { workspace = true, optional = true }
-hiroz-derive = { path = "../hiroz-derive" }
-hiroz-protocol = { path = "../hiroz-protocol", default-features = false, features = [
+hiroz-derive = { workspace = true }
+hiroz-protocol = { path = "../hiroz-protocol", version = "0.1.0", default-features = false, features = [
   "std",
 ] }
 hiroz-schema = { workspace = true }

--- a/crates/rmw-zenoh-rs/Cargo.toml
+++ b/crates/rmw-zenoh-rs/Cargo.toml
@@ -3,6 +3,7 @@ name = "rmw-zenoh-rs"
 version = "0.1.0"
 edition = "2024"
 description = "ROS 2 RMW (ROS Middleware) implementation using Zenoh - Requires ROS 2 Iron or later"
+publish = false
 
 # IMPORTANT: This crate requires ROS 2 Iron (2023) or later
 #


### PR DESCRIPTION
## Summary

- Add `license`, `repository` to `[workspace.package]`; all core crates inherit via `.workspace = true`
- Add full crates.io metadata (`description`, `keywords`, `categories`) to `hiroz-cdr`, `hiroz-derive`, `hiroz-schema`, `hiroz-codegen`, and `hiroz`
- Fix invalid category slug `robotics` → `science::robotics`
- Add `version = "0.1.0"` to all workspace member deps (crates.io rejects path-only and wildcard `*` deps)
- Add `hiroz-derive` to `[workspace.dependencies]`
- Mark tool/application crates `publish = false`: `hiroz-console`, `hiroz-bridge`, `hiroz-py`, `hiroz-msgs`, `rmw-zenoh-rs`
- Add `build.rs` to `hiroz-codegen`'s `include` list (required so downstream users get `cfg(ros_humble)` detection)
- Add `[package.metadata.docs.rs]` to `hiroz` with `features = ["jazzy", "rmw-zenoh", "dynamic-schema-loader"]`
- Add `publish-crates` job to `release.yml`: runs after `smoke-test-release-install`, uses OIDC trusted publishing, calls `cargo publish --workspace`

## Key Changes

- `cargo publish --workspace --dry-run` passes for all six core crates
- All six crates are already live on crates.io at `0.1.0` (first publish done manually)
- Subsequent releases will publish automatically via the new workflow job once Trusted Publishing is configured on crates.io for each crate

## Breaking Changes

None