### PR TITLE
fix(shm): enable transport SHM when SHM provider is configured

### DIFF
--- a/crates/hiroz/src/config.rs
+++ b/crates/hiroz/src/config.rs
@@ -293,6 +293,21 @@ pub fn session_overrides() -> Vec<ConfigOverride> {
     overrides.extend_from_slice(common_overrides());
     overrides
 }
+/// Config key controlling transport-level shared memory.
+pub(crate) const TRANSPORT_SHM_ENABLED_KEY: &str = "transport/shared_memory/enabled";
+
+/// Enable transport-level shared memory on an existing config.
+///
+/// The common session/router overrides force `transport/shared_memory/enabled`
+/// to `false` by default. When an SHM provider is configured, the transport must
+/// also be told to accept SHM buffers, otherwise zenoh silently copies the SHM
+/// contents into the regular network message and the zero-copy path never
+/// engages. This applies the override that re-enables it.
+pub(crate) fn enable_transport_shm(config: &mut zenoh::Config) -> zenoh::Result<()> {
+    config.insert_json5(TRANSPORT_SHM_ENABLED_KEY, "true")?;
+    Ok(())
+}
+
 /// Build a Zenoh config from a set of overrides
 fn build_config(overrides: &[ConfigOverride]) -> zenoh::Result<zenoh::Config> {
     let mut config = zenoh::Config::default();
@@ -540,6 +555,29 @@ impl RouterConfigBuilder {
         self
     }
 
+    /// Enable transport-level shared memory on the router.
+    ///
+    /// The default router config disables `transport/shared_memory/enabled` (see
+    /// [`common_overrides`]). A router (or `zenohd`) that relays SHM traffic
+    /// between co-located peers must have transport SHM enabled, otherwise the
+    /// zero-copy path is broken end-to-end even when both peers request SHM.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hiroz::config::RouterConfigBuilder;
+    /// let config = RouterConfigBuilder::new()
+    ///     .with_shm_enabled()
+    ///     .build_config()?;
+    /// # Ok::<(), zenoh::Error>(())
+    /// ```
+    pub fn with_shm_enabled(self) -> Self {
+        self.with_override(
+            TRANSPORT_SHM_ENABLED_KEY,
+            serde_json::json!(true),
+            "Enable transport SHM so the router can relay zero-copy buffers",
+        )
+    }
+
     /// Override a specific config key
     ///
     /// Replaces existing override if key exists, otherwise adds new one.
@@ -784,6 +822,43 @@ mod tests {
         assert!(json5.contains("GENERATED"));
         assert!(json5.contains("mode"));
         assert!(json5.contains("router"));
+    }
+
+    #[test]
+    fn test_common_default_disables_transport_shm() {
+        let common = common_overrides();
+        let shm = common
+            .iter()
+            .find(|o| o.key == TRANSPORT_SHM_ENABLED_KEY)
+            .expect("common overrides should set transport shared_memory");
+        assert_eq!(shm.value, serde_json::json!(false));
+    }
+
+    #[test]
+    fn test_enable_transport_shm_overrides_default() {
+        // Start from the session config, which disables transport SHM by default.
+        let mut config = session_config().expect("Failed to build session config");
+        assert_eq!(
+            config.get_json(TRANSPORT_SHM_ENABLED_KEY).unwrap(),
+            "false",
+            "session config should disable transport SHM by default"
+        );
+
+        enable_transport_shm(&mut config).expect("Failed to enable transport SHM");
+        assert_eq!(
+            config.get_json(TRANSPORT_SHM_ENABLED_KEY).unwrap(),
+            "true",
+            "enable_transport_shm should flip the value to true"
+        );
+    }
+
+    #[test]
+    fn test_router_builder_with_shm_enabled() {
+        let config = RouterConfigBuilder::new()
+            .with_shm_enabled()
+            .build_config()
+            .expect("Failed to build router config with SHM");
+        assert_eq!(config.get_json(TRANSPORT_SHM_ENABLED_KEY).unwrap(), "true");
     }
 
     #[test]

--- a/crates/hiroz/src/config.rs
+++ b/crates/hiroz/src/config.rs
@@ -293,16 +293,9 @@ pub fn session_overrides() -> Vec<ConfigOverride> {
     overrides.extend_from_slice(common_overrides());
     overrides
 }
-/// Config key controlling transport-level shared memory.
 pub(crate) const TRANSPORT_SHM_ENABLED_KEY: &str = "transport/shared_memory/enabled";
 
-/// Enable transport-level shared memory on an existing config.
-///
-/// The common session/router overrides force `transport/shared_memory/enabled`
-/// to `false` by default. When an SHM provider is configured, the transport must
-/// also be told to accept SHM buffers, otherwise zenoh silently copies the SHM
-/// contents into the regular network message and the zero-copy path never
-/// engages. This applies the override that re-enables it.
+/// Re-enable transport SHM, which `common_overrides` forces off by default.
 pub(crate) fn enable_transport_shm(config: &mut zenoh::Config) -> zenoh::Result<()> {
     config.insert_json5(TRANSPORT_SHM_ENABLED_KEY, "true")?;
     Ok(())
@@ -555,21 +548,7 @@ impl RouterConfigBuilder {
         self
     }
 
-    /// Enable transport-level shared memory on the router.
-    ///
-    /// The default router config disables `transport/shared_memory/enabled` (see
-    /// [`common_overrides`]). A router (or `zenohd`) that relays SHM traffic
-    /// between co-located peers must have transport SHM enabled, otherwise the
-    /// zero-copy path is broken end-to-end even when both peers request SHM.
-    ///
-    /// # Example
-    /// ```rust
-    /// # use hiroz::config::RouterConfigBuilder;
-    /// let config = RouterConfigBuilder::new()
-    ///     .with_shm_enabled()
-    ///     .build_config()?;
-    /// # Ok::<(), zenoh::Error>(())
-    /// ```
+    /// Enable transport SHM on the router so it can relay zero-copy SHM buffers between peers.
     pub fn with_shm_enabled(self) -> Self {
         self.with_override(
             TRANSPORT_SHM_ENABLED_KEY,
@@ -822,16 +801,6 @@ mod tests {
         assert!(json5.contains("GENERATED"));
         assert!(json5.contains("mode"));
         assert!(json5.contains("router"));
-    }
-
-    #[test]
-    fn test_common_default_disables_transport_shm() {
-        let common = common_overrides();
-        let shm = common
-            .iter()
-            .find(|o| o.key == TRANSPORT_SHM_ENABLED_KEY)
-            .expect("common overrides should set transport shared_memory");
-        assert_eq!(shm.value, serde_json::json!(false));
     }
 
     #[test]

--- a/crates/hiroz/src/context.rs
+++ b/crates/hiroz/src/context.rs
@@ -313,6 +313,14 @@ impl ZContextBuilder {
 
     /// Enable SHM with default pool size (10MB) and threshold (512 bytes).
     ///
+    /// This also enables transport-level shared memory on the session so that
+    /// co-located publishers and subscribers exchange large payloads zero-copy.
+    /// For zero-copy to engage end-to-end, the connected router (`zenohd` or a
+    /// [`RouterConfigBuilder`](crate::config::RouterConfigBuilder)) must also
+    /// have transport SHM enabled — e.g. via
+    /// `RouterConfigBuilder::new().with_shm_enabled()` or
+    /// `ZENOH_CONFIG_OVERRIDE=transport/shared_memory/enabled=true` for `zenohd`.
+    ///
     /// # Example
     /// ```no_run
     /// use hiroz::context::ZContextBuilder;
@@ -514,6 +522,19 @@ impl Builder for ZContextBuilder {
             // This is the key change - matching rmw_zenoh_cpp behavior
             crate::config::session_config()?
         };
+
+        // When an SHM provider is configured, transport-level shared memory must
+        // be enabled on the session as well. The common session config forces it
+        // off by default, so without this the publisher allocates from the SHM
+        // pool but zenoh copies the buffer into the regular network message
+        // instead of passing it zero-copy (see issue #208). Applied *before* the
+        // user/env `config_overrides` below so an explicit override can still win.
+        if builder.shm_config.is_some() {
+            crate::config::enable_transport_shm(&mut config).map_err(|e| {
+                format!("Failed to enable transport shared memory for SHM config: {e}")
+            })?;
+            debug!("[CTX] SHM provider configured: enabled transport/shared_memory");
+        }
 
         // Apply all JSON overrides
         for (key, value) in builder.config_overrides {

--- a/crates/hiroz/src/context.rs
+++ b/crates/hiroz/src/context.rs
@@ -311,15 +311,7 @@ impl ZContextBuilder {
         self
     }
 
-    /// Enable SHM with default pool size (10MB) and threshold (512 bytes).
-    ///
-    /// This also enables transport-level shared memory on the session so that
-    /// co-located publishers and subscribers exchange large payloads zero-copy.
-    /// For zero-copy to engage end-to-end, the connected router (`zenohd` or a
-    /// [`RouterConfigBuilder`](crate::config::RouterConfigBuilder)) must also
-    /// have transport SHM enabled — e.g. via
-    /// `RouterConfigBuilder::new().with_shm_enabled()` or
-    /// `ZENOH_CONFIG_OVERRIDE=transport/shared_memory/enabled=true` for `zenohd`.
+    /// Enable SHM with default pool size (10MB) and threshold (512 bytes). Also enables transport SHM on the session.
     ///
     /// # Example
     /// ```no_run
@@ -523,12 +515,7 @@ impl Builder for ZContextBuilder {
             crate::config::session_config()?
         };
 
-        // When an SHM provider is configured, transport-level shared memory must
-        // be enabled on the session as well. The common session config forces it
-        // off by default, so without this the publisher allocates from the SHM
-        // pool but zenoh copies the buffer into the regular network message
-        // instead of passing it zero-copy (see issue #208). Applied *before* the
-        // user/env `config_overrides` below so an explicit override can still win.
+        // common_overrides disables transport SHM; re-enable it when an SHM provider is set.
         if builder.shm_config.is_some() {
             crate::config::enable_transport_shm(&mut config).map_err(|e| {
                 format!("Failed to enable transport shared memory for SHM config: {e}")


### PR DESCRIPTION
## Summary

The common session/router overrides force `transport/shared_memory/enabled` to `false`, so even when an SHM provider is configured the zero-copy path never engages — zenoh silently copies SHM buffers into regular network messages instead.

## Key Changes

- `ZContextBuilder::build()` now automatically enables `transport/shared_memory/enabled` when `shm_config` is present, applied before user overrides so an explicit override can still win
- Added `RouterConfigBuilder::with_shm_enabled()` for routers that relay SHM traffic between co-located peers
- Added `enable_transport_shm()` helper in `config.rs` and the `TRANSPORT_SHM_ENABLED_KEY` constant
- Added unit tests covering: default is `false`, `enable_transport_shm` flips it to `true`, and `RouterConfigBuilder::with_shm_enabled` works correctly

## Breaking Changes
None
