### PR TITLE
ci: add docker-compose interop harness (hiroz container <-> ROS 2 Jazzy)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Build context for compose/docker/Dockerfile.hiroz (context = repo root).
+# Only the Rust workspace is needed; keep the context small.
+target
+**/target
+.git
+.github
+.vale
+.config
+assets
+docs
+nix
+scripts
+compose
+**/.venv
+crates/hiroz-go
+crates/hiroz-codegen-go
+flake.nix
+flake.lock
+mkdocs.yml
+cliff.toml
+codecov.yml

--- a/.github/workflows/compose-interop.yml
+++ b/.github/workflows/compose-interop.yml
@@ -1,0 +1,105 @@
+name: Compose Interop
+
+# Cross-container interop gates: hiroz in its own container (the "Raspberry
+# Pi analogue") talking zenoh through rmw_zenohd to a full ROS 2 Jazzy
+# container that exercises topics, services, parameters, actions, and graph
+# introspection. See compose/README.md.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'book/**'
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+      - '.github/workflows/mkdocs-preview.yml'
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/test.yml'
+      - '.github/workflows/rmw-zenoh-rs.yml'
+      - '.github/workflows/semantic-pr.yml'
+      - '.github/workflows/pr-draft-check.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'book/**'
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+      - '.github/workflows/mkdocs-preview.yml'
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/test.yml'
+      - '.github/workflows/rmw-zenoh-rs.yml'
+      - '.github/workflows/semantic-pr.yml'
+      - '.github/workflows/pr-draft-check.yml'
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "hiroz container platform (linux/arm64 runs the Pi analogue under QEMU)"
+        type: choice
+        options: [linux/amd64, linux/arm64]
+        default: linux/amd64
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  compose-interop:
+    name: compose interop (jazzy, ${{ inputs.platform || 'linux/amd64' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Skip for draft PRs to save CI time during development
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
+    env:
+      HIROZ_PLATFORM: ${{ inputs.platform || 'linux/amd64' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: env.HIROZ_PLATFORM == 'linux/arm64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build hiroz testbed image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: compose/docker/Dockerfile.hiroz
+          platforms: ${{ env.HIROZ_PLATFORM }}
+          load: true
+          tags: hiroz-compose-testbed:local
+          cache-from: type=gha,scope=compose-hiroz-${{ env.HIROZ_PLATFORM }}
+          cache-to: type=gha,scope=compose-hiroz-${{ env.HIROZ_PLATFORM }},mode=max
+
+      - name: Build ros2 gates image
+        uses: docker/build-push-action@v6
+        with:
+          context: compose
+          file: compose/docker/Dockerfile.ros2
+          load: true
+          tags: hiroz-compose-ros2:local
+          cache-from: type=gha,scope=compose-ros2
+          cache-to: type=gha,scope=compose-ros2,mode=max
+
+      - name: Run interop gates
+        run: |
+          docker compose -f compose/docker-compose.yml up \
+            --no-build --exit-code-from gates gates
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose -f compose/docker-compose.yml logs --timestamps
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f compose/docker-compose.yml down -v --remove-orphans

--- a/compose/README.md
+++ b/compose/README.md
@@ -1,0 +1,90 @@
+# docker-compose interop harness
+
+End-to-end RED/GREEN gates for hiroz ↔ ROS 2 interop across container
+boundaries. Unlike the single-container interop tests in CI
+(`.github/workflows/test.yml`), this harness runs hiroz in its **own**
+container — a stand-in for a Raspberry Pi or similar edge device — talking
+idiomatic zenoh over the network to a **separate** container with a full
+ROS 2 Jazzy install.
+
+## Topology
+
+```text
+┌─────────────────────┐      ┌──────────────────┐      ┌─────────────────────────┐
+│  hiroz (testbed)    │      │  router          │      │  gates                  │
+│  "Pi analogue"      │─────▶│  rmw_zenohd      │◀─────│  ROS 2 Jazzy +          │
+│  compose_testbed    │ tcp/ │  (rmw_zenoh_cpp) │ tcp/ │  rmw_zenoh_cpp          │
+│  zenoh client mode  │ 7447 │                  │ 7447 │  runs /gates/*.sh       │
+└─────────────────────┘      └──────────────────┘      └─────────────────────────┘
+```
+
+- **router** — `ros2 run rmw_zenoh_cpp rmw_zenohd`, the documented rmw_zenoh
+  deployment. Using rmw_zenoh's own router keeps the router version matched
+  to the rmw side (jazzy currently bundles zenoh-c 1.6.x while hiroz uses
+  zenoh 1.9.x; a hiroz-side 1.9.x router would need the `gateway/south`
+  workaround — see `crates/hiroz-tests/tests/common/mod.rs`).
+- **hiroz** — runs `crates/hiroz/examples/compose_testbed.rs`: talker,
+  ping→pong echo, AddTwoInts server, AddTwoInts client (polling a
+  ROS 2-hosted server), Fibonacci action server, and a parameter node.
+- **gates** — runs `gates/run_gates.sh`; multicast scouting is disabled
+  everywhere, so the only rendezvous is `tcp/router:7447`.
+
+## Gates
+
+| Gate | What it proves |
+|------|----------------|
+| `01_topics` | hiroz talker → `ros2 topic echo /chatter`; `ros2 topic pub /ping` → hiroz echo → `/pong` |
+| `02_services` | `ros2 service call /add_two_ints` against the hiroz server; hiroz client calls a ROS 2-hosted `demo_nodes_cpp` server |
+| `03_parameters` | `ros2 param list/get/set` against the hiroz `param_node` |
+| `04_actions_graph` | `ros2 node list`/`topic list` see hiroz entities via liveliness; full `ros2 action send_goal /fibonacci` goal→feedback→result |
+
+Each gate prints `GREEN`/`RED` per check; `run_gates.sh` exits with the
+number of failed gates, which `--exit-code-from gates` propagates.
+
+## Running locally
+
+```bash
+docker compose -f compose/docker-compose.yml build
+docker compose -f compose/docker-compose.yml up --no-build --exit-code-from gates gates
+echo $?    # 0 == all gates GREEN
+docker compose -f compose/docker-compose.yml down -v --remove-orphans
+```
+
+To watch the other side, tail the testbed: `docker compose -f
+compose/docker-compose.yml logs -f hiroz router`.
+
+### Simulating a RED
+
+- `docker compose -f compose/docker-compose.yml stop hiroz` mid-run → every
+  gate goes RED.
+- Point the testbed at a wrong port in `docker-compose.yml` → the hiroz
+  healthcheck never passes and `depends_on` blocks the gates (non-zero exit).
+
+## arm64 (Raspberry Pi architecture fidelity)
+
+By default the hiroz container runs `linux/amd64`. To run it as
+`linux/arm64` (cross-compiled with cargo-zigbuild; only the runtime stage is
+emulated):
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install arm64   # once per host
+HIROZ_PLATFORM=linux/arm64 docker compose -f compose/docker-compose.yml build hiroz
+HIROZ_PLATFORM=linux/arm64 docker compose -f compose/docker-compose.yml up --no-build --exit-code-from gates gates
+```
+
+In CI this is exposed as the `platform` input of the **Compose Interop**
+workflow (`workflow_dispatch`); PR/push runs stay native for speed.
+
+## CI
+
+`.github/workflows/compose-interop.yml` pre-builds both images with buildx
+(GitHub Actions layer cache), runs the harness with
+`--exit-code-from gates`, dumps all container logs on failure, and tears
+down the stack.
+
+## Pinning rmw_zenoh_cpp
+
+The ROS 2 image installs the latest `ros-jazzy-rmw-zenoh-cpp` on purpose so
+the harness flags upstream regressions early. If a known-bad version lands,
+pin it via the build arg: `RMW_ZENOH_VERSION="=<version>" docker compose
+... build` (see `docker/Dockerfile.ros2`).

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,0 +1,80 @@
+# docker-compose interop harness: a hiroz container (the "Raspberry Pi
+# analogue") talks zenoh through a rmw_zenohd router to a full ROS 2 Jazzy
+# container that exercises topics, services, parameters, actions, and graph
+# introspection as RED/GREEN gates. See compose/README.md.
+name: hiroz-compose-interop
+
+services:
+  # rmw_zenoh's own router, so the router version always matches the rmw
+  # side (the documented deployment, docs/user-guide/interop.md).
+  router:
+    image: hiroz-compose-ros2:local
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.ros2
+      args:
+        RMW_ZENOH_VERSION: ${RMW_ZENOH_VERSION:-}
+    pull_policy: never
+    command: ["ros2", "run", "rmw_zenoh_cpp", "rmw_zenohd"]
+    environment:
+      ROS_DOMAIN_ID: "0"
+      RUST_LOG: "zenoh=info"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/7447"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+      start_period: 5s
+    networks: [rosnet]
+
+  # The Pi analogue: hiroz testbed nodes built from this repo, connecting to
+  # the router as a zenoh client. Set HIROZ_PLATFORM=linux/arm64 to run it
+  # under QEMU emulation for architectural fidelity (see README).
+  hiroz:
+    image: hiroz-compose-testbed:local
+    build:
+      context: ..
+      dockerfile: compose/docker/Dockerfile.hiroz
+    pull_policy: never
+    platform: ${HIROZ_PLATFORM:-linux/amd64}
+    command: ["--endpoint", "tcp/router:7447"]
+    environment:
+      RUST_LOG: "hiroz=info,zenoh=warn"
+    depends_on:
+      router:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "test", "-f", "/tmp/testbed_ready"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 5s
+    networks: [rosnet]
+
+  # The RED/GREEN gate runner: full ROS 2 Jazzy + rmw_zenoh_cpp exercising
+  # the hiroz container over the network. Its exit code is the verdict.
+  gates:
+    image: hiroz-compose-ros2:local
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.ros2
+      args:
+        RMW_ZENOH_VERSION: ${RMW_ZENOH_VERSION:-}
+    pull_policy: never
+    command: ["/gates/run_gates.sh"]
+    environment:
+      ROS_DOMAIN_ID: "0"
+      RMW_IMPLEMENTATION: rmw_zenoh_cpp
+      # Same override format as hiroz-tests (common/mod.rs rmw_zenoh_env).
+      ZENOH_CONFIG_OVERRIDE: 'connect/endpoints=["tcp/router:7447"];scouting/multicast/enabled=false'
+      ZENOH_ROUTER_CHECK_ATTEMPTS: "30"
+    depends_on:
+      router:
+        condition: service_healthy
+      hiroz:
+        condition: service_healthy
+    networks: [rosnet]
+
+networks:
+  rosnet:
+    driver: bridge

--- a/compose/docker/Dockerfile.hiroz
+++ b/compose/docker/Dockerfile.hiroz
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+# Builds the hiroz-side testbed for the docker-compose interop harness.
+#
+# The builder stages always run on the build host's native architecture
+# ($BUILDPLATFORM); when TARGETPLATFORM=linux/arm64 the binary is
+# cross-compiled with cargo-zigbuild so only the slim runtime stage runs
+# under QEMU emulation.
+#
+# Build context must be the repository root (see compose/docker-compose.yml).
+
+ARG RUST_VERSION=1.94
+
+FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION}-bookworm AS chef
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends python3-pip \
+ && rm -rf /var/lib/apt/lists/* \
+ && pip3 install --break-system-packages cargo-zigbuild ziglang \
+ && cargo install cargo-chef --locked
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+ARG TARGETPLATFORM
+RUN case "${TARGETPLATFORM:-linux/amd64}" in \
+      "linux/arm64") echo aarch64-unknown-linux-gnu > /rust_target ;; \
+      "linux/amd64") echo x86_64-unknown-linux-gnu > /rust_target ;; \
+      *) echo "unsupported TARGETPLATFORM: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac \
+ && rustup target add "$(cat /rust_target)"
+# Cook the dependency tree as its own layer so source-only changes don't
+# rebuild zenoh and friends.
+COPY --from=planner /app/recipe.json recipe.json
+RUN if [ "$(cat /rust_target)" = "x86_64-unknown-linux-gnu" ]; then \
+      cargo chef cook --release --target "$(cat /rust_target)" \
+        --package hiroz --recipe-path recipe.json; \
+    else \
+      cargo chef cook --release --zigbuild --target "$(cat /rust_target)" \
+        --package hiroz --recipe-path recipe.json; \
+    fi
+COPY . .
+RUN if [ "$(cat /rust_target)" = "x86_64-unknown-linux-gnu" ]; then \
+      cargo build --release --target "$(cat /rust_target)" \
+        -p hiroz --example compose_testbed; \
+    else \
+      cargo zigbuild --release --target "$(cat /rust_target)" \
+        -p hiroz --example compose_testbed; \
+    fi \
+ && cp "target/$(cat /rust_target)/release/examples/compose_testbed" /compose_testbed
+
+FROM debian:bookworm-slim AS runtime
+COPY --from=builder /compose_testbed /usr/local/bin/compose_testbed
+ENTRYPOINT ["/usr/local/bin/compose_testbed"]

--- a/compose/docker/Dockerfile.ros2
+++ b/compose/docker/Dockerfile.ros2
@@ -1,0 +1,25 @@
+# Full ROS 2 Jazzy install used for both the zenoh router (rmw_zenohd) and
+# the RED/GREEN gate runner in the docker-compose interop harness.
+#
+# Build context must be the compose/ directory (see compose/docker-compose.yml).
+# Package list mirrors .github/workflows/test.yml.
+FROM ros:jazzy-ros-base
+
+# Optional apt version pin for rmw_zenoh_cpp, e.g. "=0.2.5-1noble.20250101.000000".
+# Defaults to latest so the harness catches upstream rmw_zenoh regressions early.
+ARG RMW_ZENOH_VERSION=
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      "ros-jazzy-rmw-zenoh-cpp${RMW_ZENOH_VERSION}" \
+      ros-jazzy-demo-nodes-cpp \
+      ros-jazzy-example-interfaces \
+      ros-jazzy-action-tutorials-cpp \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY gates/ /gates/
+RUN chmod +x /gates/*.sh
+
+# ros:jazzy ships /ros_entrypoint.sh which sources /opt/ros/jazzy/setup.bash.
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/compose/gates/01_topics.sh
+++ b/compose/gates/01_topics.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Gate 1: topics, both directions.
+source /gates/lib.sh
+fail=0
+
+# 1a: hiroz talker -> ros2 subscriber. The testbed's `talker` node publishes
+# "Hello World: N" on /chatter every 500 ms.
+check_chatter() {
+  timeout 20 ros2 topic echo /chatter std_msgs/msg/String --once | grep -q "Hello World"
+}
+if retry 5 2 "ros2 topic echo /chatter" -- check_chatter; then
+  green "1a hiroz talker -> ros2 echo on /chatter"
+else
+  red "1a no 'Hello World' seen on /chatter"
+  fail=1
+fi
+
+# 1b: ros2 publisher -> hiroz -> ros2 subscriber round trip. The testbed's
+# `chatter_echo` node republishes everything received on /ping to /pong, so
+# seeing our payload on /pong proves the ros2 -> hiroz direction.
+ros2 topic pub --rate 2 /ping std_msgs/msg/String '{data: ping-from-ros2}' >/dev/null 2>&1 &
+PUB_PID=$!
+check_pong() {
+  timeout 15 ros2 topic echo /pong std_msgs/msg/String --once | grep -q "ping-from-ros2"
+}
+if retry 4 2 "ros2 topic echo /pong" -- check_pong; then
+  green "1b ros2 pub /ping -> hiroz chatter_echo -> ros2 echo /pong"
+else
+  red "1b round trip via hiroz chatter_echo failed"
+  fail=1
+fi
+kill "$PUB_PID" 2>/dev/null
+wait "$PUB_PID" 2>/dev/null
+
+exit "$fail"

--- a/compose/gates/02_services.sh
+++ b/compose/gates/02_services.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Gate 2: services, both directions.
+source /gates/lib.sh
+fail=0
+
+# 2a: ros2 client -> hiroz server (mirrors
+# hiroz-tests/service_interop.rs::test_hiroz_server_ros2_client).
+call_hiroz_srv() {
+  timeout 15 ros2 service call /add_two_ints \
+    example_interfaces/srv/AddTwoInts '{a: 10, b: 7}' 2>&1 | grep -Eq 'sum[:=] ?17'
+}
+if retry 10 3 "ros2 service call /add_two_ints" -- call_hiroz_srv; then
+  green "2a ros2 client -> hiroz add_two_ints server (sum=17)"
+else
+  red "2a ros2 service call /add_two_ints did not return sum=17"
+  fail=1
+fi
+
+# 2b: hiroz client -> ros2-hosted server. Start a ROS 2 AddTwoInts server on
+# /add_two_ints_ros2 (the name the testbed client polls with {a: 2, b: 3});
+# once the testbed gets sum=5 it publishes "client_ok:sum=5" on
+# /add_two_ints_client_ok every second.
+ros2 run demo_nodes_cpp add_two_ints_server \
+  --ros-args -r add_two_ints:=add_two_ints_ros2 >/dev/null 2>&1 &
+SRV_PID=$!
+check_client_ok() {
+  timeout 10 ros2 topic echo /add_two_ints_client_ok std_msgs/msg/String --once \
+    | grep -q 'client_ok:sum=5'
+}
+if retry 12 5 "echo /add_two_ints_client_ok" -- check_client_ok; then
+  green "2b hiroz client called ros2-hosted /add_two_ints_ros2 (sum=5 confirmed)"
+else
+  red "2b hiroz client never reported success on /add_two_ints_client_ok"
+  fail=1
+fi
+kill "$SRV_PID" 2>/dev/null
+wait "$SRV_PID" 2>/dev/null
+
+exit "$fail"

--- a/compose/gates/03_parameters.sh
+++ b/compose/gates/03_parameters.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Gate 3: parameters via the ros2 param CLI against the hiroz `param_node`,
+# which declares `count` (int, 0) and `label` (string, "hello"). Mirrors
+# hiroz-tests/parameter_interop.rs.
+source /gates/lib.sh
+fail=0
+
+check_node() {
+  ros2 node list "${ROS2_FLAGS[@]}" 2>/dev/null | grep -q '^/param_node$'
+}
+if ! retry 15 2 "wait for /param_node" -- check_node; then
+  red "3 /param_node never appeared in ros2 node list"
+  exit 1
+fi
+
+list_out=$(ros2 param list /param_node "${ROS2_FLAGS[@]}" 2>&1)
+if grep -q 'count' <<<"$list_out" && grep -q 'label' <<<"$list_out"; then
+  green "3a ros2 param list sees count and label"
+else
+  red "3a param list missing count/label: ${list_out}"
+  fail=1
+fi
+
+get_out=$(ros2 param get /param_node count "${ROS2_FLAGS[@]}" 2>&1)
+if grep -q 'Integer value is: 0' <<<"$get_out"; then
+  green "3b ros2 param get count -> 0"
+else
+  red "3b unexpected initial value: ${get_out}"
+  fail=1
+fi
+
+set_out=$(ros2 param set /param_node count 42 "${ROS2_FLAGS[@]}" 2>&1)
+if grep -q 'Set parameter successful' <<<"$set_out"; then
+  green "3c ros2 param set count 42"
+else
+  red "3c param set failed: ${set_out}"
+  fail=1
+fi
+
+get_out=$(ros2 param get /param_node count "${ROS2_FLAGS[@]}" 2>&1)
+if grep -q 'Integer value is: 42' <<<"$get_out"; then
+  green "3d ros2 param get count -> 42 after set"
+else
+  red "3d set did not stick: ${get_out}"
+  fail=1
+fi
+
+exit "$fail"

--- a/compose/gates/04_actions_graph.sh
+++ b/compose/gates/04_actions_graph.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Gate 4: graph introspection (liveliness) and the Fibonacci action.
+source /gates/lib.sh
+fail=0
+
+# 4a: hiroz nodes are visible to ros2 graph introspection.
+nodes_out=$(ros2 node list "${ROS2_FLAGS[@]}" 2>/dev/null)
+for node in /talker /add_two_ints_server /fibonacci_action_server /param_node; do
+  if ! grep -q "^${node}$" <<<"$nodes_out"; then
+    red "4a ${node} missing from ros2 node list: ${nodes_out}"
+    fail=1
+  fi
+done
+if [[ "$fail" -eq 0 ]]; then
+  green "4a all hiroz nodes visible in ros2 node list"
+fi
+
+# 4b: hiroz topics are visible.
+check_topic_list() {
+  ros2 topic list "${ROS2_FLAGS[@]}" 2>/dev/null | grep -q '^/chatter$'
+}
+if retry 5 2 "ros2 topic list /chatter" -- check_topic_list; then
+  green "4b /chatter visible in ros2 topic list"
+else
+  red "4b /chatter missing from ros2 topic list"
+  fail=1
+fi
+
+# 4c: full action round trip (goal -> feedback -> result) via the ros2 CLI.
+# Jazzy's CLI/tutorials use action_tutorials_interfaces; feedback field is
+# partial_sequence (see examples/demo_nodes/fibonacci_action_server.rs).
+run_goal() {
+  goal_out=$(timeout 90 ros2 action send_goal /fibonacci \
+    action_tutorials_interfaces/action/Fibonacci '{order: 5}' --feedback 2>&1)
+  grep -q 'partial_sequence' <<<"$goal_out" \
+    && grep -q 'SUCCEEDED' <<<"$goal_out" \
+    && grep -q '0, 1, 1, 2, 3, 5' <<<"$goal_out"
+}
+if retry 3 5 "ros2 action send_goal /fibonacci" -- run_goal; then
+  green "4c fibonacci action: feedback + SUCCEEDED + result [0, 1, 1, 2, 3, 5]"
+else
+  red "4c fibonacci action failed; last output: ${goal_out:-<none>}"
+  fail=1
+fi
+
+exit "$fail"

--- a/compose/gates/lib.sh
+++ b/compose/gates/lib.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Shared helpers for the interop gate scripts.
+
+# Source ROS before `set -u`: ament setup scripts reference unset variables.
+source /opt/ros/jazzy/setup.bash
+set -uo pipefail
+
+# Flags for ros2 CLI graph/parameter commands. Mirrors crates/hiroz-tests
+# (parameter_interop.rs): --no-daemon avoids stale daemon state, --spin-time
+# bounds discovery.
+ROS2_FLAGS=(--spin-time 2 --no-daemon)
+
+# retry <attempts> <sleep_seconds> <description> -- <command...>
+retry() {
+  local attempts=$1 sleep_s=$2 desc=$3
+  shift 3
+  [[ "${1:-}" == "--" ]] && shift
+  local i
+  for ((i = 1; i <= attempts; i++)); do
+    if "$@"; then
+      return 0
+    fi
+    echo "  attempt ${i}/${attempts} failed: ${desc}" >&2
+    sleep "$sleep_s"
+  done
+  return 1
+}
+
+green() { echo "GREEN  $*"; }
+red() { echo "RED    $*"; }

--- a/compose/gates/run_gates.sh
+++ b/compose/gates/run_gates.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Runs every gate and prints a RED/GREEN summary. Exit code is the number of
+# failed gates (0 == all GREEN), which docker compose propagates via
+# --exit-code-from gates.
+# Source ROS before `set -u`: ament setup scripts reference unset variables.
+source /opt/ros/jazzy/setup.bash
+set -uo pipefail
+
+# Make sure no stale ros2 daemon with a different environment interferes.
+ros2 daemon stop >/dev/null 2>&1 || true
+
+results=()
+fail_count=0
+for gate in /gates/0*.sh; do
+  name=$(basename "$gate" .sh)
+  echo "=== Running gate: ${name} ==="
+  if bash "$gate"; then
+    results+=("GREEN  ${name}")
+  else
+    results+=("RED    ${name}")
+    fail_count=$((fail_count + 1))
+  fi
+  echo
+done
+
+echo "=== Gate summary ==="
+printf '%s\n' "${results[@]}"
+
+exit "$fail_count"

--- a/crates/hiroz/Cargo.toml
+++ b/crates/hiroz/Cargo.toml
@@ -158,6 +158,12 @@ path = "examples/demo_nodes/fibonacci_action_client.rs"
 name = "demo_nodes_fibonacci_action_server"
 path = "examples/demo_nodes/fibonacci_action_server.rs"
 
+# Long-running multi-node testbed for the docker-compose interop harness (compose/)
+[[example]]
+name = "compose_testbed"
+path = "examples/compose_testbed.rs"
+required-features = []
+
 [[example]]
 name = "z_srvcli"
 

--- a/crates/hiroz/examples/compose_testbed.rs
+++ b/crates/hiroz/examples/compose_testbed.rs
@@ -1,0 +1,277 @@
+//! Long-running multi-node testbed for the docker-compose interop harness.
+//!
+//! Runs every hiroz entity exercised by the RED/GREEN gates in `compose/gates/`
+//! inside a single process and zenoh session:
+//!
+//! | Node                      | Behavior                                                        |
+//! |---------------------------|-----------------------------------------------------------------|
+//! | `talker`                  | publishes `std_msgs/String` "Hello World: N" on `chatter`       |
+//! | `chatter_echo`            | republishes everything received on `ping` to `pong`             |
+//! | `add_two_ints_server`     | serves `example_interfaces/srv/AddTwoInts` on `add_two_ints`    |
+//! | `add_two_ints_client`     | polls `add_two_ints_ros2` until a ROS 2 server answers, then    |
+//! |                           | publishes "client_ok:sum=5" on `add_two_ints_client_ok`         |
+//! | `fibonacci_action_server` | serves the Fibonacci action on `fibonacci`                      |
+//! | `param_node`              | declares parameters `count` (int) and `label` (string)          |
+//!
+//! Once all nodes are up it writes `--ready-file` (the container healthcheck)
+//! and runs until ctrl+c.
+
+use std::time::Duration;
+
+use clap::Parser;
+use hiroz::{
+    Builder, Result,
+    action::server::ExecutingGoal,
+    context::{ZContext, ZContextBuilder},
+    parameter::{ParameterDescriptor, ParameterType, ParameterValue},
+};
+// Distro-specific action interfaces:
+// - Humble/Jazzy: action_tutorials_cpp uses action_tutorials_interfaces
+// - Kilted: action_tutorials_cpp uses example_interfaces
+#[cfg(not(feature = "kilted"))]
+use hiroz_msgs::action_tutorials_interfaces::{
+    FibonacciFeedback, FibonacciResult, action::Fibonacci,
+};
+#[cfg(feature = "kilted")]
+use hiroz_msgs::example_interfaces::{FibonacciFeedback, FibonacciResult, action::Fibonacci};
+use hiroz_msgs::{
+    example_interfaces::{AddTwoIntsRequest, AddTwoIntsResponse, srv::AddTwoInts},
+    std_msgs::String as RosString,
+};
+
+#[derive(Debug, clap::Parser)]
+#[command(
+    name = "compose_testbed",
+    about = "Multi-node testbed exercised by the docker-compose interop gates"
+)]
+struct Args {
+    /// Zenoh router endpoint to connect to (e.g., tcp/router:7447)
+    #[arg(short, long, default_value = "tcp/127.0.0.1:7447")]
+    endpoint: String,
+
+    /// File created once all nodes are up (used as the container healthcheck)
+    #[arg(long, default_value = "/tmp/testbed_ready")]
+    ready_file: String,
+}
+
+/// Publishes "Hello World: N" on `chatter` every 500 ms.
+fn spawn_talker(ctx: &ZContext) -> Result<()> {
+    let node = ctx.create_node("talker").build()?;
+    let publisher = node.create_pub::<RosString>("chatter").build()?;
+
+    tokio::spawn(async move {
+        let _node = node;
+        let mut count: u64 = 1;
+        loop {
+            let msg = RosString {
+                data: format!("Hello World: {count}"),
+            };
+            if let Err(e) = publisher.async_publish(&msg).await {
+                eprintln!("talker: publish failed: {e}");
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            count += 1;
+        }
+    });
+
+    Ok(())
+}
+
+/// Republishes everything received on `ping` to `pong`, closing the
+/// ROS 2 -> hiroz -> ROS 2 round trip checked by the topics gate.
+fn spawn_chatter_echo(ctx: &ZContext) -> Result<()> {
+    let node = ctx.create_node("chatter_echo").build()?;
+    let subscriber = node.create_sub::<RosString>("ping").build()?;
+    let publisher = node.create_pub::<RosString>("pong").build()?;
+
+    tokio::spawn(async move {
+        let _node = node;
+        loop {
+            match subscriber.async_recv().await {
+                Ok(msg) => {
+                    println!("chatter_echo: ping -> pong: '{}'", msg.data);
+                    if let Err(e) = publisher.async_publish(&msg).await {
+                        eprintln!("chatter_echo: publish failed: {e}");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("chatter_echo: recv failed: {e}");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+    });
+
+    Ok(())
+}
+
+/// Serves `example_interfaces/srv/AddTwoInts` on `add_two_ints`.
+fn spawn_add_two_ints_server(ctx: &ZContext) -> Result<()> {
+    let node = ctx.create_node("add_two_ints_server").build()?;
+    let mut service = node.create_service::<AddTwoInts>("add_two_ints").build()?;
+
+    tokio::spawn(async move {
+        let _node = node;
+        loop {
+            match service.async_take_request().await {
+                Ok(req) => {
+                    let sum = req.message().a + req.message().b;
+                    println!(
+                        "add_two_ints_server: {} + {} = {sum}",
+                        req.message().a,
+                        req.message().b
+                    );
+                    if let Err(e) = req.reply(&AddTwoIntsResponse { sum }).await {
+                        eprintln!("add_two_ints_server: reply failed: {e}");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("add_two_ints_server: take_request failed: {e}");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+    });
+
+    Ok(())
+}
+
+/// Polls a ROS 2-hosted AddTwoInts server on `add_two_ints_ros2` until it
+/// answers, then publishes "client_ok:sum=5" on `add_two_ints_client_ok` so
+/// the services gate can observe the hiroz -> ROS 2 direction.
+fn spawn_add_two_ints_client(ctx: &ZContext) -> Result<()> {
+    let node = ctx.create_node("add_two_ints_client").build()?;
+    let client = node
+        .create_client::<AddTwoInts>("add_two_ints_ros2")
+        .build()?;
+    let ok_publisher = node
+        .create_pub::<RosString>("add_two_ints_client_ok")
+        .build()?;
+
+    tokio::spawn(async move {
+        let _node = node;
+        let req = AddTwoIntsRequest { a: 2, b: 3 };
+        loop {
+            match client.call_with_timeout(&req, Duration::from_secs(2)).await {
+                Ok(resp) if resp.sum == 5 => break,
+                Ok(resp) => eprintln!("add_two_ints_client: unexpected sum {}", resp.sum),
+                // Server not up yet; keep polling.
+                Err(_) => {}
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+        println!("add_two_ints_client: got sum=5 from ROS 2 server");
+
+        let msg = RosString {
+            data: "client_ok:sum=5".to_string(),
+        };
+        loop {
+            if let Err(e) = ok_publisher.async_publish(&msg).await {
+                eprintln!("add_two_ints_client: publish failed: {e}");
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    });
+
+    Ok(())
+}
+
+/// Serves the Fibonacci action on `fibonacci`. The returned node and server
+/// must be kept alive for the action server to keep running.
+fn start_fibonacci_action_server(
+    ctx: &ZContext,
+) -> Result<(
+    hiroz::node::ZNode,
+    hiroz::action::server::ZActionServer<Fibonacci>,
+)> {
+    let node = ctx.create_node("fibonacci_action_server").build()?;
+    let server = node
+        .create_action_server::<Fibonacci>("fibonacci")
+        .build()?
+        .with_handler(|executing: ExecutingGoal<Fibonacci>| async move {
+            let order = executing.goal.order;
+            let mut sequence = vec![0, 1];
+
+            println!("fibonacci_action_server: executing goal with order {order}");
+
+            for i in 2..=order {
+                if executing.is_cancel_requested() {
+                    println!("fibonacci_action_server: goal canceled");
+                    executing
+                        .canceled(FibonacciResult { sequence })
+                        .expect("Failed to report cancellation");
+                    return;
+                }
+
+                let next = sequence[i as usize - 1] + sequence[i as usize - 2];
+                sequence.push(next);
+
+                // Distro-specific feedback field names
+                #[cfg(feature = "kilted")]
+                let feedback = FibonacciFeedback {
+                    sequence: sequence.clone(),
+                };
+                #[cfg(not(feature = "kilted"))]
+                let feedback = FibonacciFeedback {
+                    partial_sequence: sequence.clone(),
+                };
+                executing
+                    .publish_feedback(feedback)
+                    .expect("Failed to publish feedback");
+
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+
+            println!("fibonacci_action_server: goal succeeded");
+            executing
+                .succeed(FibonacciResult { sequence })
+                .expect("Failed to report success");
+        });
+
+    Ok((node, server))
+}
+
+/// Declares the parameters checked by the parameters gate and keeps the node
+/// alive so `ros2 param list/get/set` can reach it.
+fn start_param_node(ctx: &ZContext) -> Result<hiroz::node::ZNode> {
+    let node = ctx.create_node("param_node").build()?;
+
+    let desc = ParameterDescriptor::new("count", ParameterType::Integer);
+    node.declare_parameter("count", ParameterValue::Integer(0), desc)?;
+
+    let desc = ParameterDescriptor::new("label", ParameterType::String);
+    node.declare_parameter("label", ParameterValue::String("hello".into()), desc)?;
+
+    Ok(node)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    zenoh::init_log_from_env_or("error");
+
+    // Connect to the router as a client with multicast scouting disabled so
+    // discovery is deterministic inside the compose network.
+    let ctx = ZContextBuilder::default()
+        .disable_multicast_scouting()
+        .with_connect_endpoints([args.endpoint.as_str()])
+        .with_mode("client")
+        .build()?;
+
+    spawn_talker(&ctx)?;
+    spawn_chatter_echo(&ctx)?;
+    spawn_add_two_ints_server(&ctx)?;
+    spawn_add_two_ints_client(&ctx)?;
+    let _fibonacci = start_fibonacci_action_server(&ctx)?;
+    let _param_node = start_param_node(&ctx)?;
+
+    std::fs::write(&args.ready_file, "ok")?;
+    println!(
+        "compose_testbed: all nodes started, ready file written to {}",
+        args.ready_file
+    );
+
+    tokio::signal::ctrl_c().await?;
+    Ok(())
+}

--- a/docs/user-guide/interop.md
+++ b/docs/user-guide/interop.md
@@ -95,3 +95,20 @@ just -f crates/hiroz-go/justfile run-example subscriber
 ```
 
 For more detail see [Go Quick Start](../bindings/go-quick-start.md).
+
+---
+
+## Containerized interop testing
+
+The repository ships a docker-compose harness (`compose/` at the repo root)
+that runs hiroz in its own container — a stand-in for an edge device such as
+a Raspberry Pi — talking through `rmw_zenohd` to a separate container with a
+full ROS 2 Jazzy install. The ROS 2 container exercises topics, services,
+parameters, actions, and graph introspection as RED/GREEN gates, both
+locally and in CI (the **Compose Interop** workflow):
+
+```bash
+docker compose -f compose/docker-compose.yml up --exit-code-from gates gates
+```
+
+See `compose/README.md` for details.


### PR DESCRIPTION
Add a cross-container RED/GREEN test harness where hiroz runs in its own container (a Raspberry Pi analogue) and talks idiomatic zenoh through rmw_zenohd to a separate container with a full ROS 2 Jazzy install:

- compose/docker-compose.yml: three services (rmw_zenohd router, hiroz testbed, ROS 2 gate runner) on one bridge network with healthcheck-gated startup; multicast scouting disabled so tcp/router:7447 is the only rendezvous. HIROZ_PLATFORM=linux/arm64 switches the hiroz container to arm64 (cross-compiled with cargo-zigbuild, runtime under QEMU).
- crates/hiroz/examples/compose_testbed.rs: long-running multi-node testbed (talker, ping->pong echo, AddTwoInts server, retrying AddTwoInts client, Fibonacci action server, parameter node) mirroring the scenarios proven by hiroz-tests interop tests.
- compose/gates/: one bash gate per capability — topics both directions, services both directions, ros2 param list/get/set, fibonacci action goal/feedback/result plus graph introspection — with a GREEN/RED summary and aggregate exit code via --exit-code-from gates.
- .github/workflows/compose-interop.yml: builds both images with buildx (gha layer cache), runs the gates on PRs and main pushes, dumps logs on failure; workflow_dispatch input runs the Pi analogue as linux/arm64.

https://claude.ai/code/session_01ER6KMvKVGLBkdf8X5rNWNC

## Description

<!-- Brief description of changes -->


## Checklist

- [ ] Ran `./scripts/check-local.sh` successfully
- [ ] Added/updated tests/documentation (if applicable)

---

**External contributors:** Please open as **draft** initially. See [CONTRIBUTING.md](https://github.com/ZettaScaleLabs/hiroz/blob/main/CONTRIBUTING.md#pull-request-guidelines).
