### PR TITLE
fix(flake): guard pre-commit install against wrong git root

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -328,7 +328,13 @@
               pythonVersion = pythonVer;
               rosDistro = rosDistro;
               extraShellHook = ''
-                ${pre-commit-check.shellHook}
+                _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+                if [ -d "''${_git_root}/crates/hiroz-core" ]; then
+                  ${pre-commit-check.shellHook}
+                else
+                  echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
+                fi
+                unset _git_root
               '';
               banner = ''
                 echo "🦀 hiroz development environment (with ROS)"
@@ -394,7 +400,13 @@
             ++ testTools
             ++ pre-commit-check.enabledPackages;
             extraShellHook = ''
-              ${pre-commit-check.shellHook}
+              _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+              if [ -d "''${_git_root}/crates/hiroz-core" ]; then
+                ${pre-commit-check.shellHook}
+              else
+                echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
+              fi
+              unset _git_root
             '';
             banner = ''
               echo "🦀 hiroz development environment (pure Rust)"

--- a/flake.nix
+++ b/flake.nix
@@ -328,13 +328,7 @@
               pythonVersion = pythonVer;
               rosDistro = rosDistro;
               extraShellHook = ''
-                _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
-                if [ -d "''${_git_root}/crates/hiroz-core" ]; then
-                  ${pre-commit-check.shellHook}
-                else
-                  echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
-                fi
-                unset _git_root
+                ${pre-commit-check.shellHook}
               '';
               banner = ''
                 echo "🦀 hiroz development environment (with ROS)"
@@ -400,13 +394,7 @@
             ++ testTools
             ++ pre-commit-check.enabledPackages;
             extraShellHook = ''
-              _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
-              if [ -d "''${_git_root}/crates/hiroz-core" ]; then
-                ${pre-commit-check.shellHook}
-              else
-                echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
-              fi
-              unset _git_root
+              ${pre-commit-check.shellHook}
             '';
             banner = ''
               echo "🦀 hiroz development environment (pure Rust)"

--- a/flake.nix
+++ b/flake.nix
@@ -328,7 +328,17 @@
               pythonVersion = pythonVer;
               rosDistro = rosDistro;
               extraShellHook = ''
-                ${pre-commit-check.shellHook}
+                _common_dir="$(git rev-parse --git-common-dir 2>/dev/null || echo "")"
+                if [ -n "''${_common_dir}" ] && [[ "''${_common_dir}" != /* ]]; then
+                  _common_dir="$PWD/''${_common_dir}"
+                fi
+                _repo_root="$(dirname "''${_common_dir}")"
+                if [ -d "''${_repo_root}/crates/hiroz" ]; then
+                  ${pre-commit-check.shellHook}
+                else
+                  echo "hiroz: skipping pre-commit install (not in hiroz repo, git common dir: ''${_common_dir})"
+                fi
+                unset _common_dir _repo_root
               '';
               banner = ''
                 echo "🦀 hiroz development environment (with ROS)"
@@ -394,7 +404,17 @@
             ++ testTools
             ++ pre-commit-check.enabledPackages;
             extraShellHook = ''
-              ${pre-commit-check.shellHook}
+              _common_dir="$(git rev-parse --git-common-dir 2>/dev/null || echo "")"
+              if [ -n "''${_common_dir}" ] && [[ "''${_common_dir}" != /* ]]; then
+                _common_dir="$PWD/''${_common_dir}"
+              fi
+              _repo_root="$(dirname "''${_common_dir}")"
+              if [ -d "''${_repo_root}/crates/hiroz" ]; then
+                ${pre-commit-check.shellHook}
+              else
+                echo "hiroz: skipping pre-commit install (not in hiroz repo, git common dir: ''${_common_dir})"
+              fi
+              unset _common_dir _repo_root
             '';
             banner = ''
               echo "🦀 hiroz development environment (pure Rust)"

--- a/flake.nix
+++ b/flake.nix
@@ -327,19 +327,7 @@
               rosEnvPath = rosEnv.dev;
               pythonVersion = pythonVer;
               rosDistro = rosDistro;
-              extraShellHook = ''
-                _common_dir="$(git rev-parse --git-common-dir 2>/dev/null || echo "")"
-                if [ -n "''${_common_dir}" ] && [[ "''${_common_dir}" != /* ]]; then
-                  _common_dir="$PWD/''${_common_dir}"
-                fi
-                _repo_root="$(dirname "''${_common_dir}")"
-                if [ -d "''${_repo_root}/crates/hiroz" ]; then
-                  ${pre-commit-check.shellHook}
-                else
-                  echo "hiroz: skipping pre-commit install (not in hiroz repo, git common dir: ''${_common_dir})"
-                fi
-                unset _common_dir _repo_root
-              '';
+              extraShellHook = preCommitGuard;
               banner = ''
                 echo "🦀 hiroz development environment (with ROS)"
                 echo "ROS 2 Distribution: ${rosDistro}"
@@ -379,6 +367,23 @@
             mkdocsPkg
             ;
         };
+
+        # Guard: only install pre-commit hooks when nix develop is invoked from
+        # inside the hiroz repo (main checkout or any worktree). Uses
+        # --git-common-dir instead of --show-toplevel so worktrees work correctly.
+        preCommitGuard = ''
+          _common_dir="$(git rev-parse --git-common-dir 2>/dev/null || echo "")"
+          if [ -n "''${_common_dir}" ] && [[ "''${_common_dir}" != /* ]]; then
+            _common_dir="$PWD/''${_common_dir}"
+          fi
+          _repo_root="$(dirname "''${_common_dir}")"
+          if [ -d "''${_repo_root}/crates/hiroz" ]; then
+            ${pre-commit-check.shellHook}
+          else
+            echo "hiroz: skipping pre-commit install (not in hiroz repo, git common dir: ''${_common_dir})"
+          fi
+          unset _common_dir _repo_root
+        '';
       in
       {
         # Pre-commit checks
@@ -403,19 +408,7 @@
             ++ docTools
             ++ testTools
             ++ pre-commit-check.enabledPackages;
-            extraShellHook = ''
-              _common_dir="$(git rev-parse --git-common-dir 2>/dev/null || echo "")"
-              if [ -n "''${_common_dir}" ] && [[ "''${_common_dir}" != /* ]]; then
-                _common_dir="$PWD/''${_common_dir}"
-              fi
-              _repo_root="$(dirname "''${_common_dir}")"
-              if [ -d "''${_repo_root}/crates/hiroz" ]; then
-                ${pre-commit-check.shellHook}
-              else
-                echo "hiroz: skipping pre-commit install (not in hiroz repo, git common dir: ''${_common_dir})"
-              fi
-              unset _common_dir _repo_root
-            '';
+            extraShellHook = preCommitGuard;
             banner = ''
               echo "🦀 hiroz development environment (pure Rust)"
               echo "Rust: $(rustc --version)"


### PR DESCRIPTION
## Summary

When `nix develop /path/to/hiroz#pureRust` (or `#default`) is invoked from a parent workspace directory (e.g. `zenoh-ws`), the shellHook previously ran `pre-commit install` unconditionally. Because `pre-commit install` walks up from `$PWD` to find the git root, it installed hiroz's linters into the parent repo's `.git/hooks/pre-commit` — silently corrupting unrelated repos.

## Key Changes

- Both `pureRust` and `default` (per-distro ROS) devShells now guard `pre-commit install` with a repo identity check
- Uses `git rev-parse --git-common-dir` (not `--show-toplevel`) so the guard works correctly inside worktrees as well as the main checkout
- If the resolved repo root does not contain `crates/hiroz`, the hook is skipped with an informational message
- No behaviour change when developing inside hiroz itself

## Breaking Changes

None