### PR TITLE
fix(action): insert goal into manager before sending accept reply

### DIFF
--- a/crates/hiroz/src/action/server.rs
+++ b/crates/hiroz/src/action/server.rs
@@ -888,12 +888,7 @@ impl<A: ZAction> GoalHandle<A, Requested> {
     ///
     /// This sends an acceptance response to the client and updates the server state.
     pub fn accept(mut self) -> GoalHandle<A, Accepted> {
-        // Insert goal into manager BEFORE sending the accept reply.
-        //
-        // The client may immediately send a get_result query upon receiving the accept
-        // reply. If the goal is not yet in the manager when that query arrives, the
-        // driver returns NotFound and never sends a result response. Inserting first
-        // eliminates that TOCTOU window.
+        // Insert before replying — client may fire get_result before we'd register the goal.
         self.server.goal_manager().modify(|manager| {
             let expires_at = manager.goal_timeout.map(|timeout| Instant::now() + timeout);
             manager.goals.insert(

--- a/crates/hiroz/src/action/server.rs
+++ b/crates/hiroz/src/action/server.rs
@@ -888,6 +888,24 @@ impl<A: ZAction> GoalHandle<A, Requested> {
     ///
     /// This sends an acceptance response to the client and updates the server state.
     pub fn accept(mut self) -> GoalHandle<A, Accepted> {
+        // Insert goal into manager BEFORE sending the accept reply.
+        //
+        // The client may immediately send a get_result query upon receiving the accept
+        // reply. If the goal is not yet in the manager when that query arrives, the
+        // driver returns NotFound and never sends a result response. Inserting first
+        // eliminates that TOCTOU window.
+        self.server.goal_manager().modify(|manager| {
+            let expires_at = manager.goal_timeout.map(|timeout| Instant::now() + timeout);
+            manager.goals.insert(
+                self.info.goal_id,
+                ServerGoalState::Accepted {
+                    goal: self.goal.clone(),
+                    timestamp: Instant::now(),
+                    expires_at,
+                },
+            );
+        });
+
         // Send acceptance response
         // Use timestamp from GoalInfo which is already in sec/nanosec format
         let response = SendGoalResponse {
@@ -905,19 +923,6 @@ impl<A: ZAction> GoalHandle<A, Requested> {
                 .attachment(attachment)
                 .wait();
         }
-
-        // Update server state to ACCEPTED
-        self.server.goal_manager().modify(|manager| {
-            let expires_at = manager.goal_timeout.map(|timeout| Instant::now() + timeout);
-            manager.goals.insert(
-                self.info.goal_id,
-                ServerGoalState::Accepted {
-                    goal: self.goal.clone(),
-                    timestamp: Instant::now(),
-                    expires_at,
-                },
-            );
-        });
 
         // Publish status update
         self.server.publish_status();


### PR DESCRIPTION
## Summary

Fix `test_action_feedback_ordering` failing on ROS 2 Lyrical interop CI (issue #201). The action result future resolved as `Err` on Lyrical because the server sent the accept reply before registering the goal in the manager, creating a TOCTOU race.

## Key Changes

- In `GoalHandle<Requested>::accept()`, insert the goal into the goal manager **before** sending the accept reply to the client, eliminating the window where an incoming `get_result` query could find the goal absent and return without a response.

## Breaking Changes

None