### PR TITLE
fix(error): structured Timeout error variant for core, FFI, and Python bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ dependencies = [
  "sha2",
  "slab",
  "strum 0.27.2",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1382,7 +1383,7 @@ dependencies = [
  "byteorder",
  "proptest",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "zenoh-buffers",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ event-listener = "5"
 
 # Utilities
 tracing = "0.1.41"
+thiserror = "2.0"
 strum = "0.27.2"
 sha2 = "0.10.9"
 slab = "0.4.11"

--- a/crates/hiroz-cdr/Cargo.toml
+++ b/crates/hiroz-cdr/Cargo.toml
@@ -14,7 +14,7 @@ serde = { workspace = true }
 byteorder = { workspace = true }
 bytemuck = { version = "1", features = ["derive", "extern_crate_alloc"] }
 zenoh-buffers = { workspace = true }
-thiserror = "1.0"
+thiserror.workspace = true
 
 [dev-dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/crates/hiroz-cdr/tests/cdr_tests.rs
+++ b/crates/hiroz-cdr/tests/cdr_tests.rs
@@ -81,10 +81,7 @@ struct Example {
 
 #[test]
 fn test_serializer_basic() {
-    let o = Example {
-        a: 1,
-        b: [b'a', b'b', b'c', b'd'],
-    };
+    let o = Example { a: 1, b: *b"abcd" };
 
     let expected: Vec<u8> = vec![0x01, 0x00, 0x00, 0x00, 0x61, 0x62, 0x63, 0x64];
 

--- a/crates/hiroz-codegen/src/generator/rust.rs
+++ b/crates/hiroz-codegen/src/generator/rust.rs
@@ -155,7 +155,7 @@ fn generate_cdr_impls(
     let name = format_ident!("{}", msg.parsed.name);
     let fields = &msg.parsed.fields;
     let pkg = &msg.parsed.package;
-    let is_plain = plain_types.contains(&format!("{}::{}", pkg, &msg.parsed.name));
+    let is_plain = plain_types.contains(&format!("{}::{}", pkg, msg.parsed.name));
 
     // ── CdrSerialize ──────────────────────────────────────────────────────────
     let ser_fields: Vec<TokenStream> = fields

--- a/crates/hiroz-codegen/tests/cdr_roundtrip.rs
+++ b/crates/hiroz-codegen/tests/cdr_roundtrip.rs
@@ -129,7 +129,7 @@ fn roundtrip_arrays_values() {
     let msg = Arrays {
         bool_values: [true, false, true],
         byte_values: [1, 2, 3],
-        char_values: [b'a', b'b', b'c'],
+        char_values: *b"abc",
         float32_values: [1.0, 2.0, 3.0],
         float64_values: [1.0, -2.0, 3.5],
         int8_values: [-1, 0, 1],
@@ -193,7 +193,7 @@ fn roundtrip_bounded_sequences_values() {
     let msg = BoundedSequences {
         bool_values: vec![true, false],
         byte_values: vec![1, 2, 3],
-        char_values: vec![b'x'],
+        char_values: b"x".to_vec(),
         float32_values: vec![1.0, 2.0],
         float64_values: vec![-1.5],
         int8_values: vec![-128, 127],

--- a/crates/hiroz-console/src/app/mod.rs
+++ b/crates/hiroz-console/src/app/mod.rs
@@ -562,7 +562,7 @@ impl App {
     pub fn update_multi_metrics(&mut self) {
         let mut metrics = self.topic_metrics.lock();
 
-        for (_topic, tm) in metrics.iter_mut() {
+        for tm in metrics.values_mut() {
             // Raw per-second values
             let instant_rate = tm.msg_count as f64;
             let instant_bw = tm.byte_count as f64 / BYTES_PER_KB;

--- a/crates/hiroz-go/interop_tests/service_test.go
+++ b/crates/hiroz-go/interop_tests/service_test.go
@@ -5,6 +5,7 @@ package interop_tests
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"strings"
@@ -260,6 +261,67 @@ func TestGoServiceServerToGoClient(t *testing.T) {
 		}
 	}
 
+}
+
+// TestGoServiceClientTimeout verifies that a service call which never gets a
+// reply surfaces a distinct ErrorCodeServiceTimeout, not a generic failure.
+//
+// This is the end-to-end regression for issue #220: the FFI
+// `hiroz_service_client_call` previously returned a generic -1 on timeout, so
+// the Go binding's ErrorCodeServiceTimeout branch was dead code — a caller
+// could not tell a timeout apart from any other call failure.
+//
+// Test flow:
+// - Start a Zenoh router (no service server is ever created)
+// - Create a Go service client for a service that has no server
+// - Call it with a short timeout
+// - Assert the returned error wraps ErrorCodeServiceTimeout
+func TestGoServiceClientTimeout(t *testing.T) {
+	router := startZenohRouter(t)
+
+	hirozCtx, err := hiroz.NewContext().
+		WithConnectEndpoints(router.Endpoint()).DisableMulticastScouting().
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to create context: %v", err)
+	}
+	defer hirozCtx.Close()
+
+	node, err := hirozCtx.CreateNode("go_timeout_client").Build()
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	defer node.Close()
+
+	svc := &example_interfaces.AddTwoInts{}
+	client, err := node.CreateServiceClient("no_such_server").Build(svc)
+	if err != nil {
+		t.Fatalf("Failed to create service client: %v", err)
+	}
+	defer client.Close()
+
+	// No server exists on this key, so the call must time out.
+	req := &example_interfaces.AddTwoIntsRequest{A: 1, B: 2}
+	var resp example_interfaces.AddTwoIntsResponse
+	err = hiroz.CallTypedWithTimeout(client, req, &resp, 300*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+
+	var herr hiroz.HirozError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected a HirozError, got %T: %v", err, err)
+	}
+	if herr.Code() != hiroz.ErrorCodeServiceTimeout {
+		t.Errorf("expected ErrorCodeServiceTimeout (%d), got %d: %v",
+			hiroz.ErrorCodeServiceTimeout, herr.Code(), err)
+	}
+	if !herr.Timeout() {
+		t.Errorf("expected Timeout() == true, got false: %v", err)
+	}
+	if !errors.Is(err, hiroz.ErrTimeout) {
+		t.Errorf("expected errors.Is(err, ErrTimeout) == true: %v", err)
+	}
 }
 
 // TestServiceWithCustomTypes tests service with custom message types.

--- a/crates/hiroz-py/src/action.rs
+++ b/crates/hiroz-py/src/action.rs
@@ -327,10 +327,12 @@ impl PyZClientGoalHandle {
         let result = py.allow_threads(move || {
             rt.block_on(async move {
                 if let Some(t) = timeout.map(Duration::from_secs_f64) {
-                    match tokio::time::timeout(t, handle.result()).await {
-                        Ok(Ok(msg)) => Ok(Some(msg.0)),
-                        Ok(Err(e)) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
-                        Err(_) => Ok(None), // timeout
+                    // Use the core `result_with_timeout` primitive rather than
+                    // reinventing the timeout wrapper in the binding.
+                    match handle.result_with_timeout(t).await {
+                        Ok(msg) => Ok(Some(msg.0)),
+                        Err(e) if hiroz::error::is_timeout(&*e) => Ok(None), // timeout
+                        Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
                     }
                 } else {
                     handle

--- a/crates/hiroz-py/src/service.rs
+++ b/crates/hiroz-py/src/service.rs
@@ -40,7 +40,13 @@ impl PyZClient {
 
         let cdr_bytes = py
             .allow_threads(|| self.inner.call_serialized(&cdr_bytes, timeout_duration))
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            .map_err(|e| {
+                if hiroz::error::is_timeout(e.root_cause()) {
+                    crate::error::TimeoutError::new_err(e.to_string())
+                } else {
+                    pyo3::exceptions::PyRuntimeError::new_err(e.to_string())
+                }
+            })?;
         hiroz_msgs::deserialize_from_cdr(&self.response_type_name, py, &cdr_bytes)
     }
 

--- a/crates/hiroz-py/src/traits.rs
+++ b/crates/hiroz-py/src/traits.rs
@@ -126,7 +126,16 @@ impl RawClient for GenericClientWrapper {
             self.inner
                 .call_with_timeout(&request, timeout)
                 .await
-                .map_err(|e| anyhow::anyhow!("Failed to call service: {}", e))
+                .map_err(|e| {
+                    // Preserve the structured timeout so the Python layer can raise
+                    // `TimeoutError` instead of a generic exception. Any other error
+                    // keeps its message.
+                    if hiroz::error::is_timeout(&*e) {
+                        anyhow::Error::new(hiroz::error::Error::Timeout(timeout))
+                    } else {
+                        anyhow::anyhow!("Failed to call service: {}", e)
+                    }
+                })
         };
 
         let response = match tokio::runtime::Handle::try_current() {

--- a/crates/hiroz/Cargo.toml
+++ b/crates/hiroz/Cargo.toml
@@ -21,6 +21,7 @@ clap = { workspace = true, features = ["derive"] }
 flume = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }
 tracing = { workspace = true }
+thiserror = { workspace = true }
 zenoh = { workspace = true, default-features = false, features = [
   "transport_tcp",
   "unstable",

--- a/crates/hiroz/examples/z_pingpong.rs
+++ b/crates/hiroz/examples/z_pingpong.rs
@@ -107,7 +107,7 @@ pub fn run_ping(ctx: hiroz::context::ZContext, args: &Args) -> Result<()> {
 
     println!(
         "Freq: {} Hz, Payload: {} bytes, Samples: {}",
-        &args.frequency, &args.payload, &args.sample
+        args.frequency, args.payload, args.sample
     );
 
     #[cfg(not(test))]

--- a/crates/hiroz/src/action/client.rs
+++ b/crates/hiroz/src/action/client.rs
@@ -625,4 +625,30 @@ impl<A: ZAction> GoalHandle<A, goal_state::Active> {
 
         res
     }
+
+    /// Consumes the Active handle and waits for the result, failing if it does
+    /// not arrive before `timeout` elapses.
+    ///
+    /// This is the bounded counterpart to [`result`](Self::result). On timeout
+    /// it returns a structured [`crate::error::Error::Timeout`], detectable via
+    /// [`crate::error::is_timeout`], so language bindings do not each have to
+    /// reinvent their own `tokio::time::timeout` wrapper around `result()`.
+    ///
+    /// The goal is always removed from the board (even on timeout), matching
+    /// the cleanup behaviour of [`result`](Self::result).
+    ///
+    /// # Returns
+    ///
+    /// The result of the action once it completes, or a timeout error.
+    pub async fn result_with_timeout(self, timeout: std::time::Duration) -> Result<A::Result> {
+        let res = match tokio::time::timeout(timeout, self.client.get_result(self.id)).await {
+            Ok(res) => res,
+            Err(_) => Err(crate::error::Error::timeout(timeout)),
+        };
+
+        // Cleanup Board (Crucial for Memory Safety)
+        self.client.goal_board.active_goals.remove(&self.id);
+
+        res
+    }
 }

--- a/crates/hiroz/src/error.rs
+++ b/crates/hiroz/src/error.rs
@@ -1,0 +1,110 @@
+//! Structured error types for hiroz core operations.
+//!
+//! The crate's public [`Result`](crate::Result) alias is Zenoh's
+//! `Result<T, Box<dyn std::error::Error + Send + Sync>>`, which erases the
+//! concrete error type. That makes it impossible for callers — and, more
+//! importantly, the language bindings — to tell *why* an operation failed.
+//!
+//! Historically the service/action timeout path returned a stringly-typed
+//! `zenoh::Error::from(format!("... timed out ..."))`, forcing every binding
+//! to sniff the error message (`e.to_string().contains("timeout")`). That is
+//! fragile: it breaks silently the moment the wording changes.
+//!
+//! This module gives that path a real, structured error type with a
+//! [`Timeout`](Error::Timeout) variant. It is boxed into the crate's
+//! `Result`, and callers recover the structure with [`is_timeout`] (which
+//! walks the `source()` chain) or by downcasting the boxed error to [`Error`].
+
+use std::time::Duration;
+
+/// Errors produced by hiroz core operations that callers and language
+/// bindings need to distinguish structurally.
+///
+/// Construct a boxed, `Result`-compatible timeout error with
+/// [`Error::timeout`], and detect one with [`is_timeout`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// An operation did not complete before its timeout elapsed.
+    #[error("operation timed out after {0:?}")]
+    Timeout(Duration),
+
+    /// A generic, message-carrying failure that has no dedicated variant.
+    #[error("{0}")]
+    Other(String),
+}
+
+impl Error {
+    /// Build a boxed [`Error::Timeout`] suitable for returning from any
+    /// function whose error type is the crate's [`Result`](crate::Result)
+    /// (i.e. `zenoh::Error`).
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// let err = hiroz::error::Error::timeout(Duration::from_secs(1));
+    /// assert!(hiroz::error::is_timeout(&*err));
+    /// ```
+    pub fn timeout(elapsed: Duration) -> zenoh::Error {
+        Box::new(Error::Timeout(elapsed))
+    }
+}
+
+/// Returns `true` if `err` — or any error in its [`source`](std::error::Error::source)
+/// chain — is a hiroz [`Error::Timeout`].
+///
+/// Bindings use this instead of matching on the error's `Display` string, so a
+/// change to the timeout message wording can never silently break timeout
+/// detection.
+pub fn is_timeout(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = current {
+        if matches!(e.downcast_ref::<Error>(), Some(Error::Timeout(_))) {
+            return true;
+        }
+        current = e.source();
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_constructor_is_detected() {
+        let err = Error::timeout(Duration::from_millis(250));
+        assert!(is_timeout(&*err));
+        assert!(err.to_string().contains("250ms"));
+    }
+
+    #[test]
+    fn non_timeout_errors_are_not_flagged() {
+        let other = Error::Other("some other failure".to_string());
+        assert!(!is_timeout(&other));
+
+        let zenoh_err: zenoh::Error = zenoh::Error::from("plain failure");
+        assert!(!is_timeout(&*zenoh_err));
+    }
+
+    #[test]
+    fn is_timeout_walks_the_source_chain() {
+        #[derive(Debug, thiserror::Error)]
+        #[error("wrapper")]
+        struct Wrapper(#[source] Error);
+
+        let wrapped = Wrapper(Error::Timeout(Duration::from_secs(1)));
+        assert!(is_timeout(&wrapped));
+
+        let wrapped_other = Wrapper(Error::Other("nope".to_string()));
+        assert!(!is_timeout(&wrapped_other));
+    }
+
+    #[test]
+    fn downcast_recovers_the_variant() {
+        let err = Error::timeout(Duration::from_secs(3));
+        match err.downcast_ref::<Error>() {
+            Some(Error::Timeout(d)) => assert_eq!(*d, Duration::from_secs(3)),
+            other => panic!("expected Timeout, got {other:?}"),
+        }
+    }
+}

--- a/crates/hiroz/src/ffi/service.rs
+++ b/crates/hiroz/src/ffi/service.rs
@@ -60,7 +60,16 @@ impl RawServiceClient {
     }
 
     /// Send a request and wait for the response with a timeout.
-    pub fn call_raw(&self, request: &[u8], timeout: Duration) -> Result<Vec<u8>, String> {
+    ///
+    /// On timeout this returns [`crate::error::Error::Timeout`] so callers (in
+    /// particular the C FFI entry points) can map it to a distinct
+    /// [`ErrorCode::ServiceTimeout`](crate::ffi::ErrorCode::ServiceTimeout)
+    /// instead of a generic failure code.
+    pub fn call_raw(
+        &self,
+        request: &[u8],
+        timeout: Duration,
+    ) -> Result<Vec<u8>, crate::error::Error> {
         let tx = self.tx.clone();
         let attachment = self.new_attachment();
 
@@ -77,12 +86,14 @@ impl RawServiceClient {
                 }
             })
             .wait()
-            .map_err(|e| format!("Failed to send query: {}", e))?;
+            .map_err(|e| crate::error::Error::Other(format!("Failed to send query: {}", e)))?;
 
-        let sample = self
-            .rx
-            .recv_timeout(timeout)
-            .map_err(|e| format!("Timeout waiting for response: {}", e))?;
+        let sample = self.rx.recv_timeout(timeout).map_err(|e| match e {
+            flume::RecvTimeoutError::Timeout => crate::error::Error::Timeout(timeout),
+            flume::RecvTimeoutError::Disconnected => {
+                crate::error::Error::Other(format!("Reply channel disconnected: {}", e))
+            }
+        })?;
 
         Ok(sample.payload().to_bytes().to_vec())
     }
@@ -236,9 +247,13 @@ pub unsafe extern "C" fn hiroz_service_client_call(
                 *response_data = Box::into_raw(boxed) as *mut u8;
                 ErrorCode::Success as i32
             }
+            Err(crate::error::Error::Timeout(elapsed)) => {
+                tracing::warn!("hiroz: Service call timed out after {:?}", elapsed);
+                ErrorCode::ServiceTimeout as i32
+            }
             Err(e) => {
                 tracing::warn!("hiroz: Service call failed: {}", e);
-                -1
+                ErrorCode::ServiceCallFailed as i32
             }
         }
     }

--- a/crates/hiroz/src/lib.rs
+++ b/crates/hiroz/src/lib.rs
@@ -55,6 +55,8 @@ pub mod dynamic;
 pub mod encoding;
 /// Entity identity types (`TypeHash`, `TypeInfo`).
 pub mod entity;
+/// Structured error types (e.g. the timeout variant) shared across the API.
+pub mod error;
 /// Graph events emitted by the Zenoh network graph.
 pub mod event;
 #[cfg(feature = "ffi")]

--- a/crates/hiroz/src/service.rs
+++ b/crates/hiroz/src/service.rs
@@ -226,9 +226,13 @@ where
         // On timeout the call future is dropped. The Zenoh querier callback is still
         // running briefly; it will hit the `None` sender branch and log a warning.
         // This is expected and harmless.
+        //
+        // The error carries a structured [`crate::error::Error::Timeout`] so callers
+        // (and language bindings) can detect the timeout via
+        // [`crate::error::is_timeout`] instead of sniffing the message string.
         tokio::time::timeout(timeout, self.call(msg))
             .await
-            .map_err(|_| zenoh::Error::from(format!("Service call timed out after {timeout:?}")))?
+            .map_err(|_| crate::error::Error::timeout(timeout))?
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a structured `Error::Timeout` variant (via `thiserror`) to `hiroz` core, replacing the stringly-typed `zenoh::Error::from(format!(...))` used by `ZClient::call_with_timeout`.
- Thread the new variant through the FFI `ErrorCode` mapping in `hiroz_service_client_call`, fixing the previously dead `ErrorCode::ServiceTimeout` path on the Go binding.
- Add `GoalHandle::result_with_timeout()` as a core-level timeout primitive, so bindings no longer have to hand-roll their own `tokio::time::timeout` wrapper. This also fixes a latent goal-board leak: the external-timeout wrapper could drop the `result()` future before its goal-board cleanup ran; the internal timeout always cleans up.
- Replace string-sniffed timeout detection in `hiroz-py` with matching on the structured variant via `hiroz::error::is_timeout` — scoped to the service-call and action-result paths (subscriber `recv` timeouts come from a different queue-timeout path and are unchanged).
- Add a Go regression test (`TestGoServiceClientTimeout`) that exercises a real service-call timeout end-to-end and asserts `ErrorCodeServiceTimeout` is returned.

## Breaking Changes
`hiroz_service_client_call` now returns `ErrorCode::ServiceCallFailed` (-9) for generic call failures instead of a hard-coded `-1`, and `ErrorCode::ServiceTimeout` (-10) for timeouts. Callers that matched the literal `-1` for any failed call must switch to the named codes.

Closes #220.
