### PR TITLE
feat(node): expose keyexpr_format() and next_entity_id() for bridge use

### DIFF
--- a/crates/hiroz/src/context.rs
+++ b/crates/hiroz/src/context.rs
@@ -6,6 +6,8 @@ use std::{
 use tracing::{debug, warn};
 use zenoh::{Result, Session, Wait};
 
+pub use hiroz_protocol::KeyExprFormat;
+
 use crate::{
     Builder,
     entity::normalize_node_namespace,

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -955,6 +955,27 @@ impl ZNode {
     }
 
     // ========================================================================
+    // Advanced API
+    // ========================================================================
+
+    /// Returns the key expression format this node uses to construct Zenoh key expressions.
+    ///
+    /// Intended for advanced use cases where the caller needs to construct key expressions
+    /// for entities outside the normal hiroz builder API.
+    pub fn keyexpr_format(&self) -> hiroz_protocol::KeyExprFormat {
+        self.keyexpr_format
+    }
+
+    /// Allocates and returns the next entity ID from this node's shared counter.
+    ///
+    /// Each call returns a unique, monotonically increasing ID scoped to this node's
+    /// lifetime. Intended for advanced use cases where entities are created outside
+    /// the normal hiroz builder API.
+    pub fn next_entity_id(&self) -> usize {
+        self.counter.increment()
+    }
+
+    // ========================================================================
     // Parameter API
     // ========================================================================
 

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -958,19 +958,12 @@ impl ZNode {
     // Advanced API
     // ========================================================================
 
-    /// Returns the key expression format this node uses to construct Zenoh key expressions.
-    ///
-    /// Intended for advanced use cases where the caller needs to construct key expressions
-    /// for entities outside the normal hiroz builder API.
+    /// Returns the key expression format used by this node.
     pub fn keyexpr_format(&self) -> hiroz_protocol::KeyExprFormat {
         self.keyexpr_format
     }
 
-    /// Allocates and returns the next entity ID from this node's shared counter.
-    ///
-    /// Each call returns a unique, monotonically increasing ID scoped to this node's
-    /// lifetime. Intended for advanced use cases where entities are created outside
-    /// the normal hiroz builder API.
+    /// Allocates and returns the next unique entity ID from this node's counter.
     pub fn next_entity_id(&self) -> usize {
         self.counter.increment()
     }


### PR DESCRIPTION
## Summary

Exposes two methods on `ZNode` for advanced use cases where callers need to construct Zenoh key expressions for entities outside the normal hiroz builder API:

- `keyexpr_format() -> KeyExprFormat` — returns the key expression format this node uses
- `next_entity_id() -> usize` — allocates the next entity ID from the node's shared counter

Also re-exports `KeyExprFormat` from `hiroz::context` so downstream crates don't need a direct `hiroz-protocol` dependency to use these methods.

## Key Changes

- `crates/hiroz/src/node.rs`: two new `pub` methods on `ZNode`
- `crates/hiroz/src/context.rs`: `pub use hiroz_protocol::KeyExprFormat`

## Breaking Changes

None.