### PR TITLE
test(hiroz-go): deterministic reply-correlation flaky test

### DIFF
--- a/crates/hiroz-go/interop_tests/service_test.go
+++ b/crates/hiroz-go/interop_tests/service_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -362,17 +361,20 @@ func TestGoServiceReplyCorrelationAfterTimeout(t *testing.T) {
 
 	svc := &example_interfaces.AddTwoInts{}
 
-	// Server stalls only the first request long enough to outlast call #1's
-	// short timeout; every later request replies immediately.
-	var calls atomic.Int32
+	// Stall is keyed on request content, not call ordering: only req1 ({A:1})
+	// is delayed, so it outlasts call #1's short timeout regardless of how many
+	// times or in what order the callback fires. req2 ({A:7}) always replies
+	// immediately. Keying on a call counter would be order-fragile — a
+	// redelivered or retried query before call #1 would shift the stall onto
+	// the wrong request and flake the "expect timeout" assertion.
 	server, err := node.CreateServiceServer("add_two_ints").
 		Build(svc, func(reqBytes []byte) ([]byte, error) {
 			var req example_interfaces.AddTwoIntsRequest
 			if err := req.DeserializeCDR(reqBytes); err != nil {
 				return nil, err
 			}
-			if calls.Add(1) == 1 {
-				time.Sleep(400 * time.Millisecond)
+			if req.A == 1 {
+				time.Sleep(500 * time.Millisecond)
 			}
 			resp := &example_interfaces.AddTwoIntsResponse{Sum: req.A + req.B}
 			return resp.SerializeCDR()
@@ -392,10 +394,10 @@ func TestGoServiceReplyCorrelationAfterTimeout(t *testing.T) {
 		t.Fatalf("service not ready: %v", err)
 	}
 
-	// Call #1: short timeout, server stalls 400ms → must time out.
+	// Call #1: short timeout, server stalls 500ms → must time out.
 	req1 := &example_interfaces.AddTwoIntsRequest{A: 1, B: 1} // would be 2
 	var resp1 example_interfaces.AddTwoIntsResponse
-	if err := hiroz.CallTypedWithTimeout(client, req1, &resp1, 100*time.Millisecond); err == nil {
+	if err := hiroz.CallTypedWithTimeout(client, req1, &resp1, 200*time.Millisecond); err == nil {
 		t.Fatalf("call #1 expected a timeout, but it returned Sum=%d", resp1.Sum)
 	}
 


### PR DESCRIPTION
## Summary

Makes `TestGoServiceReplyCorrelationAfterTimeout` (`crates/hiroz-go/interop_tests/service_test.go`) deterministic. It intermittently reds the interop matrix (seen on ROS 2 humble) even on unrelated PRs.

## What fails without this

```
service_test.go:399: call #1 expected a timeout, but it returned Sum=2
--- FAIL: TestGoServiceReplyCorrelationAfterTimeout
```

The server stalled its callback on an atomic call counter (`calls.Add(1) == 1`), identifying the request to delay by **arrival order** rather than identity. A 400 ms stall cannot be outrun by a 100 ms timeout, so call `#1` returning `Sum=2` proves the stall did not land on call `#1` — i.e. the callback fired at least once before it (a redelivered/retried query). Order-fragile, hence the intermittent flake on some runners.

## Key changes

- Key the stall on request content: `if req.A == 1` instead of a call counter. `req1 {A:1}` always stalls, `req2 {A:7}` never does, independent of invocation count or order. The test still validates what it was written for — a late reply from a timed-out call must not be mis-delivered to the next call.
- Widen call `#1`'s margin (200 ms timeout vs a 500 ms stall) so a slow runner can't blur the boundary.
- Drop the now-unused `sync/atomic` import.

## Breaking changes

None. Test-only.

Closes #243
