### PR TITLE
fix(ci): unblock external PRs — Codecov token + pyo3 stale cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,10 +285,11 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        continue-on-error: true
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   no-ros-checks:
     name: ROS-independent Checks (${{ matrix.os }})
@@ -503,6 +504,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.distro }}-python
+
+      - name: Clean pyo3 build artifacts
+        run: find target -name 'build-script-build' -path '*pyo3-build-config*' -delete 2>/dev/null || true
 
       - name: Cache generated Python types
         uses: actions/cache@v4

--- a/flake.nix
+++ b/flake.nix
@@ -328,7 +328,13 @@
               pythonVersion = pythonVer;
               rosDistro = rosDistro;
               extraShellHook = ''
-                ${pre-commit-check.shellHook}
+                _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+                if [ -d "''${_git_root}/crates/hiroz-core" ]; then
+                  ${pre-commit-check.shellHook}
+                else
+                  echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
+                fi
+                unset _git_root
               '';
               banner = ''
                 echo "🦀 hiroz development environment (with ROS)"
@@ -394,7 +400,13 @@
             ++ testTools
             ++ pre-commit-check.enabledPackages;
             extraShellHook = ''
-              ${pre-commit-check.shellHook}
+              _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+              if [ -d "''${_git_root}/crates/hiroz-core" ]; then
+                ${pre-commit-check.shellHook}
+              else
+                echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
+              fi
+              unset _git_root
             '';
             banner = ''
               echo "🦀 hiroz development environment (pure Rust)"

--- a/flake.nix
+++ b/flake.nix
@@ -328,13 +328,7 @@
               pythonVersion = pythonVer;
               rosDistro = rosDistro;
               extraShellHook = ''
-                _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
-                if [ -d "''${_git_root}/crates/hiroz-core" ]; then
-                  ${pre-commit-check.shellHook}
-                else
-                  echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
-                fi
-                unset _git_root
+                ${pre-commit-check.shellHook}
               '';
               banner = ''
                 echo "🦀 hiroz development environment (with ROS)"
@@ -400,13 +394,7 @@
             ++ testTools
             ++ pre-commit-check.enabledPackages;
             extraShellHook = ''
-              _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
-              if [ -d "''${_git_root}/crates/hiroz-core" ]; then
-                ${pre-commit-check.shellHook}
-              else
-                echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
-              fi
-              unset _git_root
+              ${pre-commit-check.shellHook}
             '';
             banner = ''
               echo "🦀 hiroz development environment (pure Rust)"


### PR DESCRIPTION
## Summary

- Fix #213: Codecov upload now uses `continue-on-error: true` and `fail_ci_if_error: false` so fork PRs without `CODECOV_TOKEN` no longer fail CI
- Fix #212: Delete stale `pyo3-build-config` `build-script-build` binaries after Rust cache restore to prevent the "never executed" error in Python tests

## Key Changes

- `.github/workflows/ci.yml`: add `continue-on-error: true` + `fail_ci_if_error: false` to Codecov upload step
- `.github/workflows/ci.yml`: add cache-cleanup step before Python type cache restore that removes stale pyo3 build artifacts

## Breaking Changes

None