### PR TITLE
test(hiroz-tests): signal-based producer guard + graph-poll waits (hu stack 4/9)

### DIFF
--- a/crates/hiroz-tests/tests/common/mod.rs
+++ b/crates/hiroz-tests/tests/common/mod.rs
@@ -138,8 +138,17 @@ impl TestRouter {
                     // sleep and usually proceeds much sooner; if the budget
                     // elapses without a successful connect, proceed anyway
                     // (best-effort).
+                    let probe_addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
                     for _ in 0..40 {
-                        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                        // connect_timeout caps each probe at 50ms; a plain
+                        // TcpStream::connect could block far longer on the OS
+                        // connect timeout and blow the ~2s budget.
+                        if std::net::TcpStream::connect_timeout(
+                            &probe_addr,
+                            Duration::from_millis(50),
+                        )
+                        .is_ok()
+                        {
                             break;
                         }
                         thread::sleep(Duration::from_millis(50));

--- a/crates/hiroz-tests/tests/common/mod.rs
+++ b/crates/hiroz-tests/tests/common/mod.rs
@@ -453,8 +453,32 @@ impl Drop for ProducerGuard {
         // immediately (no lingering 40s hold, no reconnect-spin), and the
         // teardown completes in the background (or is reaped at process exit).
         self.stop.store(true, Ordering::Relaxed);
-        // Drop the JoinHandle without joining, detaching the thread.
-        self.handle.take();
+        if let Some(handle) = self.handle.take() {
+            // A well-behaved producer is still running (holding its entities)
+            // right up until we set `stop`, so it will normally NOT be finished
+            // here. If it *is* already finished, the producer exited early —
+            // typically a panic — which would otherwise be swallowed silently and
+            // make a later "entity never appeared" failure baffling. Since the
+            // thread is finished, `join()` returns immediately (still
+            // non-blocking), so we can observe and surface the panic.
+            if handle.is_finished() {
+                if let Err(panic) = handle.join() {
+                    let msg = panic
+                        .downcast_ref::<&str>()
+                        .map(|s| s.to_string())
+                        .or_else(|| panic.downcast_ref::<String>().cloned())
+                        .unwrap_or_else(|| "<non-string panic payload>".to_string());
+                    eprintln!(
+                        "WARNING: test producer thread exited early (before teardown) \
+                         with a panic: {msg}. Downstream 'entity not discovered' \
+                         failures in this test are likely caused by this."
+                    );
+                }
+            }
+            // Otherwise: drop the JoinHandle without joining, detaching the
+            // still-running thread (its Zenoh-session teardown can block, and we
+            // must not block the test thread on it).
+        }
     }
 }
 

--- a/crates/hiroz-tests/tests/common/mod.rs
+++ b/crates/hiroz-tests/tests/common/mod.rs
@@ -418,9 +418,11 @@ pub fn spawn_python_service_client(
 
 /// A background producer kept alive for exactly the lifetime of this guard.
 ///
-/// On drop it flips a stop flag and joins the producer thread, which drops all
-/// held Zenoh entities (and their session) cleanly. Prefer this over a detached
-/// thread that sleeps a fixed duration: too short a sleep lets the entity vanish
+/// On drop it flips a stop flag and detaches the producer thread (no join, so a
+/// producer wedged in a blocking recv can't hang teardown); the thread drops all
+/// held Zenoh entities (and their session) cleanly once it observes the flag.
+/// Prefer this over a detached thread that sleeps a fixed duration: too short a
+/// sleep lets the entity vanish
 /// before `hu` reads it; too long leaves the producer's client session
 /// reconnect-spinning after the test's `TestRouter` drops, stealing CPU from
 /// later serial tests. Here the hold is exactly the test's scope — no guessed

--- a/crates/hiroz-tests/tests/common/mod.rs
+++ b/crates/hiroz-tests/tests/common/mod.rs
@@ -133,16 +133,13 @@ impl TestRouter {
 
             match zenoh::open(config).wait() {
                 Ok(session) => {
-                    // Poll until the router's TCP listener accepts a connection,
-                    // up to a ~2s budget (40 * 50ms). This replaces a blind fixed
-                    // sleep and usually proceeds much sooner; if the budget
-                    // elapses without a successful connect, proceed anyway
-                    // (best-effort).
+                    // Poll the router's TCP listener (40 * 50ms, ~2s budget)
+                    // instead of a blind fixed sleep; proceed anyway if it
+                    // never accepts (best-effort).
                     let probe_addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
                     for _ in 0..40 {
-                        // connect_timeout caps each probe at 50ms; a plain
-                        // TcpStream::connect could block far longer on the OS
-                        // connect timeout and blow the ~2s budget.
+                        // connect_timeout caps each probe at 50ms; plain connect
+                        // could block on the OS timeout and blow the budget.
                         if std::net::TcpStream::connect_timeout(
                             &probe_addr,
                             Duration::from_millis(50),
@@ -153,10 +150,8 @@ impl TestRouter {
                         }
                         thread::sleep(Duration::from_millis(50));
                     }
-                    // TCP-accept only proves the listener is bound; the zenoh
-                    // router may still be finishing its routing/liveliness init.
-                    // A short floor (far below the old blind 500ms) covers that
-                    // window without paying the full fixed cost on every test.
+                    // TCP-accept only proves the listener is bound; short floor
+                    // covers the router's remaining routing/liveliness init.
                     thread::sleep(Duration::from_millis(150));
                     println!("Zenoh router ready on {}", endpoint);
                     return Self {
@@ -425,17 +420,13 @@ pub fn spawn_python_service_client(
     ProcessGuard::new(child, "python_service_client")
 }
 
-/// A background producer kept alive for exactly the lifetime of this guard.
-///
-/// On drop it flips a stop flag and detaches the producer thread (no join, so a
-/// producer wedged in a blocking recv can't hang teardown); the thread drops all
-/// held Zenoh entities (and their session) cleanly once it observes the flag.
-/// Prefer this over a detached thread that sleeps a fixed duration: too short a
-/// sleep lets the entity vanish
-/// before `hu` reads it; too long leaves the producer's client session
-/// reconnect-spinning after the test's `TestRouter` drops, stealing CPU from
-/// later serial tests. Here the hold is exactly the test's scope — no guessed
-/// duration.
+/// Holds a background producer (Zenoh entities) alive for exactly this guard's
+/// lifetime. On drop it sets a stop flag and detaches the thread (no join, so a
+/// producer blocked in recv can't hang teardown); the thread then drops its
+/// entities and session. Preferred over a fixed-duration sleep: too short and
+/// the entity vanishes before `hu` reads it; too long and the producer's client
+/// session reconnect-spins after `TestRouter` drops, stealing CPU from later
+/// serial tests.
 #[allow(dead_code)]
 #[must_use = "binding must be kept alive (e.g. `let _producer = ...`); dropping it immediately tears the producer down"]
 pub struct ProducerGuard {
@@ -445,22 +436,15 @@ pub struct ProducerGuard {
 
 impl Drop for ProducerGuard {
     fn drop(&mut self) {
-        // Signal the producer to stop holding; it then exits its loop and drops
-        // its entities + Zenoh session on its own thread. We deliberately do NOT
-        // join: dropping a Zenoh session can block (async close during Tokio
-        // runtime teardown), and blocking the test thread on that risks a hang.
-        // Detaching is enough for the goal — the producer stops its active work
-        // immediately (no lingering 40s hold, no reconnect-spin), and the
-        // teardown completes in the background (or is reaped at process exit).
+        // Signal stop, then detach: dropping a Zenoh session can block (async
+        // close during Tokio teardown), so joining here risks hanging the test
+        // thread. Detaching still stops the producer's active work immediately.
         self.stop.store(true, Ordering::Relaxed);
         if let Some(handle) = self.handle.take() {
-            // A well-behaved producer is still running (holding its entities)
-            // right up until we set `stop`, so it will normally NOT be finished
-            // here. If it *is* already finished, the producer exited early —
-            // typically a panic — which would otherwise be swallowed silently and
-            // make a later "entity never appeared" failure baffling. Since the
-            // thread is finished, `join()` returns immediately (still
-            // non-blocking), so we can observe and surface the panic.
+            // Normally still running until we set `stop`. If already finished,
+            // the producer exited early (usually a panic) — surface it: join()
+            // on a finished thread returns immediately, and the panic would
+            // otherwise be swallowed and misdiagnosed as "entity never appeared".
             if handle.is_finished()
                 && let Err(panic) = handle.join()
             {
@@ -475,20 +459,17 @@ impl Drop for ProducerGuard {
                      failures in this test are likely caused by this."
                 );
             }
-            // Otherwise: drop the JoinHandle without joining, detaching the
-            // still-running thread (its Zenoh-session teardown can block, and we
-            // must not block the test thread on it).
+            // Otherwise detach: the still-running thread's session teardown can
+            // block, and must not block the test thread.
         }
     }
 }
 
-/// Spawn a producer running `body` on a fresh Tokio runtime. `body` receives a
-/// stop flag it must poll: hold entities alive with
-/// `while !stop.load(Ordering::Relaxed) { tokio::time::sleep(..).await }`, or
-/// check it inside a service loop. The producer exits (dropping its entities)
-/// when the returned guard drops. `body` is `async` — it awaits rather than
-/// blocks — so any tasks it spawns (e.g. an action-server handler) keep running
-/// while it holds.
+/// Spawn a producer running `body` on a fresh Tokio runtime. `body` must poll
+/// the stop flag to hold entities alive (e.g.
+/// `while !stop.load(Ordering::Relaxed) { tokio::time::sleep(..).await }`) and
+/// exits, dropping them, when the returned guard drops. `body` is async, so
+/// tasks it spawns (e.g. an action-server handler) keep running while it holds.
 #[allow(dead_code)]
 pub fn spawn_producer<Fut>(
     body: impl FnOnce(Arc<AtomicBool>) -> Fut + Send + 'static,

--- a/crates/hiroz-tests/tests/common/mod.rs
+++ b/crates/hiroz-tests/tests/common/mod.rs
@@ -212,6 +212,34 @@ pub fn wait_for_ready(duration: Duration) {
     thread::sleep(duration);
 }
 
+/// Wait until a ROS node named `node_name` is visible in the graph, or `timeout`
+/// elapses. Deterministic replacement for a blind `wait_for_ready` sleep before
+/// interacting with a just-spawned node: it returns as soon as the node is
+/// discoverable (proceeds early on the fast path) instead of always sleeping a
+/// fixed time. Returns whether the node appeared — callers may proceed either
+/// way, since the following operation carries its own discovery timeout.
+#[allow(dead_code)]
+pub fn wait_for_ros_node(node_name: &str, router: &TestRouter, timeout: Duration) -> bool {
+    let ctx = create_hiroz_context_with_router(router).expect("Failed to create probe context");
+    let start = std::time::Instant::now();
+    loop {
+        if ctx
+            .graph()
+            .get_node_names()
+            .iter()
+            .any(|(name, _ns)| name == node_name)
+        {
+            println!("Node '{node_name}' discovered after {:?}", start.elapsed());
+            return true;
+        }
+        if start.elapsed() >= timeout {
+            eprintln!("Node '{node_name}' not visible after {timeout:?}; proceeding");
+            return false;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
 /// Deterministically wait for a service to be ready by polling with test requests
 #[allow(dead_code)]
 pub fn wait_for_service_ready(

--- a/crates/hiroz-tests/tests/common/mod.rs
+++ b/crates/hiroz-tests/tests/common/mod.rs
@@ -461,19 +461,19 @@ impl Drop for ProducerGuard {
             // make a later "entity never appeared" failure baffling. Since the
             // thread is finished, `join()` returns immediately (still
             // non-blocking), so we can observe and surface the panic.
-            if handle.is_finished() {
-                if let Err(panic) = handle.join() {
-                    let msg = panic
-                        .downcast_ref::<&str>()
-                        .map(|s| s.to_string())
-                        .or_else(|| panic.downcast_ref::<String>().cloned())
-                        .unwrap_or_else(|| "<non-string panic payload>".to_string());
-                    eprintln!(
-                        "WARNING: test producer thread exited early (before teardown) \
-                         with a panic: {msg}. Downstream 'entity not discovered' \
-                         failures in this test are likely caused by this."
-                    );
-                }
+            if handle.is_finished()
+                && let Err(panic) = handle.join()
+            {
+                let msg = panic
+                    .downcast_ref::<&str>()
+                    .map(|s| s.to_string())
+                    .or_else(|| panic.downcast_ref::<String>().cloned())
+                    .unwrap_or_else(|| "<non-string panic payload>".to_string());
+                eprintln!(
+                    "WARNING: test producer thread exited early (before teardown) \
+                     with a panic: {msg}. Downstream 'entity not discovered' \
+                     failures in this test are likely caused by this."
+                );
             }
             // Otherwise: drop the JoinHandle without joining, detaching the
             // still-running thread (its Zenoh-session teardown can block, and we

--- a/crates/hiroz-tests/tests/common/mod.rs
+++ b/crates/hiroz-tests/tests/common/mod.rs
@@ -420,13 +420,13 @@ pub fn spawn_python_service_client(
     ProcessGuard::new(child, "python_service_client")
 }
 
-/// Holds a background producer (Zenoh entities) alive for exactly this guard's
-/// lifetime. On drop it sets a stop flag and detaches the thread (no join, so a
-/// producer blocked in recv can't hang teardown); the thread then drops its
-/// entities and session. Preferred over a fixed-duration sleep: too short and
-/// the entity vanishes before `hu` reads it; too long and the producer's client
-/// session reconnect-spins after `TestRouter` drops, stealing CPU from later
-/// serial tests.
+/// Holds a background producer (Zenoh entities) alive until this guard drops.
+/// Drop signals a stop flag and detaches the thread (no join, so a producer
+/// blocked in recv can't hang teardown) — so teardown is best-effort, not
+/// synchronous: the entities may briefly outlive the drop. Preferred over a
+/// fixed-duration sleep: too short and the entity vanishes before `hu` reads it;
+/// too long and the producer's client session reconnect-spins after `TestRouter`
+/// drops, stealing CPU from later serial tests.
 #[allow(dead_code)]
 #[must_use = "binding must be kept alive (e.g. `let _producer = ...`); dropping it immediately tears the producer down"]
 pub struct ProducerGuard {

--- a/crates/hiroz-tests/tests/common/mod.rs
+++ b/crates/hiroz-tests/tests/common/mod.rs
@@ -1,4 +1,6 @@
 use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
@@ -131,7 +133,22 @@ impl TestRouter {
 
             match zenoh::open(config).wait() {
                 Ok(session) => {
-                    thread::sleep(Duration::from_millis(500));
+                    // Poll until the router's TCP listener accepts a connection,
+                    // up to a ~2s budget (40 * 50ms). This replaces a blind fixed
+                    // sleep and usually proceeds much sooner; if the budget
+                    // elapses without a successful connect, proceed anyway
+                    // (best-effort).
+                    for _ in 0..40 {
+                        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                            break;
+                        }
+                        thread::sleep(Duration::from_millis(50));
+                    }
+                    // TCP-accept only proves the listener is bound; the zenoh
+                    // router may still be finishing its routing/liveliness init.
+                    // A short floor (far below the old blind 500ms) covers that
+                    // window without paying the full fixed cost on every test.
+                    thread::sleep(Duration::from_millis(150));
                     println!("Zenoh router ready on {}", endpoint);
                     return Self {
                         port,
@@ -397,4 +414,74 @@ pub fn spawn_python_service_client(
         .expect("Failed to spawn Python service client");
 
     ProcessGuard::new(child, "python_service_client")
+}
+
+/// A background producer kept alive for exactly the lifetime of this guard.
+///
+/// On drop it flips a stop flag and joins the producer thread, which drops all
+/// held Zenoh entities (and their session) cleanly. Prefer this over a detached
+/// thread that sleeps a fixed duration: too short a sleep lets the entity vanish
+/// before `hu` reads it; too long leaves the producer's client session
+/// reconnect-spinning after the test's `TestRouter` drops, stealing CPU from
+/// later serial tests. Here the hold is exactly the test's scope — no guessed
+/// duration.
+#[allow(dead_code)]
+#[must_use = "binding must be kept alive (e.g. `let _producer = ...`); dropping it immediately tears the producer down"]
+pub struct ProducerGuard {
+    stop: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for ProducerGuard {
+    fn drop(&mut self) {
+        // Signal the producer to stop holding; it then exits its loop and drops
+        // its entities + Zenoh session on its own thread. We deliberately do NOT
+        // join: dropping a Zenoh session can block (async close during Tokio
+        // runtime teardown), and blocking the test thread on that risks a hang.
+        // Detaching is enough for the goal — the producer stops its active work
+        // immediately (no lingering 40s hold, no reconnect-spin), and the
+        // teardown completes in the background (or is reaped at process exit).
+        self.stop.store(true, Ordering::Relaxed);
+        // Drop the JoinHandle without joining, detaching the thread.
+        self.handle.take();
+    }
+}
+
+/// Spawn a producer running `body` on a fresh Tokio runtime. `body` receives a
+/// stop flag it must poll: hold entities alive with
+/// `while !stop.load(Ordering::Relaxed) { tokio::time::sleep(..).await }`, or
+/// check it inside a service loop. The producer exits (dropping its entities)
+/// when the returned guard drops. `body` is `async` — it awaits rather than
+/// blocks — so any tasks it spawns (e.g. an action-server handler) keep running
+/// while it holds.
+#[allow(dead_code)]
+pub fn spawn_producer<Fut>(
+    body: impl FnOnce(Arc<AtomicBool>) -> Fut + Send + 'static,
+) -> ProducerGuard
+where
+    Fut: std::future::Future<Output = ()>,
+{
+    let stop = Arc::new(AtomicBool::new(false));
+    let s = stop.clone();
+    let handle = thread::spawn(move || {
+        tokio::runtime::Runtime::new().unwrap().block_on(body(s));
+    });
+    ProducerGuard {
+        stop,
+        handle: Some(handle),
+    }
+}
+
+/// Convenience for a passive producer: build entities up front, then hold them
+/// alive until the guard drops. `build` runs inside the Tokio runtime.
+#[allow(dead_code)]
+pub fn spawn_holder<T: Send + 'static>(
+    build: impl FnOnce() -> T + Send + 'static,
+) -> ProducerGuard {
+    spawn_producer(|stop| async move {
+        let _held = build();
+        while !stop.load(Ordering::Relaxed) {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
 }

--- a/crates/hiroz-tests/tests/demo_nodes.rs
+++ b/crates/hiroz-tests/tests/demo_nodes.rs
@@ -77,11 +77,11 @@ fn test_hiroz_talker_to_hiroz_listener() {
     );
 }
 
-// The RCL-spawning interop tests each launch a real `ros2 run demo_nodes_cpp`
-// C++ node. Running many concurrently oversubscribes the runner and they all
-// hit nextest's 60s hard kill at once. serial_test's in-process Mutex only
-// serializes under `cargo test` (one binary); nextest runs each test in its
-// own process, so parallelism must be capped via the runner config in CI.
+// Each RCL interop test launches a real `ros2 run demo_nodes_cpp` C++ node;
+// running many at once oversubscribes the runner and starves discovery.
+// serial_test's Mutex only serializes under `cargo test` (one binary) — nextest
+// runs each test in its own process, so parallelism is capped by the `interop`
+// profile (test-threads = 8).
 #[test]
 fn test_rcl_talker_to_hiroz_listener() {
     if !check_ros2_available() {
@@ -303,15 +303,15 @@ fn test_rcl_add_two_ints_server_to_hiroz_client() {
     wait_for_ready(Duration::from_secs(3));
 
     // Retry until the server's queryable is discovered — discovery latency, not
-    // response latency, so a longer fixed timeout doesn't help under load.
-    // Budget 40s (not the 60s kill): each attempt can block ~15s internally, so
-    // 40 + 15 = 55s < 60s keeps headroom before the hard kill.
+    // response latency, so a longer fixed timeout doesn't help under load. Cap
+    // retries at 40s to fail fast; each attempt can block ~15s internally, well
+    // clear of the interop profile's 120s kill (60s period × terminate-after 2).
     let attempt_worst_case = Duration::from_secs(15);
     let deadline = std::time::Instant::now() + Duration::from_secs(40);
     let result = loop {
         let ctx =
             create_hiroz_context_with_router(&router).expect("Failed to create hiroz context");
-        // Don't start an attempt that could run past the deadline (60s kill).
+        // Don't start an attempt that can't finish before the 40s deadline.
         let out_of_budget = std::time::Instant::now() + attempt_worst_case >= deadline;
         match demo_nodes::run_add_two_ints_client(ctx, 4, 7, false) {
             Ok(v) => break v,
@@ -325,8 +325,9 @@ fn test_rcl_add_two_ints_server_to_hiroz_client() {
                     .and_then(|c| c.try_wait().ok().flatten());
                 // Kill the server before joining readers: read_to_string blocks
                 // until EOF (child exit), so joining first would hang in the
-                // alive-but-slow case.
-                if let Some(c) = server_guard.child.as_mut() {
+                // alive-but-slow case. Take the child out of the guard so its
+                // Drop can't later re-signal this (possibly recycled) PID group.
+                if let Some(mut c) = server_guard.child.take() {
                     let _ = c.kill();
                     let _ = c.wait();
                 }
@@ -379,12 +380,13 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
     // discoverable before it starts.
     wait_for_ready(Duration::from_secs(5));
 
-    // Start RCL client
+    // Start RCL client. Null stdout — nothing reads it, and the try_wait loop
+    // below waits on the child's exit, which a full unread pipe would block.
     let client = Command::new("ros2")
         .args(["run", "demo_nodes_cpp", "add_two_ints_client"])
         .env("RMW_IMPLEMENTATION", "rmw_zenoh_cpp")
         .env("ZENOH_CONFIG_OVERRIDE", router.rmw_zenoh_env())
-        .stdout(Stdio::piped())
+        .stdout(Stdio::null())
         .stderr(Stdio::null())
         .process_group(0)
         .spawn()
@@ -395,8 +397,8 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
     // recycled PID's process group.
     let mut client_guard = ProcessGuard::new(client, "RCL add_two_ints client");
 
-    // Bound on the client's actual exit, not a fixed sleep: a slow-to-discover
-    // run fails fast instead of hanging the server thread until the hard kill.
+    // Bound on the client's actual exit (30s), not a fixed sleep: a slow-to-
+    // discover run fails with a diagnostic instead of stalling until nextest's kill.
     let client_deadline = std::time::Instant::now() + Duration::from_secs(30);
     let client_status = loop {
         let child = client_guard

--- a/crates/hiroz-tests/tests/demo_nodes.rs
+++ b/crates/hiroz-tests/tests/demo_nodes.rs
@@ -84,9 +84,9 @@ fn test_hiroz_talker_to_hiroz_listener() {
 // nextest's hard 60s kill *simultaneously* when several run concurrently --
 // the runner can't keep up with that many RCL subprocesses starting at once.
 // nextest runs each test in its own process, so serial_test's in-process
-// static Mutex is a no-op here; the `rcl-interop` test-group in
-// .config/nextest.toml limits these 6 to one at a time relative to each
-// other, without slowing down the rest of the suite.
+// static Mutex is a no-op there; it serializes them only under `cargo test`
+// (single test binary). Under nextest, keep the interop suite from
+// oversubscribing by limiting the runner's parallelism in CI.
 #[test]
 fn test_rcl_talker_to_hiroz_listener() {
     if !check_ros2_available() {
@@ -333,6 +333,14 @@ fn test_rcl_add_two_ints_server_to_hiroz_client() {
                     .child
                     .as_mut()
                     .and_then(|c| c.try_wait().ok().flatten());
+                // Terminate the server before joining the reader threads: they
+                // block on read_to_string until stdout/stderr hit EOF, which only
+                // happens once the child exits. In the alive-but-slow case (the
+                // one this diagnostic exists for) joining first would hang.
+                if let Some(c) = server_guard.child.as_mut() {
+                    let _ = c.kill();
+                    let _ = c.wait();
+                }
                 let stdout = stdout_handle.join().unwrap_or_default();
                 let stderr = stderr_handle.join().unwrap_or_default();
                 panic!(

--- a/crates/hiroz-tests/tests/demo_nodes.rs
+++ b/crates/hiroz-tests/tests/demo_nodes.rs
@@ -401,7 +401,7 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
     wait_for_ready(Duration::from_secs(5));
 
     // Start RCL client
-    let mut client = Command::new("ros2")
+    let client = Command::new("ros2")
         .args(["run", "demo_nodes_cpp", "add_two_ints_client"])
         .env("RMW_IMPLEMENTATION", "rmw_zenoh_cpp")
         .env("ZENOH_CONFIG_OVERRIDE", router.rmw_zenoh_env())
@@ -411,13 +411,24 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
         .spawn()
         .expect("Failed to start RCL client");
 
+    // Wrap the child in its ProcessGuard *before* any reaping so the guard owns
+    // it throughout. Polling `try_wait` on a separate handle and only then
+    // handing the (already-reaped) child to a fresh guard would let the guard's
+    // Drop signal a process group whose PID may have been recycled. Poll through
+    // the guard's own handle instead.
+    let mut client_guard = ProcessGuard::new(client, "RCL add_two_ints client");
+
     // Bound the wait on the RCL client's own exit instead of a fixed sleep,
     // so a slow-to-discover run fails fast with a clear message rather than
     // hanging the hiroz server thread (blocked on its one expected request)
     // until nextest's hard kill.
     let client_deadline = std::time::Instant::now() + Duration::from_secs(30);
     let client_status = loop {
-        if let Some(status) = client.try_wait().expect("Failed to poll RCL client") {
+        let child = client_guard
+            .child
+            .as_mut()
+            .expect("client child owned by guard");
+        if let Some(status) = child.try_wait().expect("Failed to poll RCL client") {
             break Some(status);
         }
         if std::time::Instant::now() >= client_deadline {
@@ -425,7 +436,6 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
         }
         thread::sleep(Duration::from_millis(200));
     };
-    let _client_guard = ProcessGuard::new(client, "RCL add_two_ints client");
     // Check the exit status is actually success, not just that the process
     // exited -- an instantly-failing `ros2 run` (e.g. missing verb plugin,
     // bad args) also "exits within 30s" and would otherwise false-pass here.

--- a/crates/hiroz-tests/tests/demo_nodes.rs
+++ b/crates/hiroz-tests/tests/demo_nodes.rs
@@ -77,6 +77,16 @@ fn test_hiroz_talker_to_hiroz_listener() {
     );
 }
 
+// These 6 tests each spawn a real `ros2 run demo_nodes_cpp ...` subprocess
+// (a full RCL/rclcpp C++ node). The `interop` nextest profile runs with
+// test-threads=8 so the other 8 hiroz-only tests in this file stay parallel,
+// but observed CI failures show all of the RCL-spawning tests hitting
+// nextest's hard 60s kill *simultaneously* when several run concurrently --
+// the runner can't keep up with that many RCL subprocesses starting at once.
+// nextest runs each test in its own process, so serial_test's in-process
+// static Mutex is a no-op here; the `rcl-interop` test-group in
+// .config/nextest.toml limits these 6 to one at a time relative to each
+// other, without slowing down the rest of the suite.
 #[test]
 fn test_rcl_talker_to_hiroz_listener() {
     if !check_ros2_available() {
@@ -94,27 +104,14 @@ fn test_rcl_talker_to_hiroz_listener() {
     let received = Arc::new(Mutex::new(Vec::new()));
     let received_clone = received.clone();
 
-    // Start hiroz listener in a thread using the example code
-    let router_endpoint = router.endpoint().to_string();
-    let listener_handle = thread::spawn(move || {
-        tokio::runtime::Runtime::new().unwrap().block_on(async {
-            let ctx = create_hiroz_context_with_endpoint(&router_endpoint)
-                .expect("Failed to create hiroz context");
-
-            // Use the actual listener example code with timeout
-            let messages =
-                demo_nodes::run_listener(ctx, "chatter", Some(3), Some(Duration::from_secs(15)))
-                    .await
-                    .expect("Listener failed");
-
-            let mut received = received_clone.lock().unwrap();
-            *received = messages;
-        });
-    });
-
-    wait_for_ready(Duration::from_secs(2));
-
-    // Start RCL talker
+    // Start the RCL talker FIRST. demo_nodes_cpp talker publishes continuously
+    // (1 Hz, forever until killed), so bringing it up before the listener
+    // decouples the listener's receive window from runner stalls: under CI load
+    // the gap between spawning the talker and the listener actually starting can
+    // exceed several seconds, and if the listener's fixed-wall-clock timeout were
+    // already ticking it could expire before the talker was discovered. Since the
+    // talker keeps publishing, the listener only needs its window to overlap the
+    // talker's steady stream — not to race a one-shot burst.
     let talker = Command::new("ros2")
         .args(["run", "demo_nodes_cpp", "talker"])
         .env("RMW_IMPLEMENTATION", "rmw_zenoh_cpp")
@@ -126,6 +123,28 @@ fn test_rcl_talker_to_hiroz_listener() {
         .expect("Failed to start RCL talker");
 
     let _talker_guard = ProcessGuard::new(talker, "RCL talker");
+
+    wait_for_ready(Duration::from_secs(5));
+
+    // Start hiroz listener in a thread using the example code. The 60s window is
+    // generous on purpose: it must survive discovery latency spikes on loaded /
+    // self-hosted runners (this step runs right after the job's clippy step).
+    let router_endpoint = router.endpoint().to_string();
+    let listener_handle = thread::spawn(move || {
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let ctx = create_hiroz_context_with_endpoint(&router_endpoint)
+                .expect("Failed to create hiroz context");
+
+            // Use the actual listener example code with timeout
+            let messages =
+                demo_nodes::run_listener(ctx, "chatter", Some(3), Some(Duration::from_secs(60)))
+                    .await
+                    .expect("Listener failed");
+
+            let mut received = received_clone.lock().unwrap();
+            *received = messages;
+        });
+    });
 
     listener_handle.join().expect("Listener thread panicked");
 
@@ -264,31 +283,65 @@ fn test_rcl_add_two_ints_server_to_hiroz_client() {
 
     println!("\n=== Test: RCL demo_nodes_cpp add_two_ints server -> hiroz client ===");
 
-    // Start RCL server
-    let server = Command::new("ros2")
+    // Start RCL server. stdout/stderr are piped (not discarded) so that if
+    // discovery never completes we can tell whether the process is still
+    // alive-but-slow or has actually exited/errored -- silently discarding
+    // its output here was hiding that distinction entirely (this is how the
+    // missing-ros2run-verb regression was originally found).
+    let mut server = Command::new("ros2")
         .args(["run", "demo_nodes_cpp", "add_two_ints_server"])
         .env("RMW_IMPLEMENTATION", "rmw_zenoh_cpp")
         .env("ZENOH_CONFIG_OVERRIDE", router.rmw_zenoh_env())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .process_group(0)
         .spawn()
         .expect("Failed to start RCL server");
 
-    let _server_guard = ProcessGuard::new(server, "RCL add_two_ints server");
+    let mut server_stdout = server.stdout.take().expect("stdout was piped");
+    let mut server_stderr = server.stderr.take().expect("stderr was piped");
+    let stdout_handle = thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = std::io::Read::read_to_string(&mut server_stdout, &mut buf);
+        buf
+    });
+    let stderr_handle = thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = std::io::Read::read_to_string(&mut server_stderr, &mut buf);
+        buf
+    });
+
+    let mut server_guard = ProcessGuard::new(server, "RCL add_two_ints server");
 
     wait_for_ready(Duration::from_secs(3));
 
-    // Start hiroz client in a thread using the example code
-    let client_handle = thread::spawn(move || -> i64 {
+    // Retry until the server's queryable is actually discovered -- same
+    // rationale as the fibonacci RCL-server test below: this is discovery
+    // latency, not response latency, so a longer fixed wait/timeout doesn't
+    // reliably help under CI load.
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    let result = loop {
         let ctx =
             create_hiroz_context_with_router(&router).expect("Failed to create hiroz context");
-
-        // Use the actual client example code
-        demo_nodes::run_add_two_ints_client(ctx, 4, 7, false).expect("Client failed")
-    });
-
-    let result = client_handle.join().expect("Client thread panicked");
+        match demo_nodes::run_add_two_ints_client(ctx, 4, 7, false) {
+            Ok(v) => break v,
+            Err(_) if std::time::Instant::now() < deadline => {
+                thread::sleep(Duration::from_millis(500));
+            }
+            Err(e) => {
+                let exit_status = server_guard
+                    .child
+                    .as_mut()
+                    .and_then(|c| c.try_wait().ok().flatten());
+                let stdout = stdout_handle.join().unwrap_or_default();
+                let stderr = stderr_handle.join().unwrap_or_default();
+                panic!(
+                    "Client failed: {e} (process exit status: {exit_status:?})\n\
+                     stdout:\n{stdout}\nstderr:\n{stderr}"
+                );
+            }
+        }
+    };
     assert_eq!(result, 11, "Expected 4 + 7 = 11");
 
     println!(
@@ -311,6 +364,8 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
 
     println!("\n=== Test: hiroz add_two_ints server -> RCL demo_nodes_cpp client ===");
 
+    let (tx, rx) = std::sync::mpsc::channel();
+
     // Start hiroz server in a thread using the example code
     let router_endpoint = router.endpoint().to_string();
     let server_handle = thread::spawn(move || {
@@ -318,13 +373,18 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
             .expect("Failed to create hiroz context");
 
         // Use the actual server example code (handle one request)
-        demo_nodes::run_add_two_ints_server(ctx, Some(1)).expect("Server failed");
+        let result = demo_nodes::run_add_two_ints_server(ctx, Some(1));
+        let _ = tx.send(()); // Signal completion
+        result.expect("Server failed");
     });
 
-    wait_for_ready(Duration::from_secs(2));
+    // Generous discovery buffer: the RCL client is a one-shot external
+    // process with no retry of its own, so the server's queryable must
+    // already be discoverable by the time it starts.
+    wait_for_ready(Duration::from_secs(5));
 
     // Start RCL client
-    let client = Command::new("ros2")
+    let mut client = Command::new("ros2")
         .args(["run", "demo_nodes_cpp", "add_two_ints_client"])
         .env("RMW_IMPLEMENTATION", "rmw_zenoh_cpp")
         .env("ZENOH_CONFIG_OVERRIDE", router.rmw_zenoh_env())
@@ -334,15 +394,44 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
         .spawn()
         .expect("Failed to start RCL client");
 
+    // Bound the wait on the RCL client's own exit instead of a fixed sleep,
+    // so a slow-to-discover run fails fast with a clear message rather than
+    // hanging the hiroz server thread (blocked on its one expected request)
+    // until nextest's hard kill.
+    let client_deadline = std::time::Instant::now() + Duration::from_secs(30);
+    let client_status = loop {
+        if let Some(status) = client.try_wait().expect("Failed to poll RCL client") {
+            break Some(status);
+        }
+        if std::time::Instant::now() >= client_deadline {
+            break None;
+        }
+        thread::sleep(Duration::from_millis(200));
+    };
     let _client_guard = ProcessGuard::new(client, "RCL add_two_ints client");
+    // Check the exit status is actually success, not just that the process
+    // exited -- an instantly-failing `ros2 run` (e.g. missing verb plugin,
+    // bad args) also "exits within 30s" and would otherwise false-pass here.
+    match client_status {
+        None => panic!(
+            "RCL add_two_ints client did not exit within 30s (likely failed to discover the hiroz server)"
+        ),
+        Some(status) if !status.success() => {
+            panic!("RCL add_two_ints client exited with failure status {status:?}")
+        }
+        Some(_) => {}
+    }
 
-    // Wait for the client to complete
-    wait_for_ready(Duration::from_secs(3));
-
-    // Stop the server
-    server_handle.join().expect("Server thread panicked");
-
-    println!("Test passed: RCL client called hiroz server");
+    // Wait for server to signal completion (with timeout)
+    match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(_) => {
+            server_handle.join().expect("Server thread panicked");
+            println!("Test passed: RCL client called hiroz server");
+        }
+        Err(_) => {
+            println!("Test passed: RCL client called hiroz server (server still cleaning up)");
+        }
+    }
 }
 
 #[test]
@@ -372,18 +461,28 @@ fn test_rcl_fibonacci_action_server_to_hiroz_client() {
 
     let _server_guard = ProcessGuard::new(server, "RCL fibonacci action server");
 
-    wait_for_ready(Duration::from_secs(5));
+    wait_for_ready(Duration::from_secs(3));
 
-    // Start hiroz client in a thread
+    // Retry until the action server's queryables are actually discovered --
+    // same rationale as the add_two_ints RCL-server test above: this is
+    // discovery latency, not response latency, so a longer fixed wait/
+    // timeout doesn't reliably help under CI load.
     let client_handle = thread::spawn(move || -> Vec<i32> {
-        let ctx =
-            create_hiroz_context_with_router(&router).expect("Failed to create hiroz context");
-
-        // Use the actual client example code
-        tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(async { demo_nodes::run_fibonacci_action_client(ctx, 2).await })
-            .expect("Client failed")
+        let deadline = std::time::Instant::now() + Duration::from_secs(60);
+        loop {
+            let ctx =
+                create_hiroz_context_with_router(&router).expect("Failed to create hiroz context");
+            let result = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(async { demo_nodes::run_fibonacci_action_client(ctx, 2).await });
+            match result {
+                Ok(v) => break v,
+                Err(_) if std::time::Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(500));
+                }
+                Err(e) => panic!("Client failed: {e}"),
+            }
+        }
     });
 
     let result = client_handle.join().expect("Client thread panicked");

--- a/crates/hiroz-tests/tests/demo_nodes.rs
+++ b/crates/hiroz-tests/tests/demo_nodes.rs
@@ -319,13 +319,22 @@ fn test_rcl_add_two_ints_server_to_hiroz_client() {
     // rationale as the fibonacci RCL-server test below: this is discovery
     // latency, not response latency, so a longer fixed wait/timeout doesn't
     // reliably help under CI load.
-    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    // Budget of 40s (not the full nextest 60s kill): each
+    // run_add_two_ints_client attempt can itself block up to ~15s in its
+    // internal call_with_timeout, so a new attempt must only start when at
+    // least that worst-case window still fits before the hard kill. Starting
+    // at 40s leaves 40 + 15 = 55s < 60s of headroom.
+    let attempt_worst_case = Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + Duration::from_secs(40);
     let result = loop {
         let ctx =
             create_hiroz_context_with_router(&router).expect("Failed to create hiroz context");
+        // Pre-check: don't begin another attempt if it could run past the
+        // deadline (and thus risk nextest's 60s hard kill).
+        let out_of_budget = std::time::Instant::now() + attempt_worst_case >= deadline;
         match demo_nodes::run_add_two_ints_client(ctx, 4, 7, false) {
             Ok(v) => break v,
-            Err(_) if std::time::Instant::now() < deadline => {
+            Err(_) if !out_of_budget => {
                 thread::sleep(Duration::from_millis(500));
             }
             Err(e) => {

--- a/crates/hiroz-tests/tests/demo_nodes.rs
+++ b/crates/hiroz-tests/tests/demo_nodes.rs
@@ -114,7 +114,8 @@ fn test_rcl_talker_to_hiroz_listener() {
 
     let _talker_guard = ProcessGuard::new(talker, "RCL talker");
 
-    wait_for_ready(Duration::from_secs(5));
+    // Proceed as soon as the RCL talker is discoverable, not after a blind sleep.
+    wait_for_ros_node("talker", &router, Duration::from_secs(15));
 
     // Start hiroz listener via the example code. 60s window absorbs discovery
     // latency spikes on loaded self-hosted runners.
@@ -177,7 +178,8 @@ fn test_hiroz_talker_to_rcl_listener() {
 
     let _listener_guard = ProcessGuard::new(listener, "RCL listener");
 
-    wait_for_ready(Duration::from_secs(2));
+    // Proceed as soon as the RCL listener is discoverable, not after a blind sleep.
+    wait_for_ros_node("listener", &router, Duration::from_secs(15));
 
     // Start hiroz talker in a thread using the example code
     let talker_handle = thread::spawn(move || {
@@ -300,7 +302,8 @@ fn test_rcl_add_two_ints_server_to_hiroz_client() {
 
     let mut server_guard = ProcessGuard::new(server, "RCL add_two_ints server");
 
-    wait_for_ready(Duration::from_secs(3));
+    // Proceed as soon as the RCL server node is discoverable, not after a blind sleep.
+    wait_for_ros_node("add_two_ints_server", &router, Duration::from_secs(15));
 
     // Retry until the server's queryable is discovered — discovery latency, not
     // response latency, so a longer fixed timeout doesn't help under load. Cap
@@ -464,7 +467,8 @@ fn test_rcl_fibonacci_action_server_to_hiroz_client() {
 
     let _server_guard = ProcessGuard::new(server, "RCL fibonacci action server");
 
-    wait_for_ready(Duration::from_secs(3));
+    // Proceed as soon as the RCL action server is discoverable, not after a blind sleep.
+    wait_for_ros_node("fibonacci_action_server", &router, Duration::from_secs(15));
 
     // Retry until the action server's queryables are discovered — discovery
     // latency, not response latency, so a longer fixed timeout doesn't help.

--- a/crates/hiroz-tests/tests/demo_nodes.rs
+++ b/crates/hiroz-tests/tests/demo_nodes.rs
@@ -77,16 +77,11 @@ fn test_hiroz_talker_to_hiroz_listener() {
     );
 }
 
-// These 6 tests each spawn a real `ros2 run demo_nodes_cpp ...` subprocess
-// (a full RCL/rclcpp C++ node). The `interop` nextest profile runs with
-// test-threads=8 so the other 8 hiroz-only tests in this file stay parallel,
-// but observed CI failures show all of the RCL-spawning tests hitting
-// nextest's hard 60s kill *simultaneously* when several run concurrently --
-// the runner can't keep up with that many RCL subprocesses starting at once.
-// nextest runs each test in its own process, so serial_test's in-process
-// static Mutex is a no-op there; it serializes them only under `cargo test`
-// (single test binary). Under nextest, keep the interop suite from
-// oversubscribing by limiting the runner's parallelism in CI.
+// The RCL-spawning interop tests each launch a real `ros2 run demo_nodes_cpp`
+// C++ node. Running many concurrently oversubscribes the runner and they all
+// hit nextest's 60s hard kill at once. serial_test's in-process Mutex only
+// serializes under `cargo test` (one binary); nextest runs each test in its
+// own process, so parallelism must be capped via the runner config in CI.
 #[test]
 fn test_rcl_talker_to_hiroz_listener() {
     if !check_ros2_available() {
@@ -104,14 +99,9 @@ fn test_rcl_talker_to_hiroz_listener() {
     let received = Arc::new(Mutex::new(Vec::new()));
     let received_clone = received.clone();
 
-    // Start the RCL talker FIRST. demo_nodes_cpp talker publishes continuously
-    // (1 Hz, forever until killed), so bringing it up before the listener
-    // decouples the listener's receive window from runner stalls: under CI load
-    // the gap between spawning the talker and the listener actually starting can
-    // exceed several seconds, and if the listener's fixed-wall-clock timeout were
-    // already ticking it could expire before the talker was discovered. Since the
-    // talker keeps publishing, the listener only needs its window to overlap the
-    // talker's steady stream — not to race a one-shot burst.
+    // Start the talker first: it publishes continuously (1 Hz until killed), so
+    // the listener's window only needs to overlap that steady stream rather than
+    // race a startup burst while its fixed timeout ticks through CI-load stalls.
     let talker = Command::new("ros2")
         .args(["run", "demo_nodes_cpp", "talker"])
         .env("RMW_IMPLEMENTATION", "rmw_zenoh_cpp")
@@ -126,9 +116,8 @@ fn test_rcl_talker_to_hiroz_listener() {
 
     wait_for_ready(Duration::from_secs(5));
 
-    // Start hiroz listener in a thread using the example code. The 60s window is
-    // generous on purpose: it must survive discovery latency spikes on loaded /
-    // self-hosted runners (this step runs right after the job's clippy step).
+    // Start hiroz listener via the example code. 60s window absorbs discovery
+    // latency spikes on loaded self-hosted runners.
     let router_endpoint = router.endpoint().to_string();
     let listener_handle = thread::spawn(move || {
         tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -283,11 +272,9 @@ fn test_rcl_add_two_ints_server_to_hiroz_client() {
 
     println!("\n=== Test: RCL demo_nodes_cpp add_two_ints server -> hiroz client ===");
 
-    // Start RCL server. stdout/stderr are piped (not discarded) so that if
-    // discovery never completes we can tell whether the process is still
-    // alive-but-slow or has actually exited/errored -- silently discarding
-    // its output here was hiding that distinction entirely (this is how the
-    // missing-ros2run-verb regression was originally found).
+    // Pipe stdout/stderr (not discard) so a discovery failure can be told apart
+    // as alive-but-slow vs exited/errored — discarding output hid the
+    // missing-ros2run-verb regression.
     let mut server = Command::new("ros2")
         .args(["run", "demo_nodes_cpp", "add_two_ints_server"])
         .env("RMW_IMPLEMENTATION", "rmw_zenoh_cpp")
@@ -315,22 +302,16 @@ fn test_rcl_add_two_ints_server_to_hiroz_client() {
 
     wait_for_ready(Duration::from_secs(3));
 
-    // Retry until the server's queryable is actually discovered -- same
-    // rationale as the fibonacci RCL-server test below: this is discovery
-    // latency, not response latency, so a longer fixed wait/timeout doesn't
-    // reliably help under CI load.
-    // Budget of 40s (not the full nextest 60s kill): each
-    // run_add_two_ints_client attempt can itself block up to ~15s in its
-    // internal call_with_timeout, so a new attempt must only start when at
-    // least that worst-case window still fits before the hard kill. Starting
-    // at 40s leaves 40 + 15 = 55s < 60s of headroom.
+    // Retry until the server's queryable is discovered — discovery latency, not
+    // response latency, so a longer fixed timeout doesn't help under load.
+    // Budget 40s (not the 60s kill): each attempt can block ~15s internally, so
+    // 40 + 15 = 55s < 60s keeps headroom before the hard kill.
     let attempt_worst_case = Duration::from_secs(15);
     let deadline = std::time::Instant::now() + Duration::from_secs(40);
     let result = loop {
         let ctx =
             create_hiroz_context_with_router(&router).expect("Failed to create hiroz context");
-        // Pre-check: don't begin another attempt if it could run past the
-        // deadline (and thus risk nextest's 60s hard kill).
+        // Don't start an attempt that could run past the deadline (60s kill).
         let out_of_budget = std::time::Instant::now() + attempt_worst_case >= deadline;
         match demo_nodes::run_add_two_ints_client(ctx, 4, 7, false) {
             Ok(v) => break v,
@@ -342,10 +323,9 @@ fn test_rcl_add_two_ints_server_to_hiroz_client() {
                     .child
                     .as_mut()
                     .and_then(|c| c.try_wait().ok().flatten());
-                // Terminate the server before joining the reader threads: they
-                // block on read_to_string until stdout/stderr hit EOF, which only
-                // happens once the child exits. In the alive-but-slow case (the
-                // one this diagnostic exists for) joining first would hang.
+                // Kill the server before joining readers: read_to_string blocks
+                // until EOF (child exit), so joining first would hang in the
+                // alive-but-slow case.
                 if let Some(c) = server_guard.child.as_mut() {
                     let _ = c.kill();
                     let _ = c.wait();
@@ -395,9 +375,8 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
         result.expect("Server failed");
     });
 
-    // Generous discovery buffer: the RCL client is a one-shot external
-    // process with no retry of its own, so the server's queryable must
-    // already be discoverable by the time it starts.
+    // One-shot RCL client with no retry: the server's queryable must be
+    // discoverable before it starts.
     wait_for_ready(Duration::from_secs(5));
 
     // Start RCL client
@@ -411,17 +390,13 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
         .spawn()
         .expect("Failed to start RCL client");
 
-    // Wrap the child in its ProcessGuard *before* any reaping so the guard owns
-    // it throughout. Polling `try_wait` on a separate handle and only then
-    // handing the (already-reaped) child to a fresh guard would let the guard's
-    // Drop signal a process group whose PID may have been recycled. Poll through
-    // the guard's own handle instead.
+    // Guard owns the child throughout; poll try_wait through the guard's own
+    // handle. Reaping via a separate handle first could let Drop later signal a
+    // recycled PID's process group.
     let mut client_guard = ProcessGuard::new(client, "RCL add_two_ints client");
 
-    // Bound the wait on the RCL client's own exit instead of a fixed sleep,
-    // so a slow-to-discover run fails fast with a clear message rather than
-    // hanging the hiroz server thread (blocked on its one expected request)
-    // until nextest's hard kill.
+    // Bound on the client's actual exit, not a fixed sleep: a slow-to-discover
+    // run fails fast instead of hanging the server thread until the hard kill.
     let client_deadline = std::time::Instant::now() + Duration::from_secs(30);
     let client_status = loop {
         let child = client_guard
@@ -436,9 +411,8 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
         }
         thread::sleep(Duration::from_millis(200));
     };
-    // Check the exit status is actually success, not just that the process
-    // exited -- an instantly-failing `ros2 run` (e.g. missing verb plugin,
-    // bad args) also "exits within 30s" and would otherwise false-pass here.
+    // Require success, not just exit: an instantly-failing `ros2 run` (missing
+    // verb, bad args) also exits within 30s and would false-pass.
     match client_status {
         None => panic!(
             "RCL add_two_ints client did not exit within 30s (likely failed to discover the hiroz server)"
@@ -490,10 +464,8 @@ fn test_rcl_fibonacci_action_server_to_hiroz_client() {
 
     wait_for_ready(Duration::from_secs(3));
 
-    // Retry until the action server's queryables are actually discovered --
-    // same rationale as the add_two_ints RCL-server test above: this is
-    // discovery latency, not response latency, so a longer fixed wait/
-    // timeout doesn't reliably help under CI load.
+    // Retry until the action server's queryables are discovered — discovery
+    // latency, not response latency, so a longer fixed timeout doesn't help.
     let client_handle = thread::spawn(move || -> Vec<i32> {
         let deadline = std::time::Instant::now() + Duration::from_secs(60);
         loop {

--- a/crates/hiroz-tests/tests/parameter_interop.rs
+++ b/crates/hiroz-tests/tests/parameter_interop.rs
@@ -32,30 +32,37 @@ fn ros2_cmd(rmw_env: &str) -> Command {
     cmd
 }
 
-/// Wait until `ros2 node list` shows the given node name, or panic after timeout.
-fn wait_for_node(node_name: &str, rmw_env: &str, timeout: Duration) {
+/// Wait until the node is visible in hiroz's own graph (populated in the
+/// background by its liveliness subscriber), or panic after timeout.
+///
+/// Previously this spawned `ros2 node list` in a loop -- each invocation is
+/// an external CLI process with its own internal discovery spin-time on top
+/// of the sleep between attempts, which made the wait itself slow and
+/// non-deterministic rather than reacting to an actual discovery event.
+/// Polling the graph directly checks already-live in-memory state with no
+/// process spawn or network round-trip per check.
+fn wait_for_node(node_name: &str, router: &TestRouter, timeout: Duration) {
+    let ctx = create_hiroz_context_with_router(router).expect("Failed to create hiroz context");
     let start = Instant::now();
     loop {
-        let output = ros2_cmd(rmw_env)
-            .args(["node", "list", "--spin-time", SPIN_TIME, "--no-daemon"])
-            .output()
-            .expect("Failed to run ros2 node list");
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        if stdout.contains(node_name) {
+        if ctx
+            .graph()
+            .get_node_names()
+            .iter()
+            .any(|(name, _ns)| name == node_name)
+        {
             println!("Node {} discovered after {:?}", node_name, start.elapsed());
             return;
         }
 
         if start.elapsed() > timeout {
-            let stderr = String::from_utf8_lossy(&output.stderr);
             panic!(
-                "Timed out waiting for node {} after {:?}\nstdout: {}\nstderr: {}",
-                node_name, timeout, stdout, stderr
+                "Timed out waiting for node {} after {:?}",
+                node_name, timeout
             );
         }
 
-        thread::sleep(Duration::from_secs(1));
+        thread::sleep(Duration::from_millis(20));
     }
 }
 
@@ -85,7 +92,7 @@ fn test_ros2_param_list_on_hiroz_node() {
         thread::sleep(Duration::from_secs(30));
     });
 
-    wait_for_node("param_list_node", &rmw_env, Duration::from_secs(15));
+    wait_for_node("param_list_node", &router, Duration::from_secs(45));
 
     let output = ros2_cmd(&rmw_env)
         .args([
@@ -140,7 +147,7 @@ fn test_ros2_param_get_set_on_hiroz_node() {
         thread::sleep(Duration::from_secs(60));
     });
 
-    wait_for_node("param_getset_node", &rmw_env, Duration::from_secs(15));
+    wait_for_node("param_getset_node", &router, Duration::from_secs(45));
 
     // Get initial value
     let output = ros2_cmd(&rmw_env)
@@ -251,7 +258,7 @@ fn test_hiroz_reads_rclcpp_node_params() {
 
     let _guard = ProcessGuard::new(server, "rclcpp_param_node");
 
-    wait_for_node("rclcpp_param_node", &rmw_env, Duration::from_secs(15));
+    wait_for_node("rclcpp_param_node", &router, Duration::from_secs(45));
 
     let output = ros2_cmd(&rmw_env)
         .args([

--- a/crates/hiroz-tests/tests/parameter_interop.rs
+++ b/crates/hiroz-tests/tests/parameter_interop.rs
@@ -32,15 +32,10 @@ fn ros2_cmd(rmw_env: &str) -> Command {
     cmd
 }
 
-/// Wait until the node is visible in hiroz's own graph (populated in the
-/// background by its liveliness subscriber), or panic after timeout.
-///
-/// Previously this spawned `ros2 node list` in a loop -- each invocation is
-/// an external CLI process with its own internal discovery spin-time on top
-/// of the sleep between attempts, which made the wait itself slow and
-/// non-deterministic rather than reacting to an actual discovery event.
-/// Polling the graph directly checks already-live in-memory state with no
-/// process spawn or network round-trip per check.
+/// Wait until the node appears in hiroz's own graph (populated by its liveliness
+/// subscriber), or panic after timeout. Polls in-memory state directly — no
+/// per-check process spawn or round-trip, unlike the previous `ros2 node list`
+/// loop whose own CLI spin-time made the wait slow and non-deterministic.
 fn wait_for_node(node_name: &str, router: &TestRouter, timeout: Duration) {
     let ctx = create_hiroz_context_with_router(router).expect("Failed to create hiroz context");
     let start = Instant::now();

--- a/crates/hiroz-tests/tests/parameter_interop.rs
+++ b/crates/hiroz-tests/tests/parameter_interop.rs
@@ -60,7 +60,13 @@ fn wait_for_node(node_name: &str, router: &TestRouter, timeout: Duration) {
                 .graph()
                 .get_node_names()
                 .iter()
-                .map(|(name, ns)| format!("{ns}/{name}"))
+                .map(|(name, ns)| {
+                    if ns == "/" {
+                        format!("/{name}")
+                    } else {
+                        format!("{ns}/{name}")
+                    }
+                })
                 .collect();
             panic!(
                 "Timed out waiting for node {} after {:?}; nodes currently discovered: {:?}",

--- a/crates/hiroz-tests/tests/parameter_interop.rs
+++ b/crates/hiroz-tests/tests/parameter_interop.rs
@@ -56,9 +56,15 @@ fn wait_for_node(node_name: &str, router: &TestRouter, timeout: Duration) {
         }
 
         if start.elapsed() > timeout {
+            let discovered: Vec<String> = ctx
+                .graph()
+                .get_node_names()
+                .iter()
+                .map(|(name, ns)| format!("{ns}/{name}"))
+                .collect();
             panic!(
-                "Timed out waiting for node {} after {:?}",
-                node_name, timeout
+                "Timed out waiting for node {} after {:?}; nodes currently discovered: {:?}",
+                node_name, timeout, discovered
             );
         }
 


### PR DESCRIPTION
## Summary
Hardens the RCL/rclcpp interop test harness against discovery-latency flakes on loaded self-hosted runners: replaces blind fixed sleeps with condition-driven waits (graph discovery, process exit) and adds diagnostics that separate alive-but-slow from exited-early failures. Also adds a background-producer guard used by the hu-meter/hu-monitor suites later in the stack.

## Key changes
- **Deterministic waits** — new `wait_for_ros_node` polls the graph until a named ROS node is discoverable (backstop-bounded) and replaces the fixed `wait_for_ready` sleeps before interacting with a just-spawned RCL node (`talker`, `listener`, `add_two_ints_server`, `fibonacci_action_server`): it proceeds the moment the node appears. `TestRouter` startup polls the router's TCP listener (40 × 50ms) instead of a blind 500ms sleep; `parameter_interop::wait_for_node` polls the in-memory graph (20ms) instead of shelling out to `ros2 node list`.
- **Diagnosable failures** (`demo_nodes.rs`) — retry client/action attempts against a discovery deadline kept well under the interop profile's 120s kill (= 60s period × terminate-after 2); pipe RCL-server output to tell alive-but-slow from exited/errored; bound on the client's actual exit and require exit *success*; take manually-killed children out of their `ProcessGuard` so `Drop` can't re-signal a recycled PID group.
- **`ProducerGuard`** (`common/mod.rs`) — `spawn_producer`/`spawn_holder` hold Zenoh entities for a guard's lifetime, detaching on drop (best-effort, no join) to avoid session-teardown hangs and to surface early-exit panics. Consumed by the hu-meter/hu-monitor tests later in the stack.

## Breaking changes
None (test-only).
