### PR TITLE
fix(ci): lint hiroz-tests under interop features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,6 +412,14 @@ jobs:
           nu scripts/test-pure-rust.nu clippy-hiroz-py
         shell: bash
 
+      - name: Clippy (hiroz-tests, interop features)
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            source /tmp/nix-dev-env.sh
+          fi
+          nu scripts/test-pure-rust.nu clippy-tests
+        shell: bash
+
   go-tests:
     name: Go Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/crates/hiroz-tests/tests/cache.rs
+++ b/crates/hiroz-tests/tests/cache.rs
@@ -67,7 +67,7 @@ fn cache_zenoh_stamp_inserts() {
 
     // Allow delivery.
     thread::sleep(Duration::from_millis(200));
-    assert!(cache.len() > 0, "expected messages in cache");
+    assert!(!cache.is_empty(), "expected messages in cache");
     assert!(cache.len() <= 5);
 }
 
@@ -716,7 +716,7 @@ fn cache_drop_deregisters_subscriber() {
         .expect("cache2");
     publish_n(&endpoint, "/cache_drop", &[make_msg("new")]);
     thread::sleep(Duration::from_millis(200));
-    assert!(cache2.len() > 0, "new cache should receive messages");
+    assert!(!cache2.is_empty(), "new cache should receive messages");
     // The "after1"/"after2" messages were published while no subscriber existed;
     // they should not be present in cache2 (volatile QoS — no late-join).
     // cache2 only has messages published after it was built.

--- a/crates/hiroz-tests/tests/parameter_tests.rs
+++ b/crates/hiroz-tests/tests/parameter_tests.rs
@@ -558,9 +558,11 @@ mod service_tests {
                 .build()
                 .expect("set client");
 
-            let mut wire_value = rcl_interfaces::ParameterValue::default();
-            wire_value.r#type = 2;
-            wire_value.integer_value = 42;
+            let wire_value = rcl_interfaces::ParameterValue {
+                r#type: 2,
+                integer_value: 42,
+                ..Default::default()
+            };
 
             let set_resp: SetParametersResponse = set_client
                 .call_with_timeout(
@@ -641,9 +643,9 @@ mod service_tests {
             let ctx = create_hiroz_context_with_endpoint(&endpoint).expect("ctx");
             let node = ctx.create_node("rollback_server").build().expect("node");
 
-            for (name, val) in &[("a", 1i64), ("b", 2i64)] {
-                let desc = ParameterDescriptor::new(*name, ParameterType::Integer);
-                node.declare_parameter(*name, ParameterValue::Integer(*val), desc)
+            for (name, val) in [("a", 1i64), ("b", 2i64)] {
+                let desc = ParameterDescriptor::new(name, ParameterType::Integer);
+                node.declare_parameter(name, ParameterValue::Integer(val), desc)
                     .expect("declare");
             }
 
@@ -667,9 +669,11 @@ mod service_tests {
             tokio::time::sleep(Duration::from_millis(500)).await;
 
             let make_int = |name: &str, v: i64| {
-                let mut wire = rcl_interfaces::ParameterValue::default();
-                wire.r#type = 2;
-                wire.integer_value = v;
+                let wire = rcl_interfaces::ParameterValue {
+                    r#type: 2,
+                    integer_value: v,
+                    ..Default::default()
+                };
                 rcl_interfaces::Parameter {
                     name: name.to_string(),
                     value: wire,
@@ -736,9 +740,9 @@ mod service_tests {
             let ctx = create_hiroz_context_with_endpoint(&endpoint).expect("ctx");
             let node = ctx.create_node("atomic_server").build().expect("node");
 
-            for (name, val) in &[("a", 1i64), ("b", 2i64)] {
-                let desc = ParameterDescriptor::new(*name, ParameterType::Integer);
-                node.declare_parameter(*name, ParameterValue::Integer(*val), desc)
+            for (name, val) in [("a", 1i64), ("b", 2i64)] {
+                let desc = ParameterDescriptor::new(name, ParameterType::Integer);
+                node.declare_parameter(name, ParameterValue::Integer(val), desc)
                     .expect("declare");
             }
 
@@ -761,9 +765,11 @@ mod service_tests {
                 .expect("atomic client");
 
             let make_int = |name: &str, v: i64| {
-                let mut wire = rcl_interfaces::ParameterValue::default();
-                wire.r#type = 2;
-                wire.integer_value = v;
+                let wire = rcl_interfaces::ParameterValue {
+                    r#type: 2,
+                    integer_value: v,
+                    ..Default::default()
+                };
                 rcl_interfaces::Parameter {
                     name: name.to_string(),
                     value: wire,

--- a/crates/hiroz-tests/tests/type_description_integration.rs
+++ b/crates/hiroz-tests/tests/type_description_integration.rs
@@ -638,13 +638,10 @@ fn test_multiple_publishers_schema_discovery() {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
 
             while received.len() < 5 && tokio::time::Instant::now() < deadline {
-                match subscriber.recv_timeout(Duration::from_millis(500)) {
-                    Ok(msg) => {
-                        let data: String = msg.get("data").expect("Failed to get data");
-                        println!("Received: {}", data);
-                        received.push(data);
-                    }
-                    Err(_) => {}
+                if let Ok(msg) = subscriber.recv_timeout(Duration::from_millis(500)) {
+                    let data: String = msg.get("data").expect("Failed to get data");
+                    println!("Received: {}", data);
+                    received.push(data);
                 }
             }
 

--- a/crates/hiroz-tests/tests/type_description_interop.rs
+++ b/crates/hiroz-tests/tests/type_description_interop.rs
@@ -151,12 +151,9 @@ fn test_get_type_description_from_ros2_talker() {
                 include_type_sources: true,
             };
 
-            let resp = zcli
-                .call_with_timeout(&req, Duration::from_secs(15))
+            zcli.call_with_timeout(&req, Duration::from_secs(15))
                 .await
-                .expect("Failed to receive response");
-
-            resp
+                .expect("Failed to receive response")
         })
     })
     .join()
@@ -256,12 +253,9 @@ fn test_get_type_description_without_sources() {
                 include_type_sources: false,
             };
 
-            let resp = zcli
-                .call_with_timeout(&req, Duration::from_secs(15))
+            zcli.call_with_timeout(&req, Duration::from_secs(15))
                 .await
-                .expect("Failed to receive response");
-
-            resp
+                .expect("Failed to receive response")
         })
     })
     .join()

--- a/crates/hiroz-tests/tests/z_cache_example.rs
+++ b/crates/hiroz-tests/tests/z_cache_example.rs
@@ -44,7 +44,7 @@ fn make_ctx(endpoint: &str) -> hiroz::context::ZContext {
 #[tokio::test(flavor = "multi_thread")]
 async fn z_cache_cache_role_zenoh_stamp() {
     let router = TestRouter::new();
-    let ctx = make_ctx(&router.endpoint());
+    let ctx = make_ctx(router.endpoint());
     z_cache_zenoh_stamp::run(ctx, "/smoke/cache_zenoh".into(), 20, 500, 1)
         .await
         .expect("run returned Err");
@@ -54,7 +54,7 @@ async fn z_cache_cache_role_zenoh_stamp() {
 #[tokio::test(flavor = "multi_thread")]
 async fn z_cache_cache_role_app_stamp() {
     let router = TestRouter::new();
-    let ctx = make_ctx(&router.endpoint());
+    let ctx = make_ctx(router.endpoint());
     z_cache_app_stamp::run(ctx, "/smoke/cache_app".into(), 20, 1)
         .await
         .expect("run returned Err");
@@ -64,7 +64,7 @@ async fn z_cache_cache_role_app_stamp() {
 #[tokio::test(flavor = "multi_thread")]
 async fn z_cache_talker_role() {
     let router = TestRouter::new();
-    let ctx = make_ctx(&router.endpoint());
+    let ctx = make_ctx(router.endpoint());
     z_cache_talker::run(ctx, "/smoke/talker".into(), 3)
         .await
         .expect("run returned Err");

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -45,6 +45,11 @@ def clippy-hiroz-py [] {
     run-cmd "cargo clippy -p hiroz-py --all-targets -- -D warnings"
 }
 
+def clippy-tests [] {
+    log-step "Clippy (hiroz-tests, interop features)"
+    run-cmd "cargo clippy -p hiroz-tests --all-targets --features ros-interop,jazzy -- -D warnings"
+}
+
 def check-examples [] {
     log-step "Check all examples (cargo check --examples)"
     run-cmd "cargo check --examples"
@@ -83,6 +88,7 @@ def get-test-map [] {
         check-examples: { check-examples }
         check-distro-features: { check-distro-features }
         clippy-hiroz-py: { clippy-hiroz-py }
+        clippy-tests: { clippy-tests }
         test-shm: { test-shm }
     }
 }
@@ -96,6 +102,7 @@ def get-test-pipeline [] {
         "check-examples"
         "check-distro-features"
         "clippy-hiroz-py"
+        "clippy-tests"
         "test-shm"
     ]
 }


### PR DESCRIPTION
## Summary
- Add a `clippy-tests` step (`cargo clippy -p hiroz-tests --all-targets --features ros-interop,jazzy -- -D warnings`) to `scripts/test-pure-rust.nu` and wire it into CI, so `hiroz-tests` is linted under the same feature combo the test jobs actually run with
- Fix the 13 clippy errors this uncovered in `crates/hiroz-tests/tests/` (10 documented in the issue, plus 3 more found once the real `ros-interop` superset — not just `ros-msgs` — was exercised)

## What fails without this
`cargo clippy -p hiroz-tests --all-targets --features ros-interop,jazzy -- -D warnings` currently exits non-zero on `main` (verified: rc=101). CI's `clippy-workspace` job never catches this because it runs with no `-p`/`--workspace`, so it only lints the two `default-members` crates (`hiroz`, `hiroz-codegen`); `hiroz-tests` also isn't compiled under `ros-interop,<distro>` features by any existing clippy step, since the affected test files are `#![cfg(feature = "ros-msgs")]`-gated and compile to nothing under default features.

After this change, both invocations are clean:
- `cargo clippy -p hiroz-tests --all-targets -- -D warnings` (default features) → rc=0
- `cargo clippy -p hiroz-tests --all-targets --features ros-interop,jazzy -- -D warnings` → rc=0 (was rc=101)

## Breaking Changes
None.
