### PR TITLE
feat(hiroz): graph-settle wait + service-schema discovery (hu stack 3/9)

### DIFF
--- a/crates/hiroz-tests/tests/service_schema_discovery.rs
+++ b/crates/hiroz-tests/tests/service_schema_discovery.rs
@@ -1,9 +1,7 @@
-//! Tests for [`ZNode::discover_service_schema`], no-server path: with no node
-//! serving the name, discovery must fail with [`DynamicError::SchemaNotFound`]
-//! after the graph-poll timeout rather than hang or panic.
-//!
-//! The happy path needs a live server exposing `~get_type_description` and is
-//! covered by the hiroz-union / hu-meter integration tests instead.
+//! [`ZNode::discover_service_schema`], no-server path: with no node serving the
+//! name, discovery must fail with [`DynamicError::SchemaNotFound`] after the
+//! timeout, not hang or panic. The happy path needs a live server exposing
+//! `~get_type_description` and is covered by the hu-meter integration tests.
 
 #![cfg(feature = "ros-msgs")]
 
@@ -15,8 +13,8 @@ use common::*;
 use hiroz::Builder;
 use hiroz::dynamic::DynamicError;
 
-/// With no service server present, discovery polls the graph until the timeout
-/// and then returns `SchemaNotFound` — it must not hang or panic.
+/// With no service server present, discovery waits until the timeout and then
+/// returns `SchemaNotFound` — it must not hang or panic.
 #[tokio::test(flavor = "multi_thread")]
 async fn discover_service_schema_times_out_without_server() {
     let router = TestRouter::new();
@@ -45,10 +43,15 @@ async fn discover_service_schema_times_out_without_server() {
         other => panic!("expected SchemaNotFound for absent server, got: {other:?}"),
     }
 
-    // It should actually wait out (roughly) the graph-poll timeout, not fail
-    // instantly on the first miss.
+    // Waits out (roughly) the timeout — not an instant first-miss failure — and
+    // returns promptly after the deadline (event-driven, no poll overshoot).
+    let elapsed = start.elapsed();
     assert!(
-        start.elapsed() >= timeout,
-        "discovery returned before the graph-poll timeout elapsed"
+        elapsed >= timeout,
+        "discovery returned before the timeout elapsed: {elapsed:?}"
+    );
+    assert!(
+        elapsed < timeout + Duration::from_millis(200),
+        "discovery overshot the deadline by more than a small margin: {elapsed:?}"
     );
 }

--- a/crates/hiroz-tests/tests/service_schema_discovery.rs
+++ b/crates/hiroz-tests/tests/service_schema_discovery.rs
@@ -1,0 +1,60 @@
+//! Tests for [`ZNode::discover_service_schema`].
+//!
+//! These focus on the no-server path, which needs no external service: when no
+//! node serves the requested service name, discovery must fail with
+//! [`DynamicError::SchemaNotFound`] once the graph-poll timeout elapses rather
+//! than hanging or panicking.
+//!
+//! A full happy-path test (successful Request/Response schema resolution) is
+//! intentionally omitted here: it requires a live service server whose node
+//! exposes a working `~get_type_description` service, which is covered by the
+//! higher-level hiroz-union / hu-meter integration paths rather than a unit
+//! test in this crate.
+
+#![cfg(feature = "ros-msgs")]
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use common::*;
+use hiroz::Builder;
+use hiroz::dynamic::DynamicError;
+
+/// With no service server present, discovery polls the graph until the timeout
+/// and then returns `SchemaNotFound` — it must not hang or panic.
+#[tokio::test(flavor = "multi_thread")]
+async fn discover_service_schema_times_out_without_server() {
+    let router = TestRouter::new();
+    let ctx = create_hiroz_context_with_endpoint(router.endpoint()).expect("ctx");
+    let node = ctx.create_node("discovery_client").build().expect("node");
+
+    let timeout = Duration::from_millis(300);
+    let start = Instant::now();
+    let result = node
+        .discover_service_schema(
+            "/no_such_service",
+            "example_interfaces/msg/AddTwoIntsRequest",
+            "example_interfaces/msg/AddTwoIntsResponse",
+            timeout,
+        )
+        .await;
+
+    // Must return SchemaNotFound rather than any other error / success.
+    match result {
+        Err(DynamicError::SchemaNotFound(msg)) => {
+            assert!(
+                msg.contains("no_such_service"),
+                "error should name the missing service, got: {msg}"
+            );
+        }
+        other => panic!("expected SchemaNotFound for absent server, got: {other:?}"),
+    }
+
+    // It should actually wait out (roughly) the graph-poll timeout, not fail
+    // instantly on the first miss.
+    assert!(
+        start.elapsed() >= timeout,
+        "discovery returned before the graph-poll timeout elapsed"
+    );
+}

--- a/crates/hiroz-tests/tests/service_schema_discovery.rs
+++ b/crates/hiroz-tests/tests/service_schema_discovery.rs
@@ -1,15 +1,9 @@
-//! Tests for [`ZNode::discover_service_schema`].
+//! Tests for [`ZNode::discover_service_schema`], no-server path: with no node
+//! serving the name, discovery must fail with [`DynamicError::SchemaNotFound`]
+//! after the graph-poll timeout rather than hang or panic.
 //!
-//! These focus on the no-server path, which needs no external service: when no
-//! node serves the requested service name, discovery must fail with
-//! [`DynamicError::SchemaNotFound`] once the graph-poll timeout elapses rather
-//! than hanging or panicking.
-//!
-//! A full happy-path test (successful Request/Response schema resolution) is
-//! intentionally omitted here: it requires a live service server whose node
-//! exposes a working `~get_type_description` service, which is covered by the
-//! higher-level hiroz-union / hu-meter integration paths rather than a unit
-//! test in this crate.
+//! The happy path needs a live server exposing `~get_type_description` and is
+//! covered by the hiroz-union / hu-meter integration tests instead.
 
 #![cfg(feature = "ros-msgs")]
 

--- a/crates/hiroz/examples/demo_nodes/add_two_ints_client.rs
+++ b/crates/hiroz/examples/demo_nodes/add_two_ints_client.rs
@@ -38,9 +38,11 @@ pub fn run_add_two_ints_client(ctx: ZContext, a: i64, b: i64, async_mode: bool) 
             .unwrap()
             .block_on(async { client.call(&req).await })?
     } else {
-        tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(async { client.call_with_timeout(&req, Duration::from_secs(5)).await })?
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            client
+                .call_with_timeout(&req, Duration::from_secs(15))
+                .await
+        })?
     };
 
     println!("Received response: {}", resp.sum);

--- a/crates/hiroz/examples/demo_nodes/add_two_ints_client.rs
+++ b/crates/hiroz/examples/demo_nodes/add_two_ints_client.rs
@@ -38,11 +38,9 @@ pub fn run_add_two_ints_client(ctx: ZContext, a: i64, b: i64, async_mode: bool) 
             .unwrap()
             .block_on(async { client.call(&req).await })?
     } else {
-        tokio::runtime::Runtime::new().unwrap().block_on(async {
-            client
-                .call_with_timeout(&req, Duration::from_secs(15))
-                .await
-        })?
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async { client.call_with_timeout(&req, Duration::from_secs(5)).await })?
     };
 
     println!("Received response: {}", resp.sum);

--- a/crates/hiroz/src/graph.rs
+++ b/crates/hiroz/src/graph.rs
@@ -490,15 +490,10 @@ impl Graph {
         }
     }
 
-    /// True if the graph currently holds at least one entity whose owning node
-    /// zid is **not** in `exclude`.
-    ///
-    /// A process that opens more than one Zenoh session (e.g. `hu`, which runs
-    /// its liveliness graph on one session and its ROS node on another) sees its
-    /// *own* liveliness tokens echoed back through the graph. Passing all of the
-    /// process's own session zids as `exclude` lets a caller distinguish "the
-    /// graph reflects a genuinely external participant" from "the graph only
-    /// contains our own tokens" — which a plain emptiness check cannot do.
+    /// True if the graph holds any entity whose owning node zid is not in
+    /// `exclude`. A multi-session process (e.g. `hu`) sees its own tokens echoed
+    /// back; passing its own session zids as `exclude` distinguishes a genuine
+    /// external participant from only-our-own-tokens, which emptiness cannot.
     pub fn has_external_entity(&self, exclude: &[ZenohId]) -> bool {
         let mut data = self.data.lock();
         if !data.cached.is_empty() {
@@ -508,30 +503,22 @@ impl Graph {
             Entity::Node(node) => !exclude.contains(&node.z_id),
             Entity::Endpoint(endpoint) => match endpoint.node.as_ref() {
                 Some(node) => !exclude.contains(&node.z_id),
-                // An endpoint with no node identity carries no zid; it can only
-                // be external.
+                // No node identity means no zid to match — treat as external.
                 None => true,
             },
         })
     }
 
-    /// Wait until the graph reflects an external participant and has then gone
-    /// quiet, bounded by `timeout`.
+    /// Barrier for one-shot commands (`hu list`/`info`/`service`/`param`) before
+    /// they snapshot the graph. Waits for an external participant to appear, then
+    /// for the graph to go quiet — a quiet-only wait can mistake a not-yet-populated
+    /// graph for "settled" under CPU contention. `exclude` = caller's own session
+    /// zids, so echoed self-tokens don't satisfy the wait.
     ///
-    /// This is the barrier a one-shot command (`hu list`/`info`/`service`/
-    /// `param`) needs before it snapshots the graph. Unlike a naive quiet-only
-    /// wait, it never mistakes an empty-but-quiet graph for "settled": under CPU
-    /// contention an external liveliness token can take longer to propagate than
-    /// any fixed quiet window, and returning early there is exactly what made
-    /// these commands read an empty graph. `exclude` should list the caller's
-    /// own session zids so its own echoed tokens don't satisfy the wait.
-    ///
-    /// Returns `true` once an external entity is present and the graph has
-    /// *either* gone quiet for `quiet` *or* `timeout` elapsed while the entity
-    /// was still present (best-effort under contention — it does not guarantee a
-    /// full quiet window in that case). Returns `false` only if `timeout`
-    /// elapsed with no external entity at all (a genuinely empty graph — the
-    /// command should then report "not found").
+    /// Returns `true` once an external entity is present and the graph has either
+    /// gone quiet for `quiet` or `timeout` elapsed with it still present (best-effort
+    /// under contention). Returns `false` only if `timeout` elapsed with no external
+    /// entity (genuinely empty — caller should report "not found").
     pub async fn wait_for_external_settled(
         &self,
         exclude: &[ZenohId],

--- a/crates/hiroz/src/graph.rs
+++ b/crates/hiroz/src/graph.rs
@@ -463,7 +463,7 @@ impl Graph {
         })
     }
 
-    async fn wait_until<F>(&self, timeout: Duration, predicate: F) -> bool
+    pub(crate) async fn wait_until<F>(&self, timeout: Duration, predicate: F) -> bool
     where
         F: Fn(&Self) -> bool,
     {
@@ -509,16 +509,14 @@ impl Graph {
         })
     }
 
-    /// Barrier for one-shot commands (`hu list`/`info`/`service`/`param`) before
-    /// they snapshot the graph. Waits for an external participant to appear, then
-    /// for the graph to go quiet — a quiet-only wait can mistake a not-yet-populated
-    /// graph for "settled" under CPU contention. `exclude` = caller's own session
-    /// zids, so echoed self-tokens don't satisfy the wait.
+    /// Barrier for one-shot `hu` commands before they snapshot the graph: wait for
+    /// an external participant, then for the graph to go quiet (waiting for quiet
+    /// alone can read a not-yet-populated graph as settled). `exclude` is the
+    /// caller's own session zids, so echoed self-tokens don't count.
     ///
-    /// Returns `true` once an external entity is present and the graph has either
-    /// gone quiet for `quiet` or `timeout` elapsed with it still present (best-effort
-    /// under contention). Returns `false` only if `timeout` elapsed with no external
-    /// entity (genuinely empty — caller should report "not found").
+    /// Returns `true` once an external entity is present and the graph has gone
+    /// quiet for `quiet` (or `timeout` elapsed with it still present). Returns
+    /// `false` only if `timeout` elapsed with no external entity.
     pub async fn wait_for_external_settled(
         &self,
         exclude: &[ZenohId],

--- a/crates/hiroz/src/graph.rs
+++ b/crates/hiroz/src/graph.rs
@@ -519,16 +519,19 @@ impl Graph {
     /// quiet, bounded by `timeout`.
     ///
     /// This is the barrier a one-shot command (`hu list`/`info`/`service`/
-    /// `param`) needs before it snapshots the graph. Unlike [`wait_settled`],
-    /// it never mistakes an empty-but-quiet graph for "settled": under CPU
+    /// `param`) needs before it snapshots the graph. Unlike a naive quiet-only
+    /// wait, it never mistakes an empty-but-quiet graph for "settled": under CPU
     /// contention an external liveliness token can take longer to propagate than
     /// any fixed quiet window, and returning early there is exactly what made
     /// these commands read an empty graph. `exclude` should list the caller's
     /// own session zids so its own echoed tokens don't satisfy the wait.
     ///
-    /// Returns `true` once an external entity is present and the graph has been
-    /// quiet for `quiet`; `false` if `timeout` elapsed with no external entity
-    /// (a genuinely empty graph — the command should then report "not found").
+    /// Returns `true` once an external entity is present and the graph has
+    /// *either* gone quiet for `quiet` *or* `timeout` elapsed while the entity
+    /// was still present (best-effort under contention — it does not guarantee a
+    /// full quiet window in that case). Returns `false` only if `timeout`
+    /// elapsed with no external entity at all (a genuinely empty graph — the
+    /// command should then report "not found").
     pub async fn wait_for_external_settled(
         &self,
         exclude: &[ZenohId],

--- a/crates/hiroz/src/graph.rs
+++ b/crates/hiroz/src/graph.rs
@@ -490,6 +490,90 @@ impl Graph {
         }
     }
 
+    /// True if the graph currently holds at least one entity whose owning node
+    /// zid is **not** in `exclude`.
+    ///
+    /// A process that opens more than one Zenoh session (e.g. `hu`, which runs
+    /// its liveliness graph on one session and its ROS node on another) sees its
+    /// *own* liveliness tokens echoed back through the graph. Passing all of the
+    /// process's own session zids as `exclude` lets a caller distinguish "the
+    /// graph reflects a genuinely external participant" from "the graph only
+    /// contains our own tokens" — which a plain emptiness check cannot do.
+    pub fn has_external_entity(&self, exclude: &[ZenohId]) -> bool {
+        let mut data = self.data.lock();
+        if !data.cached.is_empty() {
+            data.parse();
+        }
+        data.parsed.values().any(|entity| match &**entity {
+            Entity::Node(node) => !exclude.contains(&node.z_id),
+            Entity::Endpoint(endpoint) => match endpoint.node.as_ref() {
+                Some(node) => !exclude.contains(&node.z_id),
+                // An endpoint with no node identity carries no zid; it can only
+                // be external.
+                None => true,
+            },
+        })
+    }
+
+    /// Wait until the graph reflects an external participant and has then gone
+    /// quiet, bounded by `timeout`.
+    ///
+    /// This is the barrier a one-shot command (`hu list`/`info`/`service`/
+    /// `param`) needs before it snapshots the graph. Unlike [`wait_settled`],
+    /// it never mistakes an empty-but-quiet graph for "settled": under CPU
+    /// contention an external liveliness token can take longer to propagate than
+    /// any fixed quiet window, and returning early there is exactly what made
+    /// these commands read an empty graph. `exclude` should list the caller's
+    /// own session zids so its own echoed tokens don't satisfy the wait.
+    ///
+    /// Returns `true` once an external entity is present and the graph has been
+    /// quiet for `quiet`; `false` if `timeout` elapsed with no external entity
+    /// (a genuinely empty graph — the command should then report "not found").
+    pub async fn wait_for_external_settled(
+        &self,
+        exclude: &[ZenohId],
+        quiet: Duration,
+        timeout: Duration,
+    ) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        // Phase 1: block until at least one external entity appears.
+        loop {
+            let notified = self.change_notify.notified();
+            tokio::pin!(notified);
+            if self.has_external_entity(exclude) {
+                break;
+            }
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            if tokio::time::timeout(remaining, &mut notified)
+                .await
+                .is_err()
+            {
+                return self.has_external_entity(exclude);
+            }
+        }
+        // Phase 2: an external entity is present; wait for the graph to go quiet
+        // so a multi-endpoint participant is fully reflected, capped at the
+        // deadline.
+        loop {
+            let notified = self.change_notify.notified();
+            tokio::pin!(notified);
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return true;
+            }
+            let quiet_window = quiet.min(remaining);
+            if tokio::time::timeout(quiet_window, &mut notified)
+                .await
+                .is_err()
+            {
+                return true;
+            }
+        }
+    }
+
     /// Create a new Graph with a custom liveliness subscription pattern and parser
     ///
     /// # Arguments

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -11,7 +11,7 @@ use crate::{
     cache::ZCacheBuilder,
     context::{GlobalCounter, RemapRules},
     dynamic::{
-        DiscoveredTopicSchema, DynPubBuilder, DynSub, DynSubBuilder, DynamicMessage,
+        DiscoveredTopicSchema, DynPubBuilder, DynSub, DynSubBuilder, DynamicError, DynamicMessage,
         DynamicSerdeCdrSerdes, MessageSchema, SchemaDiscovery, TypeDescriptionService,
         discovered_schema_type_info, schema_type_info,
     },
@@ -23,6 +23,7 @@ use crate::{
         service::{ParameterService, ParameterServiceConfig},
     },
     pubsub::{ZPubBuilder, ZSubBuilder},
+    ros_msg::MessageTypeInfo,
     service::{ZClientBuilder, ZServerBuilder},
 };
 
@@ -254,6 +255,7 @@ impl Builder for ZNodeBuilder {
                 counter: &self.counter,
                 clock: &self.clock,
                 overrides: self.parameter_overrides,
+                type_desc_service: type_desc_service.as_ref(),
             })?;
             info!("[NOD] ParameterService created");
             Some(service)
@@ -433,8 +435,13 @@ impl ZNode {
         ZCacheBuilder::new(sub_builder, capacity)
     }
 
-    /// Create a service for the given service name
-    /// If T is a tuple (Req, Resp) where both implement WithTypeInfo, type information will be automatically populated
+    /// Create a service for the given service name.
+    ///
+    /// `T::Request` and `T::Response` must implement [`WithTypeInfo`] (enforced by
+    /// the trait bounds below). Type information is always populated with this
+    /// node's type-description service so schema discovery (e.g. by hiroz-union's
+    /// WASM plugin host) can resolve the Request/Response schemas via live
+    /// `get_type_description` queries.
     ///
     /// The service name will be qualified according to ROS 2 rules:
     /// - Absolute service names (starting with '/') are used as-is
@@ -443,8 +450,22 @@ impl ZNode {
     pub fn create_service<T>(&self, name: &str) -> ZServerBuilder<T>
     where
         T: ZService + ServiceTypeInfo,
+        T::Request: WithTypeInfo,
+        T::Response: WithTypeInfo,
     {
         debug!("[NOD] Creating service: name={}", name);
+        // Mirror create_pub<T>'s auto-registration: if the Request/Response types
+        // carry a runtime schema (generated ROS 2 message types do), register both
+        // with this node's type description service so `discover_service_schema`
+        // (used by hiroz-union's WASM plugin host, among others) can resolve them
+        // via live `get_type_description` queries instead of requiring callers to
+        // pre-populate the (otherwise-unpopulated) global SchemaRegistry.
+        if let Some(schema) = T::Request::message_schema() {
+            self.register_schema_with_type_description_service(&schema);
+        }
+        if let Some(schema) = T::Response::message_schema() {
+            self.register_schema_with_type_description_service(&schema);
+        }
         self.create_service_impl(name, Some(T::service_type_info()))
     }
 
@@ -1086,6 +1107,110 @@ impl ZNode {
             .discover(topic)
             .await
             .map_err(|e| zenoh::Error::from(e.to_string()))
+    }
+
+    /// Resolve a service's request and response schemas via live discovery.
+    ///
+    /// Mirrors [`discover_topic_schema`](ZNode::discover_topic_schema): rather than
+    /// reading from the (always-empty, for services) global `SchemaRegistry`, this
+    /// finds a node currently serving `service_name` in the graph and queries that
+    /// node's own `~get_type_description` service twice — once for
+    /// `request_type_name`, once for `response_type_name`. This is the same
+    /// `GetTypeDescription` protocol topic pub/sub already relies on
+    /// (`query_type_description`); it just keys off a service's graph entity
+    /// instead of a topic's publisher list.
+    ///
+    /// Type hash validation is skipped (empty `type_hash` on the query) since the
+    /// caller here generally only has the *service's* composite hash, not the
+    /// hashes of the Request/Response types individually.
+    ///
+    /// # Arguments
+    ///
+    /// * `service_name` - The service name (qualified using the same ROS 2 rules
+    ///   as [`create_service`](ZNode::create_service)/[`create_client`](ZNode::create_client)).
+    /// * `request_type_name` - The Request type's registered schema name.
+    ///   `hiroz-codegen`-generated services register these as
+    ///   `"{pkg}/msg/{Name}Request"` (e.g.
+    ///   `"example_interfaces/msg/AddTwoIntsRequest"`) -- Request/Response are
+    ///   ordinary generated messages, not a `/srv/`-namespaced schema. See
+    ///   `hiroz_union`'s `service_request_response_type_names` helper, which
+    ///   derives this from a service's `pkg/srv/Name` type name.
+    /// * `response_type_name` - The Response type's registered schema name,
+    ///   analogous to `request_type_name` (e.g.
+    ///   `"example_interfaces/msg/AddTwoIntsResponse"`).
+    /// * `timeout` - Per-phase timeout. Applied independently to (1) the initial
+    ///   graph poll that waits for the service's liveliness entry to appear and
+    ///   (2) each of the two sequential underlying `get_type_description` calls,
+    ///   so the total worst-case latency is up to `3 * timeout` -- callers with a
+    ///   tight overall call budget should pass a short, fixed timeout here rather
+    ///   than reusing the full call timeout (see hu-meter's discovery timeout
+    ///   handling).
+    pub async fn discover_service_schema(
+        &self,
+        service_name: &str,
+        request_type_name: &str,
+        response_type_name: &str,
+        timeout: Duration,
+    ) -> std::result::Result<(Arc<MessageSchema>, Arc<MessageSchema>), DynamicError> {
+        let qualified_service =
+            crate::topic_name::qualify_service_name(service_name, self.namespace(), self.name())
+                .map_err(|error| {
+                    DynamicError::SchemaNotFound(format!("Failed to qualify service name: {error}"))
+                })?;
+
+        // The service server's liveliness token may not have reached this
+        // node's graph yet (graph population is async, independent of the
+        // caller's own setup). Poll briefly rather than failing on the first
+        // miss -- same tolerance connect_service's key-expression resolution
+        // gets implicitly via its wildcard fallback, which this lookup has no
+        // equivalent for since it needs a concrete node identity to query.
+        let poll_interval = Duration::from_millis(100);
+        let deadline = std::time::Instant::now() + timeout;
+        let node = loop {
+            let entities = self
+                .graph
+                .get_entities_by_service(EndpointKind::Service, &qualified_service);
+            let found = entities.iter().find_map(|entity| match entity.as_ref() {
+                Entity::Endpoint(endpoint) => endpoint.node.clone(),
+                _ => None,
+            });
+            match found {
+                Some(node) => break node,
+                None if std::time::Instant::now() < deadline => {
+                    tokio::time::sleep(poll_interval).await;
+                }
+                None => {
+                    return Err(DynamicError::SchemaNotFound(format!(
+                        "No service server found for: {}",
+                        qualified_service
+                    )));
+                }
+            }
+        };
+
+        let candidate = |type_name: &str| crate::dynamic::discovery::TopicSchemaCandidate {
+            node_name: node.name.clone(),
+            namespace: node.namespace.clone(),
+            type_name: type_name.to_string(),
+            type_hash: String::new(),
+        };
+
+        let (request_schema, _) = crate::dynamic::type_description_client::query_type_description(
+            self,
+            &candidate(request_type_name),
+            timeout,
+            false,
+        )
+        .await?;
+        let (response_schema, _) = crate::dynamic::type_description_client::query_type_description(
+            self,
+            &candidate(response_type_name),
+            timeout,
+            false,
+        )
+        .await?;
+
+        Ok((request_schema, response_schema))
     }
 
     /// Create a dynamic subscriber with automatic schema discovery.

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -1181,7 +1181,10 @@ impl ZNode {
             match found {
                 Some(node) => break node,
                 None if std::time::Instant::now() < deadline => {
-                    tokio::time::sleep(poll_interval).await;
+                    // Clamp the final sleep to the remaining time so the loop
+                    // never overshoots the deadline by up to poll_interval.
+                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                    tokio::time::sleep(poll_interval.min(remaining)).await;
                 }
                 None if saw_endpoint => {
                     // A server exists but exposes no node identity, so we can't

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -437,14 +437,11 @@ impl ZNode {
 
     /// Create a service for the given service name.
     ///
-    /// `T::Request` and `T::Response` must implement [`WithTypeInfo`] (enforced by
-    /// the trait bounds below). When this node's type-description service is
-    /// enabled *and* the Request/Response types carry a runtime schema (as
-    /// `hiroz-codegen`-generated ROS 2 message types do), both are registered with
-    /// that service so schema discovery (e.g. by hiroz-union's WASM plugin host)
-    /// can resolve the Request/Response schemas via live `get_type_description`
-    /// queries. Registration is therefore conditional: if the service is disabled
-    /// or a type carries no runtime schema, discovery for it will not resolve.
+    /// If the type-description service is enabled and the Request/Response types
+    /// carry a runtime schema (generated ROS 2 message types do), both are
+    /// registered with it so [`discover_service_schema`](ZNode::discover_service_schema)
+    /// can resolve them via live `get_type_description` queries; otherwise
+    /// discovery for this service won't resolve.
     ///
     /// The service name will be qualified according to ROS 2 rules:
     /// - Absolute service names (starting with '/') are used as-is
@@ -457,12 +454,9 @@ impl ZNode {
         T::Response: WithTypeInfo,
     {
         debug!("[NOD] Creating service: name={}", name);
-        // Mirror create_pub<T>'s auto-registration: if the Request/Response types
-        // carry a runtime schema (generated ROS 2 message types do), register both
-        // with this node's type description service so `discover_service_schema`
-        // (used by hiroz-union's WASM plugin host, among others) can resolve them
-        // via live `get_type_description` queries instead of requiring callers to
-        // pre-populate the (otherwise-unpopulated) global SchemaRegistry.
+        // Mirror create_pub<T>'s auto-registration so discover_service_schema can
+        // resolve Request/Response via get_type_description instead of the
+        // (otherwise-empty) global SchemaRegistry.
         if let Some(schema) = T::Request::message_schema() {
             self.register_schema_with_type_description_service(&schema);
         }
@@ -1114,40 +1108,22 @@ impl ZNode {
 
     /// Resolve a service's request and response schemas via live discovery.
     ///
-    /// Mirrors [`discover_topic_schema`](ZNode::discover_topic_schema): rather than
-    /// reading from the (always-empty, for services) global `SchemaRegistry`, this
-    /// finds a node currently serving `service_name` in the graph and queries that
-    /// node's own `~get_type_description` service twice — once for
-    /// `request_type_name`, once for `response_type_name`. This is the same
-    /// `GetTypeDescription` protocol topic pub/sub already relies on
-    /// (`query_type_description`); it just keys off a service's graph entity
-    /// instead of a topic's publisher list.
-    ///
-    /// Type hash validation is skipped (empty `type_hash` on the query) since the
-    /// caller here generally only has the *service's* composite hash, not the
-    /// hashes of the Request/Response types individually.
+    /// Service analogue of [`discover_topic_schema`](ZNode::discover_topic_schema):
+    /// finds a node serving `service_name` in the graph and queries its
+    /// `~get_type_description` service for `request_type_name` and
+    /// `response_type_name`. Type-hash validation is skipped (the caller usually
+    /// only has the service's composite hash, not the per-type hashes).
     ///
     /// # Arguments
     ///
-    /// * `service_name` - The service name (qualified using the same ROS 2 rules
-    ///   as [`create_service`](ZNode::create_service)/[`create_client`](ZNode::create_client)).
-    /// * `request_type_name` - The Request type's registered schema name.
-    ///   `hiroz-codegen`-generated services register these as
-    ///   `"{pkg}/msg/{Name}Request"` (e.g.
-    ///   `"example_interfaces/msg/AddTwoIntsRequest"`) -- Request/Response are
-    ///   ordinary generated messages, not a `/srv/`-namespaced schema. See
-    ///   `hiroz_union`'s `service_request_response_type_names` helper, which
-    ///   derives this from a service's `pkg/srv/Name` type name.
-    /// * `response_type_name` - The Response type's registered schema name,
-    ///   analogous to `request_type_name` (e.g.
-    ///   `"example_interfaces/msg/AddTwoIntsResponse"`).
-    /// * `timeout` - Per-phase timeout. Applied independently to (1) the initial
-    ///   graph poll that waits for the service's liveliness entry to appear and
-    ///   (2) each of the two sequential underlying `get_type_description` calls,
-    ///   so the total worst-case latency is up to `3 * timeout` -- callers with a
-    ///   tight overall call budget should pass a short, fixed timeout here rather
-    ///   than reusing the full call timeout (see hu-meter's discovery timeout
-    ///   handling).
+    /// * `service_name` - Qualified per the same ROS 2 rules as
+    ///   [`create_service`](ZNode::create_service)/[`create_client`](ZNode::create_client).
+    /// * `request_type_name` / `response_type_name` - The Request/Response schema
+    ///   names, which codegen registers as `"{pkg}/msg/{Name}Request"` /
+    ///   `"{pkg}/msg/{Name}Response"` (e.g. `"example_interfaces/msg/AddTwoIntsRequest"`),
+    ///   not `/srv/`-namespaced. See hiroz-union's `service_request_response_type_names`.
+    /// * `timeout` - Per-phase: applied independently to the graph poll and each of
+    ///   the two sequential `get_type_description` calls, so worst-case is `3 * timeout`.
     pub async fn discover_service_schema(
         &self,
         service_name: &str,
@@ -1161,12 +1137,9 @@ impl ZNode {
                     DynamicError::SchemaNotFound(format!("Failed to qualify service name: {error}"))
                 })?;
 
-        // The service server's liveliness token may not have reached this
-        // node's graph yet (graph population is async, independent of the
-        // caller's own setup). Poll briefly rather than failing on the first
-        // miss -- same tolerance connect_service's key-expression resolution
-        // gets implicitly via its wildcard fallback, which this lookup has no
-        // equivalent for since it needs a concrete node identity to query.
+        // The server's liveliness token may not have reached our graph yet
+        // (async population); poll briefly rather than failing on the first miss,
+        // since we need a concrete node identity to query.
         let poll_interval = Duration::from_millis(100);
         let deadline = std::time::Instant::now() + timeout;
         let node = loop {

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -1116,14 +1116,13 @@ impl ZNode {
     ///
     /// # Arguments
     ///
-    /// * `service_name` - Qualified per the same ROS 2 rules as
+    /// * `service_name` — qualified per the same rules as
     ///   [`create_service`](ZNode::create_service)/[`create_client`](ZNode::create_client).
-    /// * `request_type_name` / `response_type_name` - The Request/Response schema
-    ///   names, which codegen registers as `"{pkg}/msg/{Name}Request"` /
-    ///   `"{pkg}/msg/{Name}Response"` (e.g. `"example_interfaces/msg/AddTwoIntsRequest"`),
-    ///   not `/srv/`-namespaced. See hiroz-union's `service_request_response_type_names`.
-    /// * `timeout` - Per-phase: applied independently to the graph poll and each of
-    ///   the two sequential `get_type_description` calls, so worst-case is `3 * timeout`.
+    /// * `request_type_name` / `response_type_name` — the `msg`-namespaced schema
+    ///   names codegen registers, e.g. `example_interfaces/msg/AddTwoIntsRequest`
+    ///   (not `/srv/`-namespaced).
+    /// * `timeout` — applied per phase (the graph wait, then each of the two
+    ///   `get_type_description` calls), so worst-case is `3 * timeout`.
     pub async fn discover_service_schema(
         &self,
         service_name: &str,
@@ -1137,47 +1136,44 @@ impl ZNode {
                     DynamicError::SchemaNotFound(format!("Failed to qualify service name: {error}"))
                 })?;
 
-        // The server's liveliness token may not have reached our graph yet
-        // (async population); poll briefly rather than failing on the first miss,
-        // since we need a concrete node identity to query.
-        let poll_interval = Duration::from_millis(100);
-        let deadline = std::time::Instant::now() + timeout;
-        let node = loop {
-            let entities = self
-                .graph
-                .get_entities_by_service(EndpointKind::Service, &qualified_service);
-            let mut saw_endpoint = false;
-            let found = entities.iter().find_map(|entity| match entity.as_ref() {
-                Entity::Endpoint(endpoint) => {
-                    saw_endpoint = true;
-                    endpoint.node.clone()
-                }
-                _ => None,
-            });
-            match found {
-                Some(node) => break node,
-                None if std::time::Instant::now() < deadline => {
-                    // Clamp the final sleep to the remaining time so the loop
-                    // never overshoots the deadline by up to poll_interval.
-                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-                    tokio::time::sleep(poll_interval.min(remaining)).await;
-                }
-                None if saw_endpoint => {
-                    // A server exists but exposes no node identity, so we can't
-                    // issue the node-scoped type-description query. Distinguish
-                    // this from a genuinely absent server for easier debugging.
-                    return Err(DynamicError::SchemaNotFound(format!(
-                        "Service server(s) for {} are present but expose no node \
-                         identity; cannot query their schema",
-                        qualified_service
-                    )));
-                }
-                None => {
-                    return Err(DynamicError::SchemaNotFound(format!(
-                        "No service server found for: {}",
-                        qualified_service
-                    )));
-                }
+        // A serving node's liveliness token may not have reached our graph yet;
+        // wait (event-driven) for a service server that exposes a node identity —
+        // we need a concrete node to query for the type description.
+        self.graph
+            .wait_until(timeout, |g| {
+                g.get_entities_by_service(EndpointKind::Service, &qualified_service)
+                    .iter()
+                    .any(|e| matches!(e.as_ref(), Entity::Endpoint(ep) if ep.node.is_some()))
+            })
+            .await;
+
+        // Re-read once to extract the node, distinguishing "present but no node
+        // identity" from "no server at all" for a clearer error.
+        let entities = self
+            .graph
+            .get_entities_by_service(EndpointKind::Service, &qualified_service);
+        let mut saw_endpoint = false;
+        let found = entities.iter().find_map(|entity| match entity.as_ref() {
+            Entity::Endpoint(endpoint) => {
+                saw_endpoint = true;
+                endpoint.node.clone()
+            }
+            _ => None,
+        });
+        let node = match found {
+            Some(node) => node,
+            None if saw_endpoint => {
+                return Err(DynamicError::SchemaNotFound(format!(
+                    "Service server(s) for {} are present but expose no node \
+                     identity; cannot query their schema",
+                    qualified_service
+                )));
+            }
+            None => {
+                return Err(DynamicError::SchemaNotFound(format!(
+                    "No service server found for: {}",
+                    qualified_service
+                )));
             }
         };
 

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -438,10 +438,13 @@ impl ZNode {
     /// Create a service for the given service name.
     ///
     /// `T::Request` and `T::Response` must implement [`WithTypeInfo`] (enforced by
-    /// the trait bounds below). Type information is always populated with this
-    /// node's type-description service so schema discovery (e.g. by hiroz-union's
-    /// WASM plugin host) can resolve the Request/Response schemas via live
-    /// `get_type_description` queries.
+    /// the trait bounds below). When this node's type-description service is
+    /// enabled *and* the Request/Response types carry a runtime schema (as
+    /// `hiroz-codegen`-generated ROS 2 message types do), both are registered with
+    /// that service so schema discovery (e.g. by hiroz-union's WASM plugin host)
+    /// can resolve the Request/Response schemas via live `get_type_description`
+    /// queries. Registration is therefore conditional: if the service is disabled
+    /// or a type carries no runtime schema, discovery for it will not resolve.
     ///
     /// The service name will be qualified according to ROS 2 rules:
     /// - Absolute service names (starting with '/') are used as-is

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -1170,14 +1170,28 @@ impl ZNode {
             let entities = self
                 .graph
                 .get_entities_by_service(EndpointKind::Service, &qualified_service);
+            let mut saw_endpoint = false;
             let found = entities.iter().find_map(|entity| match entity.as_ref() {
-                Entity::Endpoint(endpoint) => endpoint.node.clone(),
+                Entity::Endpoint(endpoint) => {
+                    saw_endpoint = true;
+                    endpoint.node.clone()
+                }
                 _ => None,
             });
             match found {
                 Some(node) => break node,
                 None if std::time::Instant::now() < deadline => {
                     tokio::time::sleep(poll_interval).await;
+                }
+                None if saw_endpoint => {
+                    // A server exists but exposes no node identity, so we can't
+                    // issue the node-scoped type-description query. Distinguish
+                    // this from a genuinely absent server for easier debugging.
+                    return Err(DynamicError::SchemaNotFound(format!(
+                        "Service server(s) for {} are present but expose no node \
+                         identity; cannot query their schema",
+                        qualified_service
+                    )));
                 }
                 None => {
                     return Err(DynamicError::SchemaNotFound(format!(

--- a/crates/hiroz/src/parameter/service.rs
+++ b/crates/hiroz/src/parameter/service.rs
@@ -45,6 +45,11 @@ pub(crate) struct ParameterServiceConfig<'a> {
     pub counter: &'a GlobalCounter,
     pub clock: &'a crate::time::ZClock,
     pub overrides: HashMap<String, ParameterValue>,
+    /// This node's type description service, if enabled. When present, the six
+    /// built-in parameter services' Request/Response schemas are registered
+    /// with it so `ZNode::discover_service_schema` can resolve them (see
+    /// `wire_types::register_parameter_schemas`).
+    pub type_desc_service: Option<&'a crate::dynamic::TypeDescriptionService>,
 }
 
 struct ParameterState {
@@ -263,7 +268,12 @@ impl ParameterService {
             counter,
             clock,
             overrides,
+            type_desc_service,
         } = config;
+
+        if let Some(tds) = type_desc_service {
+            wire_types::register_parameter_schemas(tds);
+        }
         let node_entity = NodeEntity::new(
             0,
             session.zid(),

--- a/crates/hiroz/src/parameter/wire_types.rs
+++ b/crates/hiroz/src/parameter/wire_types.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::ServiceTypeInfo;
 use crate::ZBuf;
+use crate::dynamic::{FieldType, MessageSchema, TypeDescriptionService};
 use crate::entity::{TypeHash, TypeInfo};
 use crate::msg::{SerdeCdrSerdes, ZMessage, ZService};
 
@@ -380,4 +381,230 @@ impl ZMessage for SetParametersAtomicallyResponse {
 }
 impl ZMessage for WireParameterEvent {
     type Serdes = SerdeCdrSerdes<Self>;
+}
+
+// ============================================================================
+// Type-description-service schema registration
+// ============================================================================
+//
+// Unlike codegen'd message/service types (whose `create_pub`/`create_service`
+// callers auto-register a runtime schema via `MessageTypeInfo::message_schema`),
+// these rcl_interfaces wire types are hand-written and don't implement
+// `MessageTypeInfo` at all -- and `ParameterService` builds its `ZServer`s
+// directly rather than through `ZNode::create_service`, so there's no generic
+// hook that would register them either way. Every hiroz node declares these
+// six parameter services implicitly, so without an explicit registration here
+// `ZNode::discover_service_schema` (and anything else that queries
+// `~get_type_description` for one of these types) always fails with
+// "not registered" -- this is the concrete manifestation of the schema-registry
+// gap for the built-in parameter/description services (as opposed to
+// user-defined services, which get registered automatically via the
+// `create_service<T>` auto-registration path).
+//
+// Type names follow the same `{pkg}/msg/{Name}Request`/`{pkg}/msg/{Name}Response`
+// convention `hiroz-codegen` uses for generated service Request/Response types
+// (see `hiroz-codegen`'s `parser/srv.rs` + `generator/rust.rs`), so a discovery
+// query built from a service's `pkg/srv/Name` type name resolves the same way
+// for both codegen'd and built-in services.
+
+fn floating_point_range_schema()
+-> std::result::Result<std::sync::Arc<MessageSchema>, crate::dynamic::DynamicError> {
+    MessageSchema::builder("rcl_interfaces/msg/FloatingPointRange")
+        .field("from_value", FieldType::Float64)
+        .field("to_value", FieldType::Float64)
+        .field("step", FieldType::Float64)
+        .build()
+}
+
+fn integer_range_schema()
+-> std::result::Result<std::sync::Arc<MessageSchema>, crate::dynamic::DynamicError> {
+    MessageSchema::builder("rcl_interfaces/msg/IntegerRange")
+        .field("from_value", FieldType::Int64)
+        .field("to_value", FieldType::Int64)
+        .field("step", FieldType::Uint64)
+        .build()
+}
+
+fn parameter_value_schema()
+-> std::result::Result<std::sync::Arc<MessageSchema>, crate::dynamic::DynamicError> {
+    MessageSchema::builder("rcl_interfaces/msg/ParameterValue")
+        .field("type", FieldType::Uint8)
+        .field("bool_value", FieldType::Bool)
+        .field("integer_value", FieldType::Int64)
+        .field("double_value", FieldType::Float64)
+        .field("string_value", FieldType::String)
+        .field(
+            "byte_array_value",
+            FieldType::Sequence(Box::new(FieldType::Uint8)),
+        )
+        .field(
+            "bool_array_value",
+            FieldType::Sequence(Box::new(FieldType::Bool)),
+        )
+        .field(
+            "integer_array_value",
+            FieldType::Sequence(Box::new(FieldType::Int64)),
+        )
+        .field(
+            "double_array_value",
+            FieldType::Sequence(Box::new(FieldType::Float64)),
+        )
+        .field(
+            "string_array_value",
+            FieldType::Sequence(Box::new(FieldType::String)),
+        )
+        .build()
+}
+
+fn parameter_schema()
+-> std::result::Result<std::sync::Arc<MessageSchema>, crate::dynamic::DynamicError> {
+    let value = parameter_value_schema()?;
+    MessageSchema::builder("rcl_interfaces/msg/Parameter")
+        .field("name", FieldType::String)
+        .field("value", FieldType::Message(value))
+        .build()
+}
+
+fn parameter_descriptor_schema()
+-> std::result::Result<std::sync::Arc<MessageSchema>, crate::dynamic::DynamicError> {
+    let fp_range = floating_point_range_schema()?;
+    let int_range = integer_range_schema()?;
+    MessageSchema::builder("rcl_interfaces/msg/ParameterDescriptor")
+        .field("name", FieldType::String)
+        .field("type", FieldType::Uint8)
+        .field("description", FieldType::String)
+        .field("additional_constraints", FieldType::String)
+        .field("read_only", FieldType::Bool)
+        .field("dynamic_typing", FieldType::Bool)
+        .field(
+            "floating_point_range",
+            FieldType::Sequence(Box::new(FieldType::Message(fp_range))),
+        )
+        .field(
+            "integer_range",
+            FieldType::Sequence(Box::new(FieldType::Message(int_range))),
+        )
+        .build()
+}
+
+fn set_parameters_result_schema()
+-> std::result::Result<std::sync::Arc<MessageSchema>, crate::dynamic::DynamicError> {
+    MessageSchema::builder("rcl_interfaces/msg/SetParametersResult")
+        .field("successful", FieldType::Bool)
+        .field("reason", FieldType::String)
+        .build()
+}
+
+fn list_parameters_result_schema()
+-> std::result::Result<std::sync::Arc<MessageSchema>, crate::dynamic::DynamicError> {
+    MessageSchema::builder("rcl_interfaces/msg/ListParametersResult")
+        .field("names", FieldType::Sequence(Box::new(FieldType::String)))
+        .field("prefixes", FieldType::Sequence(Box::new(FieldType::String)))
+        .build()
+}
+
+/// Register the request/response schemas for all 6 built-in `rcl_interfaces`
+/// parameter services with `tds`, so `ZNode::discover_service_schema` can
+/// resolve them for this node.
+///
+/// Best-effort: schema-building failures are logged and skipped rather than
+/// failing node startup, matching `register_schema_with_type_description_service`'s
+/// existing warn-and-continue behavior for the same reason (a schema-registration
+/// failure shouldn't take down an otherwise-working node).
+pub(crate) fn register_parameter_schemas(tds: &TypeDescriptionService) {
+    let register = |result: std::result::Result<
+        std::sync::Arc<MessageSchema>,
+        crate::dynamic::DynamicError,
+    >| match result {
+        Ok(schema) => {
+            if let Err(error) = tds.register_schema(schema.clone()) {
+                tracing::warn!(
+                    "[PARAMS] Failed to register schema {} with type description service: {}",
+                    schema.type_name,
+                    error
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                "[PARAMS] Failed to build parameter service schema: {}",
+                error
+            );
+        }
+    };
+
+    let names_req = |type_name: &str| {
+        MessageSchema::builder(type_name)
+            .field("names", FieldType::Sequence(Box::new(FieldType::String)))
+            .build()
+    };
+
+    register(names_req("rcl_interfaces/msg/DescribeParametersRequest"));
+    register(parameter_descriptor_schema().and_then(|descriptor| {
+        MessageSchema::builder("rcl_interfaces/msg/DescribeParametersResponse")
+            .field(
+                "descriptors",
+                FieldType::Sequence(Box::new(FieldType::Message(descriptor))),
+            )
+            .build()
+    }));
+
+    register(names_req("rcl_interfaces/msg/GetParametersRequest"));
+    register(parameter_value_schema().and_then(|value| {
+        MessageSchema::builder("rcl_interfaces/msg/GetParametersResponse")
+            .field(
+                "values",
+                FieldType::Sequence(Box::new(FieldType::Message(value))),
+            )
+            .build()
+    }));
+
+    register(names_req("rcl_interfaces/msg/GetParameterTypesRequest"));
+    register(
+        MessageSchema::builder("rcl_interfaces/msg/GetParameterTypesResponse")
+            .field("types", FieldType::Sequence(Box::new(FieldType::Uint8)))
+            .build(),
+    );
+
+    register(
+        MessageSchema::builder("rcl_interfaces/msg/ListParametersRequest")
+            .field("prefixes", FieldType::Sequence(Box::new(FieldType::String)))
+            .field("depth", FieldType::Uint64)
+            .build(),
+    );
+    register(list_parameters_result_schema().and_then(|result| {
+        MessageSchema::builder("rcl_interfaces/msg/ListParametersResponse")
+            .field("result", FieldType::Message(result))
+            .build()
+    }));
+
+    let parameters_req = |type_name: &str| {
+        parameter_schema().and_then(|parameter| {
+            MessageSchema::builder(type_name)
+                .field(
+                    "parameters",
+                    FieldType::Sequence(Box::new(FieldType::Message(parameter))),
+                )
+                .build()
+        })
+    };
+
+    register(parameters_req("rcl_interfaces/msg/SetParametersRequest"));
+    register(set_parameters_result_schema().and_then(|result| {
+        MessageSchema::builder("rcl_interfaces/msg/SetParametersResponse")
+            .field(
+                "results",
+                FieldType::Sequence(Box::new(FieldType::Message(result))),
+            )
+            .build()
+    }));
+
+    register(parameters_req(
+        "rcl_interfaces/msg/SetParametersAtomicallyRequest",
+    ));
+    register(set_parameters_result_schema().and_then(|result| {
+        MessageSchema::builder("rcl_interfaces/msg/SetParametersAtomicallyResponse")
+            .field("result", FieldType::Message(result))
+            .build()
+    }));
 }

--- a/crates/hiroz/src/parameter/wire_types.rs
+++ b/crates/hiroz/src/parameter/wire_types.rs
@@ -387,13 +387,11 @@ impl ZMessage for WireParameterEvent {
 // Type-description-service schema registration
 // ============================================================================
 //
-// These rcl_interfaces wire types are hand-written (no `MessageTypeInfo`), and
-// `ParameterService` builds its `ZServer`s directly rather than via
-// `ZNode::create_service`, so nothing auto-registers their schemas. Every hiroz
-// node has these six parameter services, so without explicit registration here
-// `ZNode::discover_service_schema` for them always fails. Type names use the same
-// `{pkg}/msg/{Name}Request`/`Response` convention as codegen'd services, so
-// discovery resolves both the same way.
+// These wire types are hand-written (no `MessageTypeInfo`) and `ParameterService`
+// builds its `ZServer`s directly, bypassing `ZNode::create_service`'s
+// auto-registration. Without explicit registration here, `discover_service_schema`
+// can't resolve the six built-in parameter services every hiroz node exposes.
+// Names follow codegen's `{pkg}/msg/{Name}Request`/`Response` convention.
 
 fn floating_point_range_schema()
 -> std::result::Result<std::sync::Arc<MessageSchema>, crate::dynamic::DynamicError> {
@@ -464,13 +462,15 @@ fn parameter_descriptor_schema()
         .field("additional_constraints", FieldType::String)
         .field("read_only", FieldType::Bool)
         .field("dynamic_typing", FieldType::Bool)
+        // `[<=1]` in the real message, not unbounded — register as bounded so
+        // GetTypeDescription reports the true constraint.
         .field(
             "floating_point_range",
-            FieldType::Sequence(Box::new(FieldType::Message(fp_range))),
+            FieldType::BoundedSequence(Box::new(FieldType::Message(fp_range)), 1),
         )
         .field(
             "integer_range",
-            FieldType::Sequence(Box::new(FieldType::Message(int_range))),
+            FieldType::BoundedSequence(Box::new(FieldType::Message(int_range)), 1),
         )
         .build()
 }

--- a/crates/hiroz/src/parameter/wire_types.rs
+++ b/crates/hiroz/src/parameter/wire_types.rs
@@ -387,25 +387,13 @@ impl ZMessage for WireParameterEvent {
 // Type-description-service schema registration
 // ============================================================================
 //
-// Unlike codegen'd message/service types (whose `create_pub`/`create_service`
-// callers auto-register a runtime schema via `MessageTypeInfo::message_schema`),
-// these rcl_interfaces wire types are hand-written and don't implement
-// `MessageTypeInfo` at all -- and `ParameterService` builds its `ZServer`s
-// directly rather than through `ZNode::create_service`, so there's no generic
-// hook that would register them either way. Every hiroz node declares these
-// six parameter services implicitly, so without an explicit registration here
-// `ZNode::discover_service_schema` (and anything else that queries
-// `~get_type_description` for one of these types) always fails with
-// "not registered" -- this is the concrete manifestation of the schema-registry
-// gap for the built-in parameter/description services (as opposed to
-// user-defined services, which get registered automatically via the
-// `create_service<T>` auto-registration path).
-//
-// Type names follow the same `{pkg}/msg/{Name}Request`/`{pkg}/msg/{Name}Response`
-// convention `hiroz-codegen` uses for generated service Request/Response types
-// (see `hiroz-codegen`'s `parser/srv.rs` + `generator/rust.rs`), so a discovery
-// query built from a service's `pkg/srv/Name` type name resolves the same way
-// for both codegen'd and built-in services.
+// These rcl_interfaces wire types are hand-written (no `MessageTypeInfo`), and
+// `ParameterService` builds its `ZServer`s directly rather than via
+// `ZNode::create_service`, so nothing auto-registers their schemas. Every hiroz
+// node has these six parameter services, so without explicit registration here
+// `ZNode::discover_service_schema` for them always fails. Type names use the same
+// `{pkg}/msg/{Name}Request`/`Response` convention as codegen'd services, so
+// discovery resolves both the same way.
 
 fn floating_point_range_schema()
 -> std::result::Result<std::sync::Arc<MessageSchema>, crate::dynamic::DynamicError> {
@@ -534,10 +522,8 @@ fn list_parameters_result_schema()
 /// parameter services with `tds`, so `ZNode::discover_service_schema` can
 /// resolve them for this node.
 ///
-/// Best-effort: schema-building failures are logged and skipped rather than
-/// failing node startup, matching `register_schema_with_type_description_service`'s
-/// existing warn-and-continue behavior for the same reason (a schema-registration
-/// failure shouldn't take down an otherwise-working node).
+/// Best-effort: build/registration failures are logged and skipped rather than
+/// failing node startup (matches `register_schema_with_type_description_service`).
 pub(crate) fn register_parameter_schemas(tds: &TypeDescriptionService) {
     let register = |result: std::result::Result<
         std::sync::Arc<MessageSchema>,

--- a/crates/hiroz/src/parameter/wire_types.rs
+++ b/crates/hiroz/src/parameter/wire_types.rs
@@ -487,6 +487,33 @@ fn parameter_descriptor_schema()
         .build()
 }
 
+/// Schema for the `rcl_interfaces/msg/ParameterEvent` message that is
+/// implicitly published on `/parameter_events` by every parameterized node.
+fn parameter_event_schema()
+-> std::result::Result<std::sync::Arc<MessageSchema>, crate::dynamic::DynamicError> {
+    let parameter = parameter_schema()?;
+    let stamp = MessageSchema::builder("builtin_interfaces/msg/Time")
+        .field("sec", FieldType::Int32)
+        .field("nanosec", FieldType::Uint32)
+        .build()?;
+    MessageSchema::builder("rcl_interfaces/msg/ParameterEvent")
+        .field("stamp", FieldType::Message(stamp))
+        .field("node", FieldType::String)
+        .field(
+            "new_parameters",
+            FieldType::Sequence(Box::new(FieldType::Message(parameter.clone()))),
+        )
+        .field(
+            "changed_parameters",
+            FieldType::Sequence(Box::new(FieldType::Message(parameter.clone()))),
+        )
+        .field(
+            "deleted_parameters",
+            FieldType::Sequence(Box::new(FieldType::Message(parameter))),
+        )
+        .build()
+}
+
 fn set_parameters_result_schema()
 -> std::result::Result<std::sync::Arc<MessageSchema>, crate::dynamic::DynamicError> {
     MessageSchema::builder("rcl_interfaces/msg/SetParametersResult")
@@ -607,4 +634,8 @@ pub(crate) fn register_parameter_schemas(tds: &TypeDescriptionService) {
             .field("result", FieldType::Message(result))
             .build()
     }));
+
+    // The implicitly-published `/parameter_events` topic
+    // (`rcl_interfaces/msg/ParameterEvent`).
+    register(parameter_event_schema());
 }


### PR DESCRIPTION
## Summary
Adds live service-schema discovery so callers (hiroz-union's WASM plugin host) can resolve a service's Request/Response schemas at runtime, and makes those schemas discoverable via `GetTypeDescription` for both user-defined and built-in parameter services.

## Key changes
- `ZNode::discover_service_schema`: service analogue of `discover_topic_schema` — waits (event-driven, via `Graph::wait_until`) for a serving node to appear in the graph, then queries its `~get_type_description` for the Request/Response type names, bounded by `timeout`.
- `ZNode::create_service<T>`: auto-registers Request/Response runtime schemas with the type-description service (adds `T::Request/Response: WithTypeInfo` bounds).
- `parameter/`: register the 6 built-in `rcl_interfaces` parameter services' (and `ParameterEvent`'s) schemas with the node's type-description service, since these hand-written wire types bypass the generic `create_service` registration path. `ParameterDescriptor`'s `floating_point_range`/`integer_range` are registered as `BoundedSequence[<=1]` to match the real message.
- `Graph::has_external_entity` + `wait_for_external_settled`: a settle barrier for one-shot `hu` commands that ignores the process's own echoed liveliness tokens.
- Adds a no-server discovery-timeout test asserting `discover_service_schema` waits out the timeout (within a small margin) and returns `SchemaNotFound` rather than hanging.

## Breaking changes
`ZNode::create_service<T>` gains `T::Request: WithTypeInfo` / `T::Response: WithTypeInfo` bounds — callers whose service types don't satisfy these (hand-written `ZService` types that don't `impl WithTypeInfo`) will no longer compile. All in-tree call sites use codegen'd types, which implement it automatically.
