### PR TITLE
feat(msgs): rcl_interfaces logger-level messages (hu stack 2/9)

### DIFF
--- a/crates/hiroz-codegen/assets/jazzy/rcl_interfaces/msg/LoggerLevel.msg
+++ b/crates/hiroz-codegen/assets/jazzy/rcl_interfaces/msg/LoggerLevel.msg
@@ -1,0 +1,9 @@
+# A map of logger name and its logging severity level.
+
+# The logger name '' will set the default logging severity level for a given node.
+string name
+
+# The logging severity level.
+# Supported logging severity level values from rcl_interfaces/msg/Log:
+#   DEBUG=10 INFO=20 WARN=30 ERROR=40 FATAL=50
+uint32 level

--- a/crates/hiroz-codegen/assets/jazzy/rcl_interfaces/msg/SetLoggerLevelsResult.msg
+++ b/crates/hiroz-codegen/assets/jazzy/rcl_interfaces/msg/SetLoggerLevelsResult.msg
@@ -1,0 +1,6 @@
+# A true value indicates the logger level was set successfully.
+bool successful
+
+# Reason why the setting was a failure. On success, the contents of this field
+# are undefined. This should only be used for logging and user interfaces.
+string reason

--- a/crates/hiroz-codegen/assets/jazzy/rcl_interfaces/srv/GetLoggerLevels.srv
+++ b/crates/hiroz-codegen/assets/jazzy/rcl_interfaces/srv/GetLoggerLevels.srv
@@ -1,0 +1,6 @@
+# A list of logger names to get the levels for.
+string[] names
+
+---
+# A list of logger levels, in the same length and order as the provided names.
+LoggerLevel[] levels

--- a/crates/hiroz-codegen/assets/jazzy/rcl_interfaces/srv/SetLoggerLevels.srv
+++ b/crates/hiroz-codegen/assets/jazzy/rcl_interfaces/srv/SetLoggerLevels.srv
@@ -1,0 +1,6 @@
+# A list of logger levels to set.
+LoggerLevel[] levels
+
+---
+# A list of results, in the same length and order as the provided levels.
+SetLoggerLevelsResult[] results

--- a/crates/hiroz-msgs/build.rs
+++ b/crates/hiroz-msgs/build.rs
@@ -7,10 +7,8 @@ use hiroz_codegen::python_msgspec_generator;
 fn main() -> Result<()> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
-    // The message/service definitions live outside this crate (in
-    // hiroz-codegen/assets/), so cargo's default "rerun on package change"
-    // heuristic never notices when a .msg/.srv is added or edited there. Track
-    // the asset trees explicitly so codegen re-runs when definitions change.
+    // .msg/.srv definitions live in hiroz-codegen/assets/, outside this crate,
+    // so cargo won't rerun codegen on edits there unless we track them explicitly.
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
     if let Some(codegen_assets) = manifest_dir
         .parent()

--- a/crates/hiroz-msgs/build.rs
+++ b/crates/hiroz-msgs/build.rs
@@ -7,6 +7,19 @@ use hiroz_codegen::python_msgspec_generator;
 fn main() -> Result<()> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
+    // The message/service definitions live outside this crate (in
+    // hiroz-codegen/assets/), so cargo's default "rerun on package change"
+    // heuristic never notices when a .msg/.srv is added or edited there. Track
+    // the asset trees explicitly so codegen re-runs when definitions change.
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    if let Some(codegen_assets) = manifest_dir
+        .parent()
+        .map(|p| p.join("hiroz-codegen/assets"))
+        && codegen_assets.exists()
+    {
+        println!("cargo:rerun-if-changed={}", codegen_assets.display());
+    }
+
     // Declare custom cfg for ROS version detection
     println!("cargo:rustc-check-cfg=cfg(ros_humble)");
 


### PR DESCRIPTION
## Summary
Vendors the rcl_interfaces logger-level message/service definitions (needed by the `hu param`/logging paths) and makes codegen re-run when any asset definition changes.

## Key changes
- Add `rcl_interfaces` `LoggerLevel.msg`, `SetLoggerLevelsResult.msg`, `GetLoggerLevels.srv`, `SetLoggerLevels.srv` under `hiroz-codegen/assets/jazzy/`.
- `hiroz-msgs/build.rs`: emit `cargo:rerun-if-changed` for the `hiroz-codegen/assets/` tree, which lives outside the crate and is otherwise invisible to cargo's change detection.

## Breaking changes
None.
