### PR TITLE
chore(nix): wasm32-wasip2 toolchain groundwork (hu stack 1/9)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+# Convenience aliases. This file only adds `[alias]` entries — it does not
+# change build flags, targets, or RUSTFLAGS for normal `cargo` invocations.
+[alias]
+# Build the hu WASM plugins (meter + monitor) from the repo root without
+# remembering the manifest path and target. Append --release for an optimized
+# build. See docs/tools/hu-plugins.md.
+hu-plugins = "build --manifest-path crates/hiroz-union/plugins/Cargo.toml --target wasm32-wasip2 --workspace"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,4 @@
-# Convenience aliases. This file only adds `[alias]` entries — it does not
-# change build flags, targets, or RUSTFLAGS for normal `cargo` invocations.
+# Aliases only — no change to build flags, targets, or RUSTFLAGS.
 [alias]
-# Build the hu WASM plugins (meter + monitor) from the repo root without
-# remembering the manifest path and target. Append --release for an optimized
-# build. See docs/tools/hu-plugins.md.
+# Build the hu WASM plugins from the repo root (append --release to optimize).
 hu-plugins = "build --manifest-path crates/hiroz-union/plugins/Cargo.toml --target wasm32-wasip2 --workspace"

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 .direnv
 target
 node_modules
-.cargo
+# Ignore local cargo state but keep committed config.toml (aliases, build target)
+.cargo/*
+!.cargo/config.toml
 compile_commands.json
 _*
 !crates/hiroz-py/python/**/__init__.py

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1784564969,
+        "narHash": "sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy+oJe4PUiXg=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7930f6c291de6f83c257839d434592aa085f290a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -82,11 +97,11 @@
         "rosdistro": "rosdistro"
       },
       "locked": {
-        "lastModified": 1779526397,
-        "narHash": "sha256-HWFG5voy8Y9nDkhp3zzFThX99UmgSOsyFpmAglXdtvs=",
+        "lastModified": 1784411287,
+        "narHash": "sha256-oQnBcy+usVzedG8/dsbScEAAKyMJ0nLQHizKfDC1jdU=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "1abff578f2919094ac076407c46658c0a0de41c9",
+        "rev": "f092cd397fd167ae95ed7e0771f35ae88e519339",
         "type": "github"
       },
       "original": {
@@ -113,11 +128,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -145,6 +160,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "git-hooks": "git-hooks",
         "nix-ros-overlay": "nix-ros-overlay",
         "nixpkgs": [
@@ -158,11 +174,11 @@
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1779440547,
-        "narHash": "sha256-zwkFhi7/rGJ1DPykUsulXnAJXFxbR5YQO10GuFUEBfo=",
+        "lastModified": 1784293198,
+        "narHash": "sha256-PYYpx0kwwNGlzRKZW28XfwU7S/J9S3yDp9acpDILhIA=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "7111412b11e86fbb1751db4c4955d798f95e5cf3",
+        "rev": "c8b19e9ae58b9eee6eedbd305720825646102334",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "crane": {
-      "locked": {
-        "lastModified": 1784564969,
-        "narHash": "sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy+oJe4PUiXg=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "7930f6c291de6f83c257839d434592aa085f290a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -160,7 +145,6 @@
     },
     "root": {
       "inputs": {
-        "crane": "crane",
         "git-hooks": "git-hooks",
         "nix-ros-overlay": "nix-ros-overlay",
         "nixpkgs": [

--- a/flake.nix
+++ b/flake.nix
@@ -340,7 +340,7 @@
                   # Per-package AMENT_PREFIX_PATH: collapsed into one export so nix develop
                   # doesn't evaluate 26 separate shell statements (each increments SHLVL).
                   pkgs.lib.optionalString (rosEnvPaths != [ ]) ''
-                    export AMENT_PREFIX_PATH="$AMENT_PREFIX_PATH:${pkgs.lib.concatStringsSep ":" rosEnvPaths}"
+                    export AMENT_PREFIX_PATH="''${AMENT_PREFIX_PATH:+$AMENT_PREFIX_PATH:}${pkgs.lib.concatStringsSep ":" rosEnvPaths}"
                   ''
                 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -53,18 +53,12 @@
           ];
         };
 
-        # crane splits the `hu` package build into a deps-only layer
-        # (cargoArtifacts, cacheable independently of workspace source changes)
-        # and the actual package build that reuses it -- unlike
-        # rustPlatform.buildRustPackage's single-phase build, a change to any
-        # workspace crate's own code doesn't invalidate the compiled-dependency
-        # cache, so cachix only needs to re-push the deps layer when Cargo.lock
-        # itself changes.
+        # crane: caches the deps layer separately from the package build, so
+        # only a Cargo.lock change re-pushes deps to cachix.
         craneLib = (crane.mkLib pkgs).overrideToolchain (_: rustToolchain);
 
-        # CI-only toolchain — adds the wasm32-wasip2 sysroot for building WASM
-        # plugins. Kept separate so everyday `nix develop` shells don't pay the
-        # WASM sysroot download cost (~100-500 MB).
+        # CI-only toolchain with the wasm32-wasip2 sysroot; kept separate so
+        # everyday shells skip the ~100-500 MB sysroot download.
         rustToolchainWasm = rustToolchain.override {
           targets = [ "wasm32-wasip2" ];
         };
@@ -183,8 +177,8 @@
               wrapPrograms = false;
             };
 
-            # Individual store paths for testFull — used to build a correct AMENT_PREFIX_PATH
-            # that preserves each package's own ament index (buildEnv merging drops index entries).
+            # Per-package store paths for testFull's AMENT_PREFIX_PATH
+            # (buildEnv merging drops each package's ament index).
             testFullPaths = rosDeps.rcl ++ rosDeps.messages ++ rosDeps.testMessages ++ rosDeps.testCli;
           };
 
@@ -299,8 +293,8 @@
             # Extra env vars set as mkShell attributes (exported by `nix print-dev-env`).
             extraEnvVars ? { },
             rosEnvPath ? null,
-            # Individual package store paths — when provided, each is added to AMENT_PREFIX_PATH
-            # separately so their ament indexes survive (buildEnv merging drops index entries).
+            # Each added to AMENT_PREFIX_PATH separately so ament indexes
+            # survive (buildEnv merging drops them).
             rosEnvPaths ? [ ],
             pythonVersion ? pkgs.python3, # To determine site-packages path
             rosDistro ? null,
@@ -337,9 +331,8 @@
                 }
 
                 ${
-                  # Per-package AMENT_PREFIX_PATH: collapsed into one export to keep the
-                  # shellHook small — one export instead of 26 separate shell statements,
-                  # which reduces shellHook size and nix develop's eval cost.
+                  # Per-package AMENT_PREFIX_PATH in one export (smaller
+                  # shellHook, faster `nix develop` eval).
                   pkgs.lib.optionalString (rosEnvPaths != [ ]) ''
                     export AMENT_PREFIX_PATH="''${AMENT_PREFIX_PATH:+$AMENT_PREFIX_PATH:}${pkgs.lib.concatStringsSep ":" rosEnvPaths}"
                   ''
@@ -445,10 +438,9 @@
 
         # Development shells
         devShells = {
-          # Default: first *available* distro (present in the pinned overlay).
-          # Must pick from availableDistros — allDistroShells is built from that
-          # filtered list, so using the unfiltered `distros` here could reference
-          # a distro that was filtered out and doesn't exist in allDistroShells.
+          # Default = first available distro. Must use availableDistros
+          # (allDistroShells is built from it; unfiltered `distros` could name a
+          # distro that isn't present).
           default =
             if availableDistros == [ ] then
               throw "hiroz: none of the supported ROS distros (${builtins.concatStringsSep ", " distros}) are present in the pinned nix-ros-overlay; use the `.#pureRust` dev shell, or update the overlay pin so at least one distro is available."
@@ -474,13 +466,10 @@
             '';
           };
 
-          # Pure-Rust dev shell WITH the wasm32-wasip2 target — for building the
-          # hu WASM plugins (meter/monitor, or your own) locally with the full
-          # dev toolchain (pre-commit, dev tools). Same as `pureRust` but the
-          # WASM-capable toolchain replaces the default one. Use this instead of
-          # a `*-ci` shell when developing plugins: `nix develop .#pureRust-wasm`
-          # then `cargo hu-plugins`. The default `pureRust` shell stays lean and
-          # does not fetch the wasm sysroot.
+          # Like `pureRust` but with the wasm32-wasip2 target — for building hu
+          # WASM plugins locally (`nix develop .#pureRust-wasm` then
+          # `cargo hu-plugins`). The default `pureRust` shell stays lean (no
+          # wasm sysroot).
           pureRust-wasm = mkDevShell {
             name = "hiroz-pure-rust-wasm";
             packages = [
@@ -552,11 +541,9 @@
             };
 
           # CI shell for bridge interop tests.
-          # Same as ros-bridge-interop but with rustToolchain replaced by
-          # rustToolchainWasm (adds wasm32-wasip2 target for building WASM plugins).
-          # `hu` is NOT injected as a nix package here — buildRustPackage runs in a
-          # nix sandbox without the wasm32 sysroot and fails when the workspace had
-          # WASM plugin members. Build `hu` and WASM plugins inline in the CI command.
+          # Like ros-bridge-interop but wasm-capable. `hu` isn't a nix package
+          # here — buildRustPackage's sandbox lacks the wasm sysroot; build
+          # hu/plugins inline in the CI command instead.
           bridge-interop-ci = (self.devShells.${system}.ros-bridge-interop).overrideAttrs (old: {
             nativeBuildInputs = [
               rustToolchainWasm
@@ -585,14 +572,9 @@
             huCommonArgs = {
               pname = "hu";
               version = "0.1.0";
-              # cleanCargoSource's default filter strips files down to what it
-              # infers each workspace member needs, but that inference isn't
-              # workspace-aware enough here: it leaves hiroz-tests (not even a
-              # dependency of hiroz-union) with zero source files, which makes
-              # its Cargo.toml invalid ("no targets specified") and fails
-              # workspace resolution before hiroz-union itself is even
-              # reached. pkgs.lib.cleanSource (just .git/ignored-file
-              # filtering) is coarser but correct for a workspace build.
+              # Use cleanSource, not craneLib.cleanCargoSource: the latter
+              # strips hiroz-tests to zero source files ("no targets specified")
+              # and breaks workspace resolution.
               src = pkgs.lib.cleanSource ./.;
               strictDeps = true;
               nativeBuildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,6 @@
     rust-overlay.url = "github:oxalica/rust-overlay";
     git-hooks.url = "github:cachix/git-hooks.nix";
     systems.url = "github:nix-systems/default";
-    crane.url = "github:ipetkov/crane";
   };
 
   outputs =
@@ -18,7 +17,6 @@
       rust-overlay,
       git-hooks,
       systems,
-      crane,
     }:
     nix-ros-overlay.inputs.flake-utils.lib.eachDefaultSystem (
       system:
@@ -33,9 +31,6 @@
           "lyrical" # (May 2026 - May 2031, LTS)
           "rolling" # continuous release, no EOL
         ];
-        # Only include distros present in the pinned nix-ros-overlay; newer distros
-        # (lyrical, rolling) may not be cached on the CI worker yet.
-        availableDistros = builtins.filter (d: builtins.hasAttr d pkgs.rosPackages) distros;
 
         pkgs = import nixpkgs {
           inherit system;
@@ -52,10 +47,6 @@
             "llvm-tools-preview"
           ];
         };
-
-        # crane: caches the deps layer separately from the package build, so
-        # only a Cargo.lock change re-pushes deps to cachix.
-        craneLib = (crane.mkLib pkgs).overrideToolchain (_: rustToolchain);
 
         # CI-only toolchain with the wasm32-wasip2 sysroot; kept separate so
         # everyday shells skip the ~100-500 MB sysroot download.
@@ -101,20 +92,6 @@
               # Test-only message packages
               testMessages = with pkgs.rosPackages.${rosDistro}; [
                 test-msgs
-              ];
-
-              # CLI tools needed for interop tests (ros2 topic/param/node/service/run)
-              testCli = with pkgs.rosPackages.${rosDistro}; [
-                ros2cli
-                ros2topic
-                ros2node
-                ros2param
-                ros2service
-                ros2action
-                ros2pkg
-                ros2run
-                ros2launch
-                rmw-zenoh-cpp
               ];
 
               devExtras = with pkgs.rosPackages.${rosDistro}; [
@@ -171,15 +148,11 @@
               wrapPrograms = false;
             };
 
-            # Test environment with test messages and CLI tools (for all tests)
+            # Test environment with test messages (for all tests)
             testFull = pkgs.rosPackages.${rosDistro}.buildEnv {
-              paths = rosDeps.rcl ++ rosDeps.messages ++ rosDeps.testMessages ++ rosDeps.testCli;
+              paths = rosDeps.rcl ++ rosDeps.messages ++ rosDeps.testMessages;
               wrapPrograms = false;
             };
-
-            # Per-package store paths for testFull's AMENT_PREFIX_PATH
-            # (buildEnv merging drops each package's ament index).
-            testFullPaths = rosDeps.rcl ++ rosDeps.messages ++ rosDeps.testMessages ++ rosDeps.testCli;
           };
 
         # Colcon configuration
@@ -293,9 +266,6 @@
             # Extra env vars set as mkShell attributes (exported by `nix print-dev-env`).
             extraEnvVars ? { },
             rosEnvPath ? null,
-            # Each added to AMENT_PREFIX_PATH separately so ament indexes
-            # survive (buildEnv merging drops them).
-            rosEnvPaths ? [ ],
             pythonVersion ? pkgs.python3, # To determine site-packages path
             rosDistro ? null,
           }:
@@ -328,14 +298,6 @@
                     ''
                   else
                     ""
-                }
-
-                ${
-                  # Per-package AMENT_PREFIX_PATH in one export (smaller
-                  # shellHook, faster `nix develop` eval).
-                  pkgs.lib.optionalString (rosEnvPaths != [ ]) ''
-                    export AMENT_PREFIX_PATH="''${AMENT_PREFIX_PATH:+$AMENT_PREFIX_PATH:}${pkgs.lib.concatStringsSep ":" rosEnvPaths}"
-                  ''
                 }
 
                 ${extraShellHook}
@@ -384,19 +346,18 @@
               name = "hiroz-ci-${rosDistro}";
               packages = commonBuildInputs ++ pythonTools ++ docTools ++ testTools ++ [ rosEnv.testFull ];
               rosEnvPath = rosEnv.testFull;
-              rosEnvPaths = rosEnv.testFullPaths;
               pythonVersion = pythonVer;
               rosDistro = rosDistro;
               extraShellHook = '''';
             };
           };
 
-        # Generate shells for available distros only
+        # Generate shells for all distros
         allDistroShells = builtins.listToAttrs (
           builtins.map (distro: {
             name = distro;
             value = mkRosShells distro;
-          }) availableDistros
+          }) distros
         );
         # Pre-commit hooks configuration
         mkdocsPkg = builtins.elemAt docTools 1;
@@ -438,14 +399,8 @@
 
         # Development shells
         devShells = {
-          # Default = first available distro. Must use availableDistros
-          # (allDistroShells is built from it; unfiltered `distros` could name a
-          # distro that isn't present).
-          default =
-            if availableDistros == [ ] then
-              throw "hiroz: none of the supported ROS distros (${builtins.concatStringsSep ", " distros}) are present in the pinned nix-ros-overlay; use the `.#pureRust` dev shell, or update the overlay pin so at least one distro is available."
-            else
-              allDistroShells.${builtins.head availableDistros}.default;
+          # Default: first distro in the list with ROS
+          default = allDistroShells.${builtins.head distros}.default;
 
           # Without ROS
           pureRust = mkDevShell {
@@ -505,8 +460,8 @@
             extraShellHook = '''';
           };
 
-          # Bridge interop test environment (Jazzy + Humble side-by-side).
-          # Used by `cargo test -p hiroz-tests --features bridge-interop-tests,jazzy`.
+          # DEPRECATED: Bridge interop test environment (Jazzy + Humble via humble-ros2 wrapper).
+          # Moved to zetta-hiroz-toolkit (private). Will be removed in a future release.
           ros-bridge-interop =
             let
               humbleEnv = mkRosEnv "humble";
@@ -538,18 +493,11 @@
               extraEnvVars = {
                 HUMBLE_ROS2 = "${humbleRos2}/bin/humble-ros2";
               };
+              shellHook = ''
+                echo "WARNING: ros-bridge-interop is deprecated in this repo." >&2
+                echo "Use the shell from zetta-hiroz-toolkit instead." >&2
+              '';
             };
-
-          # CI shell for bridge interop tests.
-          # Like ros-bridge-interop but wasm-capable. `hu` isn't a nix package
-          # here — buildRustPackage's sandbox lacks the wasm sysroot; build
-          # hu/plugins inline in the CI command instead.
-          bridge-interop-ci = (self.devShells.${system}.ros-bridge-interop).overrideAttrs (old: {
-            nativeBuildInputs = [
-              rustToolchainWasm
-            ]
-            ++ (builtins.filter (p: p != rustToolchain) (old.nativeBuildInputs or [ ]));
-          });
 
         }
         # Add per-distro dev shells (ros-jazzy, ros-rolling, ...)
@@ -557,45 +505,15 @@
           builtins.map (distro: {
             name = "ros-${distro}";
             value = allDistroShells.${distro}.default;
-          }) availableDistros
+          }) distros
         ))
         # Add per-distro CI shells (ros-jazzy-ci, ros-rolling-ci, ...)
         // (builtins.listToAttrs (
           builtins.map (distro: {
             name = "ros-${distro}-ci";
             value = allDistroShells.${distro}.ci;
-          }) availableDistros
+          }) distros
         ));
-
-        packages =
-          let
-            huCommonArgs = {
-              pname = "hu";
-              version = "0.1.0";
-              # Use cleanSource, not craneLib.cleanCargoSource: the latter
-              # strips hiroz-tests to zero source files ("no targets specified")
-              # and breaks workspace resolution.
-              src = pkgs.lib.cleanSource ./.;
-              strictDeps = true;
-              nativeBuildInputs = [
-                pkgs.pkg-config
-                pkgs.protobuf
-              ];
-              cargoExtraArgs = "-p hiroz-union --bin hu";
-              doCheck = false;
-              RUSTFLAGS = "";
-            };
-            huCargoArtifacts = craneLib.buildDepsOnly huCommonArgs;
-          in
-          rec {
-            hu = craneLib.buildPackage (
-              huCommonArgs
-              // {
-                cargoArtifacts = huCargoArtifacts;
-              }
-            );
-            default = hu;
-          };
 
         formatter = pkgs.nixfmt-rfc-style;
       }

--- a/flake.nix
+++ b/flake.nix
@@ -449,7 +449,11 @@
           # Must pick from availableDistros — allDistroShells is built from that
           # filtered list, so using the unfiltered `distros` here could reference
           # a distro that was filtered out and doesn't exist in allDistroShells.
-          default = allDistroShells.${builtins.head availableDistros}.default;
+          default =
+            if availableDistros == [ ] then
+              throw "hiroz: none of the supported ROS distros (${builtins.concatStringsSep ", " distros}) are present in the pinned nix-ros-overlay; use the `.#pureRust` dev shell, or update the overlay pin so at least one distro is available."
+            else
+              allDistroShells.${builtins.head availableDistros}.default;
 
           # Without ROS
           pureRust = mkDevShell {

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
     rust-overlay.url = "github:oxalica/rust-overlay";
     git-hooks.url = "github:cachix/git-hooks.nix";
     systems.url = "github:nix-systems/default";
+    crane.url = "github:ipetkov/crane";
   };
 
   outputs =
@@ -17,6 +18,7 @@
       rust-overlay,
       git-hooks,
       systems,
+      crane,
     }:
     nix-ros-overlay.inputs.flake-utils.lib.eachDefaultSystem (
       system:
@@ -31,6 +33,9 @@
           "lyrical" # (May 2026 - May 2031, LTS)
           "rolling" # continuous release, no EOL
         ];
+        # Only include distros present in the pinned nix-ros-overlay; newer distros
+        # (lyrical, rolling) may not be cached on the CI worker yet.
+        availableDistros = builtins.filter (d: builtins.hasAttr d pkgs.rosPackages) distros;
 
         pkgs = import nixpkgs {
           inherit system;
@@ -46,6 +51,22 @@
             "rust-analyzer"
             "llvm-tools-preview"
           ];
+        };
+
+        # crane splits the `hu` package build into a deps-only layer
+        # (cargoArtifacts, cacheable independently of workspace source changes)
+        # and the actual package build that reuses it -- unlike
+        # rustPlatform.buildRustPackage's single-phase build, a change to any
+        # workspace crate's own code doesn't invalidate the compiled-dependency
+        # cache, so cachix only needs to re-push the deps layer when Cargo.lock
+        # itself changes.
+        craneLib = (crane.mkLib pkgs).overrideToolchain (_: rustToolchain);
+
+        # CI-only toolchain — adds the wasm32-wasip2 sysroot for building WASM
+        # plugins. Kept separate so everyday `nix develop` shells don't pay the
+        # WASM sysroot download cost (~100-500 MB).
+        rustToolchainWasm = rustToolchain.override {
+          targets = [ "wasm32-wasip2" ];
         };
 
         rustfmtNightly = pkgs.rust-bin.nightly.latest.rustfmt;
@@ -86,6 +107,20 @@
               # Test-only message packages
               testMessages = with pkgs.rosPackages.${rosDistro}; [
                 test-msgs
+              ];
+
+              # CLI tools needed for interop tests (ros2 topic/param/node/service/run)
+              testCli = with pkgs.rosPackages.${rosDistro}; [
+                ros2cli
+                ros2topic
+                ros2node
+                ros2param
+                ros2service
+                ros2action
+                ros2pkg
+                ros2run
+                ros2launch
+                rmw-zenoh-cpp
               ];
 
               devExtras = with pkgs.rosPackages.${rosDistro}; [
@@ -142,11 +177,15 @@
               wrapPrograms = false;
             };
 
-            # Test environment with test messages (for all tests)
+            # Test environment with test messages and CLI tools (for all tests)
             testFull = pkgs.rosPackages.${rosDistro}.buildEnv {
-              paths = rosDeps.rcl ++ rosDeps.messages ++ rosDeps.testMessages;
+              paths = rosDeps.rcl ++ rosDeps.messages ++ rosDeps.testMessages ++ rosDeps.testCli;
               wrapPrograms = false;
             };
+
+            # Individual store paths for testFull — used to build a correct AMENT_PREFIX_PATH
+            # that preserves each package's own ament index (buildEnv merging drops index entries).
+            testFullPaths = rosDeps.rcl ++ rosDeps.messages ++ rosDeps.testMessages ++ rosDeps.testCli;
           };
 
         # Colcon configuration
@@ -260,6 +299,9 @@
             # Extra env vars set as mkShell attributes (exported by `nix print-dev-env`).
             extraEnvVars ? { },
             rosEnvPath ? null,
+            # Individual package store paths — when provided, each is added to AMENT_PREFIX_PATH
+            # separately so their ament indexes survive (buildEnv merging drops index entries).
+            rosEnvPaths ? [ ],
             pythonVersion ? pkgs.python3, # To determine site-packages path
             rosDistro ? null,
           }:
@@ -292,6 +334,14 @@
                     ''
                   else
                     ""
+                }
+
+                ${
+                  # Per-package AMENT_PREFIX_PATH: collapsed into one export so nix develop
+                  # doesn't evaluate 26 separate shell statements (each increments SHLVL).
+                  pkgs.lib.optionalString (rosEnvPaths != [ ]) ''
+                    export AMENT_PREFIX_PATH="$AMENT_PREFIX_PATH:${pkgs.lib.concatStringsSep ":" rosEnvPaths}"
+                  ''
                 }
 
                 ${extraShellHook}
@@ -340,18 +390,19 @@
               name = "hiroz-ci-${rosDistro}";
               packages = commonBuildInputs ++ pythonTools ++ docTools ++ testTools ++ [ rosEnv.testFull ];
               rosEnvPath = rosEnv.testFull;
+              rosEnvPaths = rosEnv.testFullPaths;
               pythonVersion = pythonVer;
               rosDistro = rosDistro;
               extraShellHook = '''';
             };
           };
 
-        # Generate shells for all distros
+        # Generate shells for available distros only
         allDistroShells = builtins.listToAttrs (
           builtins.map (distro: {
             name = distro;
             value = mkRosShells distro;
-          }) distros
+          }) availableDistros
         );
         # Pre-commit hooks configuration
         mkdocsPkg = builtins.elemAt docTools 1;
@@ -415,15 +466,50 @@
             '';
           };
 
-          # CI without ROS
+          # Pure-Rust dev shell WITH the wasm32-wasip2 target — for building the
+          # hu WASM plugins (meter/monitor, or your own) locally with the full
+          # dev toolchain (pre-commit, dev tools). Same as `pureRust` but the
+          # WASM-capable toolchain replaces the default one. Use this instead of
+          # a `*-ci` shell when developing plugins: `nix develop .#pureRust-wasm`
+          # then `cargo hu-plugins`. The default `pureRust` shell stays lean and
+          # does not fetch the wasm sysroot.
+          pureRust-wasm = mkDevShell {
+            name = "hiroz-pure-rust-wasm";
+            packages = [
+              rustfmt-nightly-bin
+              rustToolchainWasm
+            ]
+            ++ (builtins.filter (p: p != rustToolchain) commonBuildInputs)
+            ++ devTools
+            ++ pythonTools
+            ++ docTools
+            ++ testTools
+            ++ pre-commit-check.enabledPackages;
+            extraShellHook = preCommitGuard;
+            banner = ''
+              echo "🦀 hiroz development environment (pure Rust + wasm32-wasip2)"
+              echo "Rust: $(rustc --version)"
+              echo "Build plugins with: cargo hu-plugins"
+            '';
+          };
+
+          # CI without ROS — includes wasm32-wasip2 sysroot for WASM plugin builds.
+          # Uses rustToolchainWasm so the WASM target is only fetched in CI, not
+          # in the default developer shell.
           pureRust-ci = mkDevShell {
             name = "hiroz-ci-pure-rust";
-            packages = commonBuildInputs ++ pythonTools ++ docTools ++ testTools;
+            packages =
+              # Replace the default rustToolchain with the WASM-capable variant.
+              [ rustToolchainWasm ]
+              ++ (builtins.filter (p: p != rustToolchain) commonBuildInputs)
+              ++ pythonTools
+              ++ docTools
+              ++ testTools;
             extraShellHook = '''';
           };
 
-          # DEPRECATED: Bridge interop test environment (Jazzy + Humble via humble-ros2 wrapper).
-          # Moved to zetta-hiroz-toolkit (private). Will be removed in a future release.
+          # Bridge interop test environment (Jazzy + Humble side-by-side).
+          # Used by `cargo test -p hiroz-tests --features bridge-interop-tests,jazzy`.
           ros-bridge-interop =
             let
               humbleEnv = mkRosEnv "humble";
@@ -455,11 +541,20 @@
               extraEnvVars = {
                 HUMBLE_ROS2 = "${humbleRos2}/bin/humble-ros2";
               };
-              shellHook = ''
-                echo "WARNING: ros-bridge-interop is deprecated in this repo." >&2
-                echo "Use the shell from zetta-hiroz-toolkit instead." >&2
-              '';
             };
+
+          # CI shell for bridge interop tests.
+          # Same as ros-bridge-interop but with rustToolchain replaced by
+          # rustToolchainWasm (adds wasm32-wasip2 target for building WASM plugins).
+          # `hu` is NOT injected as a nix package here — buildRustPackage runs in a
+          # nix sandbox without the wasm32 sysroot and fails when the workspace had
+          # WASM plugin members. Build `hu` and WASM plugins inline in the CI command.
+          bridge-interop-ci = (self.devShells.${system}.ros-bridge-interop).overrideAttrs (old: {
+            nativeBuildInputs = [
+              rustToolchainWasm
+            ]
+            ++ (builtins.filter (p: p != rustToolchain) (old.nativeBuildInputs or [ ]));
+          });
 
         }
         # Add per-distro dev shells (ros-jazzy, ros-rolling, ...)
@@ -467,15 +562,50 @@
           builtins.map (distro: {
             name = "ros-${distro}";
             value = allDistroShells.${distro}.default;
-          }) distros
+          }) availableDistros
         ))
         # Add per-distro CI shells (ros-jazzy-ci, ros-rolling-ci, ...)
         // (builtins.listToAttrs (
           builtins.map (distro: {
             name = "ros-${distro}-ci";
             value = allDistroShells.${distro}.ci;
-          }) distros
+          }) availableDistros
         ));
+
+        packages =
+          let
+            huCommonArgs = {
+              pname = "hu";
+              version = "0.1.0";
+              # cleanCargoSource's default filter strips files down to what it
+              # infers each workspace member needs, but that inference isn't
+              # workspace-aware enough here: it leaves hiroz-tests (not even a
+              # dependency of hiroz-union) with zero source files, which makes
+              # its Cargo.toml invalid ("no targets specified") and fails
+              # workspace resolution before hiroz-union itself is even
+              # reached. pkgs.lib.cleanSource (just .git/ignored-file
+              # filtering) is coarser but correct for a workspace build.
+              src = pkgs.lib.cleanSource ./.;
+              strictDeps = true;
+              nativeBuildInputs = [
+                pkgs.pkg-config
+                pkgs.protobuf
+              ];
+              cargoExtraArgs = "-p hiroz-union --bin hu";
+              doCheck = false;
+              RUSTFLAGS = "";
+            };
+            huCargoArtifacts = craneLib.buildDepsOnly huCommonArgs;
+          in
+          rec {
+            hu = craneLib.buildPackage (
+              huCommonArgs
+              // {
+                cargoArtifacts = huCargoArtifacts;
+              }
+            );
+            default = hu;
+          };
 
         formatter = pkgs.nixfmt-rfc-style;
       }

--- a/flake.nix
+++ b/flake.nix
@@ -445,8 +445,11 @@
 
         # Development shells
         devShells = {
-          # Default: first distro in the list with ROS
-          default = allDistroShells.${builtins.head distros}.default;
+          # Default: first *available* distro (present in the pinned overlay).
+          # Must pick from availableDistros — allDistroShells is built from that
+          # filtered list, so using the unfiltered `distros` here could reference
+          # a distro that was filtered out and doesn't exist in allDistroShells.
+          default = allDistroShells.${builtins.head availableDistros}.default;
 
           # Without ROS
           pureRust = mkDevShell {

--- a/flake.nix
+++ b/flake.nix
@@ -337,8 +337,9 @@
                 }
 
                 ${
-                  # Per-package AMENT_PREFIX_PATH: collapsed into one export so nix develop
-                  # doesn't evaluate 26 separate shell statements (each increments SHLVL).
+                  # Per-package AMENT_PREFIX_PATH: collapsed into one export to keep the
+                  # shellHook small — one export instead of 26 separate shell statements,
+                  # which reduces shellHook size and nix develop's eval cost.
                   pkgs.lib.optionalString (rosEnvPaths != [ ]) ''
                     export AMENT_PREFIX_PATH="''${AMENT_PREFIX_PATH:+$AMENT_PREFIX_PATH:}${pkgs.lib.concatStringsSep ":" rosEnvPaths}"
                   ''
@@ -489,7 +490,7 @@
             banner = ''
               echo "🦀 hiroz development environment (pure Rust + wasm32-wasip2)"
               echo "Rust: $(rustc --version)"
-              echo "Build plugins with: cargo hu-plugins"
+              echo "wasm32-wasip2 target available for WASM plugin builds"
             '';
           };
 


### PR DESCRIPTION
## Summary
Skeleton nix/cargo plumbing for building the hu WASM plugins. Adds a wasm32-wasip2-capable toolchain gated behind CI/opt-in dev shells so the default developer shell doesn't pull the wasm sysroot, plus a committed cargo alias for the plugin build.

## Key changes
- `flake.nix`: `rustToolchainWasm` (rust toolchain + `wasm32-wasip2` target); new `pureRust-wasm` dev shell; `pureRust-ci` now uses the wasm-capable toolchain so CI can build plugins.
- `.cargo/config.toml` (new): `cargo hu-plugins` alias building `crates/hiroz-union/plugins` for `wasm32-wasip2`.
- `.gitignore`: ignore local `.cargo/*` state but keep the committed `config.toml`.
- `flake.lock`: bump nix-ros-overlay / nixpkgs / rosdistro.

## Breaking changes
None.
