### PR TITLE
docs: link the Go interop tests page from the nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - Go:
           - Quick Start: bindings/go-quick-start.md
           - Bindings: bindings/go.md
+          - Interop Tests: user-guide/go_interop_tests.md
   - Advanced Topics:
       - Shared Memory (SHM): experimental/shm.md
   - Reference:


### PR DESCRIPTION
## Summary

Adds `docs/user-guide/go_interop_tests.md` to the mkdocs nav.

The page is already reachable — `docs/bindings/go.md` links to it in the "Interop Tests" reference — but it has no nav entry, so it never appears in the sidebar and cannot be found by browsing. mkdocs also warns about docs files absent from `nav`.

## Key Changes

- `mkdocs.yml`: one nav entry under Language Bindings → Go, placed after Quick Start and Bindings so it reads in dependency order.

## Breaking Changes

None. Navigation only; no page content changes.
