### PR TITLE
ci: add Free Disk Space step to python-tests and ros-tests jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,6 +470,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          large-packages: true
+          tool-cache: false
+          android: false
+          dotnet: false
+          haskell: false
+          docker-images: false
+          swap-storage: false
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
@@ -572,6 +583,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          large-packages: true
+          tool-cache: false
+          android: false
+          dotnet: false
+          haskell: false
+          docker-images: false
+          swap-storage: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31

--- a/flake.nix
+++ b/flake.nix
@@ -328,7 +328,13 @@
               pythonVersion = pythonVer;
               rosDistro = rosDistro;
               extraShellHook = ''
-                ${pre-commit-check.shellHook}
+                _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+                if [ -d "''${_git_root}/crates/hiroz-core" ]; then
+                  ${pre-commit-check.shellHook}
+                else
+                  echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
+                fi
+                unset _git_root
               '';
               banner = ''
                 echo "🦀 hiroz development environment (with ROS)"
@@ -394,7 +400,13 @@
             ++ testTools
             ++ pre-commit-check.enabledPackages;
             extraShellHook = ''
-              ${pre-commit-check.shellHook}
+              _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+              if [ -d "''${_git_root}/crates/hiroz-core" ]; then
+                ${pre-commit-check.shellHook}
+              else
+                echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
+              fi
+              unset _git_root
             '';
             banner = ''
               echo "🦀 hiroz development environment (pure Rust)"

--- a/flake.nix
+++ b/flake.nix
@@ -328,13 +328,7 @@
               pythonVersion = pythonVer;
               rosDistro = rosDistro;
               extraShellHook = ''
-                _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
-                if [ -d "''${_git_root}/crates/hiroz-core" ]; then
-                  ${pre-commit-check.shellHook}
-                else
-                  echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
-                fi
-                unset _git_root
+                ${pre-commit-check.shellHook}
               '';
               banner = ''
                 echo "🦀 hiroz development environment (with ROS)"
@@ -400,13 +394,7 @@
             ++ testTools
             ++ pre-commit-check.enabledPackages;
             extraShellHook = ''
-              _git_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
-              if [ -d "''${_git_root}/crates/hiroz-core" ]; then
-                ${pre-commit-check.shellHook}
-              else
-                echo "hiroz: skipping pre-commit install (not in hiroz repo root, git root: ''${_git_root})"
-              fi
-              unset _git_root
+              ${pre-commit-check.shellHook}
             '';
             banner = ''
               echo "🦀 hiroz development environment (pure Rust)"


### PR DESCRIPTION
## Summary

- Add `jlumbroso/free-disk-space@main` step to `python-tests` and `ros-tests` matrix jobs, matching the pattern already used in all other heavy CI jobs (pureRust tests, SHM tests, coverage)

## Root cause

`ubuntu-latest` runners have ~14 GB usable disk. `python-tests` and `ros-tests` accumulate Nix store + Rust cache + incremental build artifacts without first freeing space, leaving no headroom and causing sporadic `No space left on device (os error 28)` failures during the build step.

Fixes #216

## Breaking Changes

None