### PR TITLE
fix: structured timeout detection in hiroz-py subscriber recv (#224)

### DIFF
--- a/crates/hiroz-py/src/pubsub.rs
+++ b/crates/hiroz-py/src/pubsub.rs
@@ -118,12 +118,9 @@ impl PyZSubscriber {
                 Ok(Some(result?))
             }
             Err(e) => {
-                // Check if it's a timeout error
-                let err_str = e.to_string();
-                if err_str.contains("timeout")
-                    || err_str.contains("Timeout")
-                    || err_str.contains("timed out")
-                {
+                // A recv timeout is expected and maps to `None`. Detect it via the
+                // structured `is_timeout` path rather than matching the error string.
+                if hiroz::error::is_timeout(e.root_cause()) {
                     Ok(None)
                 } else {
                     Err(e.into_pyerr())
@@ -173,12 +170,9 @@ impl PyZSubscriber {
         match result {
             Ok(data) => Ok(Some(PyBytes::new_bound(py, &data).into())),
             Err(e) => {
-                // Check if it's a timeout error
-                let err_str = e.to_string();
-                if err_str.contains("timeout")
-                    || err_str.contains("Timeout")
-                    || err_str.contains("timed out")
-                {
+                // A recv timeout is expected and maps to `None`. Detect it via the
+                // structured `is_timeout` path rather than matching the error string.
+                if hiroz::error::is_timeout(e.root_cause()) {
                     Ok(None)
                 } else {
                     Err(e.into_pyerr())
@@ -229,11 +223,9 @@ impl PyZSubscriber {
                 Ok(Some(Py::new(py, view)?.into_any()))
             }
             Err(e) => {
-                let err_str = e.to_string();
-                if err_str.contains("timeout")
-                    || err_str.contains("Timeout")
-                    || err_str.contains("timed out")
-                {
+                // A recv timeout is expected and maps to `None`. Detect it via the
+                // structured `is_timeout` path rather than matching the error string.
+                if hiroz::error::is_timeout(e.root_cause()) {
                     Ok(None)
                 } else {
                     Err(e.into_pyerr())

--- a/crates/hiroz-py/src/pubsub.rs
+++ b/crates/hiroz-py/src/pubsub.rs
@@ -120,7 +120,7 @@ impl PyZSubscriber {
             Err(e) => {
                 // A recv timeout is expected and maps to `None`. Detect it via the
                 // structured `is_timeout` path rather than matching the error string.
-                if hiroz::error::is_timeout(e.root_cause()) {
+                if hiroz::error::is_timeout(&*e) {
                     Ok(None)
                 } else {
                     Err(e.into_pyerr())
@@ -172,7 +172,7 @@ impl PyZSubscriber {
             Err(e) => {
                 // A recv timeout is expected and maps to `None`. Detect it via the
                 // structured `is_timeout` path rather than matching the error string.
-                if hiroz::error::is_timeout(e.root_cause()) {
+                if hiroz::error::is_timeout(&*e) {
                     Ok(None)
                 } else {
                     Err(e.into_pyerr())
@@ -225,7 +225,7 @@ impl PyZSubscriber {
             Err(e) => {
                 // A recv timeout is expected and maps to `None`. Detect it via the
                 // structured `is_timeout` path rather than matching the error string.
-                if hiroz::error::is_timeout(e.root_cause()) {
+                if hiroz::error::is_timeout(&*e) {
                     Ok(None)
                 } else {
                     Err(e.into_pyerr())

--- a/crates/hiroz-py/src/traits.rs
+++ b/crates/hiroz-py/src/traits.rs
@@ -62,9 +62,12 @@ impl RawSubscriber for GenericSubWrapper {
             let queue = self.inner.queue.as_ref().ok_or_else(|| {
                 anyhow::anyhow!("Subscriber was built with callback, no queue available")
             })?;
+            // Map a queue timeout to the structured `Error::Timeout` so the
+            // Python layer can detect it via `hiroz::error::is_timeout` instead
+            // of sniffing the error message string.
             queue
                 .recv_timeout(t)
-                .ok_or_else(|| anyhow::anyhow!("Receive timeout"))
+                .ok_or_else(|| anyhow::Error::new(hiroz::error::Error::Timeout(t)))
         } else {
             self.inner.recv_serialized().map_err(|e| anyhow::anyhow!(e))
         }

--- a/crates/hiroz-tests/tests/subscriber_timeout.rs
+++ b/crates/hiroz-tests/tests/subscriber_timeout.rs
@@ -1,0 +1,68 @@
+//! Structured subscriber-timeout tests for hiroz.
+//!
+//! Regression coverage for [hiroz#224](https://github.com/ZettaScaleLabs/hiroz/issues/224):
+//! a subscriber `recv_timeout` that elapses must return a *structured*
+//! [`hiroz::error::Error::Timeout`], detectable via [`hiroz::error::is_timeout`],
+//! rather than a stringly-typed error that bindings have to sniff.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{TestRouter, create_hiroz_context_with_endpoint};
+use hiroz::Builder;
+use hiroz_msgs::std_msgs;
+use serial_test::serial;
+
+/// A typed `recv_timeout` on an idle subscriber must surface a structured timeout.
+#[test]
+#[serial]
+fn typed_recv_timeout_is_structured() {
+    let router = TestRouter::new();
+    let ctx =
+        create_hiroz_context_with_endpoint(router.endpoint()).expect("Failed to create context");
+    let node = ctx
+        .create_node("timeout_sub")
+        .build()
+        .expect("Failed to create node");
+    let sub = node
+        .create_sub::<std_msgs::String>("/no_publisher_topic")
+        .build()
+        .expect("Failed to create subscriber");
+
+    // No publisher exists, so this must time out.
+    let err = sub
+        .recv_timeout(Duration::from_millis(200))
+        .expect_err("recv_timeout on an idle topic should fail");
+
+    assert!(
+        hiroz::error::is_timeout(&*err),
+        "expected a structured timeout error, got: {err}"
+    );
+}
+
+/// The raw-sample `recv_serialized_timeout` path must also be structured.
+#[test]
+#[serial]
+fn serialized_recv_timeout_is_structured() {
+    let router = TestRouter::new();
+    let ctx =
+        create_hiroz_context_with_endpoint(router.endpoint()).expect("Failed to create context");
+    let node = ctx
+        .create_node("timeout_sub_raw")
+        .build()
+        .expect("Failed to create node");
+    let sub = node
+        .create_sub::<std_msgs::String>("/no_publisher_topic_raw")
+        .build()
+        .expect("Failed to create subscriber");
+
+    let err = sub
+        .recv_serialized_timeout(Duration::from_millis(200))
+        .expect_err("recv_serialized_timeout on an idle topic should fail");
+
+    assert!(
+        hiroz::error::is_timeout(&*err),
+        "expected a structured timeout error, got: {err}"
+    );
+}

--- a/crates/hiroz-tests/tests/subscriber_timeout.rs
+++ b/crates/hiroz-tests/tests/subscriber_timeout.rs
@@ -5,6 +5,11 @@
 //! [`hiroz::error::Error::Timeout`], detectable via [`hiroz::error::is_timeout`],
 //! rather than a stringly-typed error that bindings have to sniff.
 
+// Uses generated message types (`hiroz-msgs`), an optional dep linked only via
+// the `ros-msgs` feature. The `-F rmw`-only clippy pass does not enable it, so
+// gate the whole file like the sibling interop tests (e.g. cache.rs).
+#![cfg(feature = "ros-msgs")]
+
 mod common;
 
 use std::time::Duration;

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -1018,7 +1018,7 @@ where
         })?;
         queue
             .recv_timeout(timeout)
-            .ok_or_else(|| zenoh::Error::from("Receive timed out"))
+            .ok_or_else(|| crate::error::Error::timeout(timeout))
     }
 
     pub fn events_mgr(&self) -> &Arc<Mutex<EventsManager>> {
@@ -1113,7 +1113,7 @@ where
         })?;
         let sample = queue
             .recv_timeout(timeout)
-            .ok_or_else(|| zenoh::Error::from("Receive timed out"))?;
+            .ok_or_else(|| crate::error::Error::timeout(timeout))?;
         let payload = sample.payload().to_bytes();
         S::deserialize(&payload).map_err(|e| zenoh::Error::from(e.to_string()))
     }
@@ -1180,7 +1180,7 @@ impl ZSub<crate::dynamic::DynamicMessage, Sample, crate::dynamic::DynamicSerdeCd
 
         let sample = queue
             .recv_timeout(timeout)
-            .ok_or_else(|| zenoh::Error::from("Receive timed out"))?;
+            .ok_or_else(|| crate::error::Error::timeout(timeout))?;
         let payload = sample.payload().to_bytes();
 
         crate::dynamic::DynamicSerdeCdrSerdes::deserialize((&payload, schema))

--- a/crates/hiroz/tests/message_type_info_derive.rs
+++ b/crates/hiroz/tests/message_type_info_derive.rs
@@ -6,8 +6,7 @@ use hiroz::{
     dynamic::{FieldType, MessageSchemaTypeDescription},
 };
 use serde::{Deserialize, Serialize};
-use zenoh::Wait;
-use zenoh::config::WhatAmI;
+use zenoh::{Wait, config::WhatAmI};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, hiroz::MessageTypeInfo)]
 #[ros_msg(type_name = "custom_msgs/msg/Position2D")]


### PR DESCRIPTION
## Summary

The Python bindings' subscriber receive paths detected timeouts by string-matching error messages (`err_str.contains("timeout")`), the same fragility that #221 removed from the service and action paths. Any rewording of an error message would silently turn an expected timeout into an exception. This routes subscriber timeouts through the structured `Error::Timeout` / `hiroz::error::is_timeout()` path instead. Closes #224.

## Key Changes

- Map the subscriber queue's `flume::RecvTimeoutError::Timeout` to the structured `Error::Timeout` at the core level (`crates/hiroz/src/pubsub.rs`, `crates/hiroz-py/src/traits.rs`).
- Replace the three `err_str.contains("timeout")` checks in `crates/hiroz-py/src/pubsub.rs` (`recv`, `recv_serialized`, `recv_raw_view`) with `hiroz::error::is_timeout()`, passing the whole error (`&*e`) so its full `source()` chain is walked — consistent with the sibling service path in `traits.rs`.
- Add integration test `crates/hiroz-tests/tests/subscriber_timeout.rs` asserting that subscriber recv timeouts are classified structurally rather than by string match.
- Go bindings audited: they already use structured error codes, no string-sniffing.

## Breaking Changes

None.
