### PR TITLE
ci: fix bridge-interop cachix skipPush condition never caching on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,7 +636,7 @@ jobs:
         with:
           name: hiroz
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          skipPush: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+          skipPush: ${{ github.event_name == 'pull_request' }}
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

The `bridge-interop` job had a different `skipPush` condition from every other CI job:

```yaml
# Wrong — evaluates to true on push events (empty string != repo name)
skipPush: ${{ github.event.pull_request.head.repo.full_name != github.repository }}

# Fixed — consistent with all other jobs
skipPush: ${{ github.event_name == 'pull_request' }}
```

On a `push` event, `github.event.pull_request` is not set, so `github.event.pull_request.head.repo.full_name` resolves to an empty string. `'' != 'ZettaScaleLabs/hiroz'` is `true`, so `skipPush` was always `true` — the bridge-interop job never pushed derivations to the hiroz cachix cache, even on main branch runs.

## Key Changes

- Fix `bridge-interop` `skipPush` to use `github.event_name == 'pull_request'`, matching all other jobs