### PR TITLE
fix(hiroz): give each FFI service call its own reply channel

### DIFF
--- a/crates/hiroz-go/interop_tests/service_test.go
+++ b/crates/hiroz-go/interop_tests/service_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -330,4 +331,86 @@ func TestGoServiceClientTimeout(t *testing.T) {
 // user-defined service types, not just standard messages.
 func TestServiceWithCustomTypes(t *testing.T) {
 	t.Skip("Requires custom service type code generation")
+}
+
+// TestGoServiceReplyCorrelationAfterTimeout is a deterministic regression for
+// the reply-correlation bug (issue #241): the FFI service client took the next
+// reply off a shared channel without matching it to the request that was sent,
+// so a late reply from a timed-out call was mis-delivered to the following call.
+//
+// It forces exactly that race: the server stalls the first request past the
+// client's timeout, so call #1 times out and its reply lands late in the shared
+// channel. Call #2, with different arguments, must return its OWN reply — not
+// the stale one. Pre-fix this returned call #1's result; post-fix the client
+// discards the non-matching reply and waits for its own.
+func TestGoServiceReplyCorrelationAfterTimeout(t *testing.T) {
+	router := startZenohRouter(t)
+
+	hirozCtx, err := hiroz.NewContext().
+		WithConnectEndpoints(router.Endpoint()).DisableMulticastScouting().
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to create context: %v", err)
+	}
+	defer hirozCtx.Close()
+
+	node, err := hirozCtx.CreateNode("go_reply_correlation").Build()
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	defer node.Close()
+
+	svc := &example_interfaces.AddTwoInts{}
+
+	// Server stalls only the first request long enough to outlast call #1's
+	// short timeout; every later request replies immediately.
+	var calls atomic.Int32
+	server, err := node.CreateServiceServer("add_two_ints").
+		Build(svc, func(reqBytes []byte) ([]byte, error) {
+			var req example_interfaces.AddTwoIntsRequest
+			if err := req.DeserializeCDR(reqBytes); err != nil {
+				return nil, err
+			}
+			if calls.Add(1) == 1 {
+				time.Sleep(400 * time.Millisecond)
+			}
+			resp := &example_interfaces.AddTwoIntsResponse{Sum: req.A + req.B}
+			return resp.SerializeCDR()
+		})
+	if err != nil {
+		t.Fatalf("Failed to create service server: %v", err)
+	}
+	defer server.Close()
+
+	client, err := node.CreateServiceClient("add_two_ints").Build(svc)
+	if err != nil {
+		t.Fatalf("Failed to create service client: %v", err)
+	}
+	defer client.Close()
+
+	if err := client.WaitForService(20 * time.Second); err != nil {
+		t.Fatalf("service not ready: %v", err)
+	}
+
+	// Call #1: short timeout, server stalls 400ms → must time out.
+	req1 := &example_interfaces.AddTwoIntsRequest{A: 1, B: 1} // would be 2
+	var resp1 example_interfaces.AddTwoIntsResponse
+	if err := hiroz.CallTypedWithTimeout(client, req1, &resp1, 100*time.Millisecond); err == nil {
+		t.Fatalf("call #1 expected a timeout, but it returned Sum=%d", resp1.Sum)
+	}
+
+	// Let call #1's late reply (Sum=2) arrive and sit in the shared channel.
+	time.Sleep(500 * time.Millisecond)
+
+	// Call #2: distinct args, generous timeout. Must get its own reply (7+8=15),
+	// not the stale reply from call #1 (2).
+	req2 := &example_interfaces.AddTwoIntsRequest{A: 7, B: 8} // 15
+	var resp2 example_interfaces.AddTwoIntsResponse
+	if err := hiroz.CallTypedWithTimeout(client, req2, &resp2, 5*time.Second); err != nil {
+		t.Fatalf("call #2 failed: %v", err)
+	}
+	if resp2.Sum != 15 {
+		t.Fatalf("reply mis-correlated: call #2 (7+8) got Sum=%d, want 15 "+
+			"(stale reply from the timed-out call #1 was delivered instead)", resp2.Sum)
+	}
 }

--- a/crates/hiroz-tests/tests/service_interop.rs
+++ b/crates/hiroz-tests/tests/service_interop.rs
@@ -469,3 +469,104 @@ fn test_ros2_server_hiroz_client() {
 
     println!("Test passed: hiroz client called ROS2 service");
 }
+
+/// Typed-path counterpart to the FFI regression in the Go interop suite
+/// (issue #241): a reply that arrives after its own call has already timed out
+/// must never be delivered to a later call on the same client.
+///
+/// The typed client (`ZClient::call` / `call_with_timeout`, used by both the
+/// native Rust API and the Python bindings) is immune by construction — each
+/// call owns a private oneshot channel, so a late reply for a timed-out call
+/// has no receiver and is dropped. This test locks that guarantee in against a
+/// future refactor to a shared reply channel (which is exactly what broke the
+/// FFI path).
+#[test]
+fn test_typed_client_reply_correlation_after_timeout() {
+    let router = TestRouter::new();
+
+    println!("\n=== Test: typed client reply correlation after a timeout ===");
+
+    // Server: stall the first request past the client's timeout so its reply is
+    // sent late, then answer the second request immediately.
+    let router_endpoint = router.endpoint().to_string();
+    let _server_handle = thread::spawn(move || {
+        let ctx =
+            create_hiroz_context_with_endpoint(&router_endpoint).expect("Failed to create context");
+        let node = ctx
+            .create_node("corr_server")
+            .build()
+            .expect("Failed to create node");
+        let mut zsrv = node
+            .create_service::<AddTwoInts>("corr_add_two_ints")
+            .build()
+            .expect("Failed to create service");
+
+        // Request #1 — reply only after the client has already timed out.
+        if let Ok(req) = zsrv.take_request() {
+            let resp = AddTwoIntsResponse {
+                sum: req.message().a + req.message().b,
+            };
+            thread::sleep(Duration::from_millis(500));
+            req.reply_blocking(&resp).expect("reply #1 failed");
+        }
+        // Request #2 — reply immediately.
+        if let Ok(req) = zsrv.take_request() {
+            let resp = AddTwoIntsResponse {
+                sum: req.message().a + req.message().b,
+            };
+            req.reply_blocking(&resp).expect("reply #2 failed");
+        }
+    });
+
+    wait_for_ready(Duration::from_secs(3));
+
+    let client_handle = thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let ctx = create_hiroz_context_with_router(&router).expect("Failed to create context");
+            let node = ctx
+                .create_node("corr_client")
+                .build()
+                .expect("Failed to create node");
+            let zcli = node
+                .create_client::<AddTwoInts>("corr_add_two_ints")
+                .build()
+                .expect("Failed to create client");
+
+            // Let discovery settle before the first call.
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            // Call #1: short timeout; the server stalls 500ms → must time out.
+            let r1 = zcli
+                .call_with_timeout(
+                    &AddTwoIntsRequest { a: 1, b: 1 },
+                    Duration::from_millis(200),
+                )
+                .await;
+            assert!(
+                r1.is_err(),
+                "call #1 was expected to time out, got sum={:?}",
+                r1.map(|r| r.sum)
+            );
+
+            // Let call #1's late reply (sum=2) be delivered while no call owns it.
+            tokio::time::sleep(Duration::from_millis(800)).await;
+
+            // Call #2: distinct args; must receive its own reply (7+8=15), not
+            // the stale reply from the timed-out call #1 (2).
+            let r2 = zcli
+                .call_with_timeout(&AddTwoIntsRequest { a: 7, b: 8 }, Duration::from_secs(5))
+                .await
+                .expect("call #2 failed");
+            assert_eq!(
+                r2.sum, 15,
+                "typed client mis-correlated: call #2 (7+8) got {}, expected 15 \
+                 (stale reply from the timed-out call #1 delivered instead)",
+                r2.sum
+            );
+        });
+    });
+
+    client_handle.join().expect("Client thread panicked");
+    println!("Test passed: typed client reply correlation holds after a timeout");
+}

--- a/crates/hiroz/src/ffi/service.rs
+++ b/crates/hiroz/src/ffi/service.rs
@@ -42,8 +42,6 @@ pub struct RawServiceClient {
     pub(crate) sn: AtomicUsize,
     pub(crate) gid: GidArray,
     pub(crate) inner: zenoh::query::Querier<'static>,
-    pub(crate) tx: flume::Sender<zenoh::sample::Sample>,
-    pub(crate) rx: flume::Receiver<zenoh::sample::Sample>,
     pub(crate) _key_expr: zenoh::key_expr::KeyExpr<'static>,
     /// Liveliness token — kept alive so that rmw_zenoh_cpp service servers can
     /// observe this client via Zenoh liveliness.
@@ -70,13 +68,19 @@ impl RawServiceClient {
         request: &[u8],
         timeout: Duration,
     ) -> Result<Vec<u8>, crate::error::Error> {
-        let tx = self.tx.clone();
-        let attachment = self.new_attachment();
+        // Each call gets its own reply channel. Zenoh delivers a query's replies
+        // only to the callback registered on that `get()`, so a private channel
+        // keeps each call's reply to itself: a reply that arrives after its call
+        // has returned (e.g. after a timeout) finds the receiver already dropped
+        // and is discarded, rather than leaking into the next call as it would on
+        // a channel shared across calls. Capacity 1 keeps the first reply and
+        // drops any extras — a unary service call needs exactly one.
+        let (tx, rx) = flume::bounded(1);
 
         self.inner
             .get()
             .payload(request.to_vec())
-            .attachment(attachment)
+            .attachment(self.new_attachment())
             .callback(move |reply| match reply.into_result() {
                 Ok(sample) => {
                     let _ = tx.try_send(sample);
@@ -88,10 +92,13 @@ impl RawServiceClient {
             .wait()
             .map_err(|e| crate::error::Error::Other(format!("Failed to send query: {}", e)))?;
 
-        let sample = self.rx.recv_timeout(timeout).map_err(|e| match e {
-            flume::RecvTimeoutError::Timeout => crate::error::Error::Timeout(timeout),
-            flume::RecvTimeoutError::Disconnected => {
-                crate::error::Error::Other(format!("Reply channel disconnected: {}", e))
+        let sample = rx.recv_timeout(timeout).map_err(|e| match e {
+            // No reply before the deadline, or the query finalized with no reply
+            // buffered — the latter happens when there is no matching server, so
+            // the callback (and its sender) is dropped. Both mean this call got no
+            // response, which is a service timeout.
+            flume::RecvTimeoutError::Timeout | flume::RecvTimeoutError::Disconnected => {
+                crate::error::Error::Timeout(timeout)
             }
         })?;
 

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -691,8 +691,6 @@ impl ZNode {
             .timeout(std::time::Duration::from_secs(10))
             .wait()?;
 
-        let (tx, rx) = flume::bounded(10);
-
         // Declare liveliness token so rmw_zenoh_cpp service servers can observe this client.
         let lv_ke = self
             .keyexpr_format
@@ -708,8 +706,6 @@ impl ZNode {
             gid: crate::entity::endpoint_gid(&entity)
                 .expect("service client always has node identity"),
             inner,
-            tx,
-            rx,
             _key_expr: key_expr,
             _lv_token: lv_token,
             qualified_service,


### PR DESCRIPTION
## Summary

`RawServiceClient` held a single reply channel **shared across every call on the client**, and `call_raw` took the next sample off it with no per-call correlation. A reply that arrived after its own call had already returned (e.g. after a timeout) lingered in that channel and was then handed to the *next* call, producing an off-by-one cascade. Whether it happened depended on reply timing, so it surfaced as an intermittent `TestGoServiceServerToGoClient` failure (`Expected 10 + 20 = 30, got 3`, …).

## Key Changes

- **`crates/hiroz/src/ffi/service.rs` + `crates/hiroz/src/node.rs`** — give each `call_raw` its own reply channel instead of sharing one on the client. Zenoh delivers a query's replies only to the callback registered on that `get()`, so a private channel keeps each call's reply to itself: a late reply for a timed-out call finds its receiver already dropped and is discarded, rather than leaking into the next call. This removes the shared `tx`/`rx` fields from `RawServiceClient` and the per-client channel setup.
- **`crates/hiroz-go/interop_tests/service_test.go`** — `TestGoServiceReplyCorrelationAfterTimeout`, a deterministic regression: the server stalls the first request past the client's timeout so call #1 times out and its late reply lands in the channel; the test asserts call #2 (distinct arguments) returns its own reply, not the stale one.
- **`crates/hiroz-tests/tests/service_interop.rs`** — `test_typed_client_reply_correlation_after_timeout`, the same scenario against the typed `ZClient` path (native Rust + Python bindings), which was already correct. A guard against regressing that path to a shared channel.

## What fails without this

`TestGoServiceReplyCorrelationAfterTimeout` fails deterministically before the fix — call #2 (`7 + 8`) receives call #1's stale reply:

```
reply mis-correlated: call #2 (7+8) got Sum=2, want 15
  (stale reply from the timed-out call #1 was delivered instead)
--- FAIL: TestGoServiceReplyCorrelationAfterTimeout
```

With the fix the test passes. This also removes the timing dependence behind the intermittent `TestGoServiceServerToGoClient` failures.

## Consistency across bindings

All service-call paths now use the same principle — **per-call reply isolation** — so a call only ever observes its own reply:

| Binding | Service-call path | Reply isolation |
|---|---|---|
| Rust (native) | `ZClient::call` / `call_with_timeout` → `call_sample` | per-call `tokio::oneshot` |
| Python (`hiroz-py`) | same `ZClient::call_with_timeout` | per-call `tokio::oneshot` |
| Go / C (FFI) | `RawServiceClient::call_raw` | per-call `flume` channel (this PR) |

Before, only the FFI path shared a channel across calls; it now matches the typed path's design rather than reimplementing correlation a second way. The typed-path test guards against the two drifting apart.

## Breaking Changes

None. The typed async client was already correct and is unchanged. The `rmw_send_request` / `rmw_try_take_response_sample` path is intentionally untouched — it operates under a different contract where the RMW layer holds the returned sequence number and correlates itself.

Closes #241.
