### PR TITLE
perf(hiroz-py): remove per-message Python work from the receive path

### DIFF
--- a/crates/hiroz-codegen/src/python_msgspec_generator.rs
+++ b/crates/hiroz-codegen/src/python_msgspec_generator.rs
@@ -418,9 +418,10 @@ fn generate_complete_rust_module(
 
         /// Deserialize CDR bytes to a Python message
         ///
-        /// Dispatches through the direct Rust `match` rather than the Python
-        /// REGISTRY, mirroring `serialize_to_zbuf`. See
-        /// `generate_deserialize_direct` for why.
+        /// Codegen-known types dispatch through the direct Rust `match` rather
+        /// than the Python REGISTRY, mirroring `serialize_to_zbuf`. Anything
+        /// else falls back to the registry, so types registered at runtime keep
+        /// decoding as they always have. See `generate_deserialize_direct`.
         pub fn deserialize_from_cdr(type_name: &str, py: Python, bytes: &[u8]) -> PyResult<PyObject> {
             deserialize_direct(type_name, py, bytes)
         }
@@ -714,7 +715,19 @@ fn generate_deserialize_direct(
     }
 
     quote! {
-        /// Direct CDR deserialization - bypasses the Python registry.
+        /// Direct CDR deserialization for codegen-known types, falling back to
+        /// the Python REGISTRY for anything else.
+        ///
+        /// The fallback is not optional. `REGISTRY` is a live, mutable Python
+        /// dict, and `create_subscriber` accepts any class carrying
+        /// `__msgtype__` — it documents itself as working with "any registered
+        /// message type". Before the direct dispatch existed, every receive
+        /// resolved through `REGISTRY` at runtime, so a type registered after
+        /// module init decoded fine. Erroring on the wildcard instead would
+        /// silently withdraw that: the subscriber would still be created, then
+        /// every callback would raise `Unknown message type`. Codegen-known
+        /// types take the fast Rust path; everything else keeps working exactly
+        /// as it did.
         pub fn deserialize_direct(type_name: &str, py: Python, bytes: &[u8]) -> PyResult<PyObject> {
             use ::hiroz::python_bridge::IntoPyMessage;
             // Skip 4-byte CDR encapsulation header
@@ -726,9 +739,11 @@ fn generate_deserialize_direct(
             let payload = &bytes[4..];
             match type_name {
                 #(#match_arms)*
-                _ => Err(pyo3::exceptions::PyValueError::new_err(
-                    format!("Unknown message type: {}", type_name)
-                )),
+                // Not known at codegen time: defer to the runtime registry.
+                // `deserialize_message` takes the *whole* buffer, header
+                // included — it hands it to the type's own Python
+                // `deserialize`, which strips the header itself.
+                _ => unsafe { deserialize_message(py, type_name, bytes) },
             }
         }
     }

--- a/crates/hiroz-codegen/src/python_msgspec_generator.rs
+++ b/crates/hiroz-codegen/src/python_msgspec_generator.rs
@@ -701,7 +701,8 @@ fn generate_deserialize_direct(
         });
 
         let resp_full_name = format!("{}/srv/{}_Response", srv.parsed.package, srv.parsed.name);
-        let resp_fn_ident = format_ident!("deserialize_{}", srv.response.parsed.name.to_lowercase());
+        let resp_fn_ident =
+            format_ident!("deserialize_{}", srv.response.parsed.name.to_lowercase());
         match_arms.push(quote! {
             #resp_full_name => #mod_ident::#resp_fn_ident(py, bytes),
         });

--- a/crates/hiroz-codegen/src/python_msgspec_generator.rs
+++ b/crates/hiroz-codegen/src/python_msgspec_generator.rs
@@ -672,45 +672,38 @@ fn generate_deserialize_direct(
 ) -> TokenStream {
     let mut match_arms = Vec::new();
 
+    // Each arm delegates to the per-type `deserialize_<name>` already emitted by
+    // `generate_deserialize_function`, rather than repeating its body. Inlining
+    // the decode here would give three copies of the same header handling,
+    // endianness choice and error mapping (messages, requests, responses) that
+    // could drift apart under any future fix. The call keeps the fast path
+    // intact -- it is a direct Rust call, no Python registry and no Python-level
+    // dispatch -- and those functions take the *whole* buffer because they strip
+    // the encapsulation header themselves.
     for (package_name, package_msgs) in packages {
-        let package_ident = format_ident!("{}", package_name.replace('-', "_"));
+        let mod_ident = format_ident!("{}_py", package_name.replace('-', "_"));
         for msg in package_msgs {
             let full_name = format!("{}/msg/{}", package_name, msg.parsed.name);
-            let name_ident = format_ident!("{}", msg.parsed.name);
+            let fn_ident = format_ident!("deserialize_{}", msg.parsed.name.to_lowercase());
             match_arms.push(quote! {
-                #full_name => {
-                    let (rust_msg, _): (ros::#package_ident::#name_ident, _) =
-                        hiroz_cdr::from_bytes::<_, hiroz_cdr::LittleEndian>(payload)
-                            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
-                    rust_msg.into_py_message(py)
-                }
+                #full_name => #mod_ident::#fn_ident(py, bytes),
             });
         }
     }
 
     for srv in services {
-        let package_ident = format_ident!("{}", srv.parsed.package.replace('-', "_"));
+        let mod_ident = format_ident!("{}_srv_py", srv.parsed.package.replace('-', "_"));
 
         let req_full_name = format!("{}/srv/{}_Request", srv.parsed.package, srv.parsed.name);
-        let req_name_ident = format_ident!("{}Request", srv.parsed.name);
+        let req_fn_ident = format_ident!("deserialize_{}", srv.request.parsed.name.to_lowercase());
         match_arms.push(quote! {
-            #req_full_name => {
-                let (rust_msg, _): (ros::#package_ident::#req_name_ident, _) =
-                    hiroz_cdr::from_bytes::<_, hiroz_cdr::LittleEndian>(payload)
-                        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
-                rust_msg.into_py_message(py)
-            }
+            #req_full_name => #mod_ident::#req_fn_ident(py, bytes),
         });
 
         let resp_full_name = format!("{}/srv/{}_Response", srv.parsed.package, srv.parsed.name);
-        let resp_name_ident = format_ident!("{}Response", srv.parsed.name);
+        let resp_fn_ident = format_ident!("deserialize_{}", srv.response.parsed.name.to_lowercase());
         match_arms.push(quote! {
-            #resp_full_name => {
-                let (rust_msg, _): (ros::#package_ident::#resp_name_ident, _) =
-                    hiroz_cdr::from_bytes::<_, hiroz_cdr::LittleEndian>(payload)
-                        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
-                rust_msg.into_py_message(py)
-            }
+            #resp_full_name => #mod_ident::#resp_fn_ident(py, bytes),
         });
     }
 
@@ -729,14 +722,14 @@ fn generate_deserialize_direct(
         /// types take the fast Rust path; everything else keeps working exactly
         /// as it did.
         pub fn deserialize_direct(type_name: &str, py: Python, bytes: &[u8]) -> PyResult<PyObject> {
-            use ::hiroz::python_bridge::IntoPyMessage;
-            // Skip 4-byte CDR encapsulation header
+            // Header length is validated here so the error is identical for the
+            // registry fallback, which does not check. The per-type functions
+            // re-check and strip it themselves.
             if bytes.len() < 4 {
                 return Err(pyo3::exceptions::PyValueError::new_err(
                     "CDR data too short: missing encapsulation header"
                 ));
             }
-            let payload = &bytes[4..];
             match type_name {
                 #(#match_arms)*
                 // Not known at codegen time: defer to the runtime registry.

--- a/crates/hiroz-codegen/src/python_msgspec_generator.rs
+++ b/crates/hiroz-codegen/src/python_msgspec_generator.rs
@@ -406,6 +406,9 @@ fn generate_complete_rust_module(
     // Generate serialize_to_zbuf function
     let serialize_to_zbuf_fn = generate_serialize_to_zbuf(packages, services);
 
+    // Generate the direct-dispatch deserializer (mirror of serialize_to_zbuf).
+    let deserialize_direct_fn = generate_deserialize_direct(packages, services);
+
     // Generate Rust API wrappers
     let rust_api_wrappers = quote! {
         /// Serialize a Python message to CDR bytes
@@ -414,8 +417,12 @@ fn generate_complete_rust_module(
         }
 
         /// Deserialize CDR bytes to a Python message
+        ///
+        /// Dispatches through the direct Rust `match` rather than the Python
+        /// REGISTRY, mirroring `serialize_to_zbuf`. See
+        /// `generate_deserialize_direct` for why.
         pub fn deserialize_from_cdr(type_name: &str, py: Python, bytes: &[u8]) -> PyResult<PyObject> {
-            unsafe { deserialize_message(py, type_name, bytes) }
+            deserialize_direct(type_name, py, bytes)
         }
     };
 
@@ -448,6 +455,8 @@ fn generate_complete_rust_module(
         #helper_fns
 
         #serialize_to_zbuf_fn
+
+        #deserialize_direct_fn
 
         #rust_api_wrappers
     })
@@ -637,6 +646,91 @@ fn generate_helper_functions(
         }
 
         pub use helper_fns::{serialize_message, deserialize_message, list_registered_types, get_type_hash};
+    }
+}
+
+/// Generate `deserialize_direct` — the receive-side mirror of
+/// `serialize_to_zbuf`.
+///
+/// The send path already bypasses the Python REGISTRY with a plain Rust
+/// `match` on the type name. The receive path did not: `deserialize_message`
+/// resolved every single incoming message through
+/// `sys.modules["hiroz_py.hiroz_msgs"].REGISTRY[type_name]["deserialize"]` and
+/// then made a Python-level call. That is six Python C-API round trips plus two
+/// transient `PyString` allocations plus a `PyBytes` copy plus a tuple build,
+/// per message, all under the callback's re-acquired GIL — purely to reach a
+/// function whose identity is known at codegen time.
+///
+/// Measured on this host (12-joint JointState, inter-proc-local, half-trip
+/// p50): the send side costs 4.5 us of CDR encode while the receive side costs
+/// ~15 us fixed + ~0.55 us/field. The asymmetry is the registry walk, not the
+/// codec.
+fn generate_deserialize_direct(
+    packages: &BTreeMap<String, Vec<&ResolvedMessage>>,
+    services: &[ResolvedService],
+) -> TokenStream {
+    let mut match_arms = Vec::new();
+
+    for (package_name, package_msgs) in packages {
+        let package_ident = format_ident!("{}", package_name.replace('-', "_"));
+        for msg in package_msgs {
+            let full_name = format!("{}/msg/{}", package_name, msg.parsed.name);
+            let name_ident = format_ident!("{}", msg.parsed.name);
+            match_arms.push(quote! {
+                #full_name => {
+                    let (rust_msg, _): (ros::#package_ident::#name_ident, _) =
+                        hiroz_cdr::from_bytes::<_, hiroz_cdr::LittleEndian>(payload)
+                            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+                    rust_msg.into_py_message(py)
+                }
+            });
+        }
+    }
+
+    for srv in services {
+        let package_ident = format_ident!("{}", srv.parsed.package.replace('-', "_"));
+
+        let req_full_name = format!("{}/srv/{}_Request", srv.parsed.package, srv.parsed.name);
+        let req_name_ident = format_ident!("{}Request", srv.parsed.name);
+        match_arms.push(quote! {
+            #req_full_name => {
+                let (rust_msg, _): (ros::#package_ident::#req_name_ident, _) =
+                    hiroz_cdr::from_bytes::<_, hiroz_cdr::LittleEndian>(payload)
+                        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+                rust_msg.into_py_message(py)
+            }
+        });
+
+        let resp_full_name = format!("{}/srv/{}_Response", srv.parsed.package, srv.parsed.name);
+        let resp_name_ident = format_ident!("{}Response", srv.parsed.name);
+        match_arms.push(quote! {
+            #resp_full_name => {
+                let (rust_msg, _): (ros::#package_ident::#resp_name_ident, _) =
+                    hiroz_cdr::from_bytes::<_, hiroz_cdr::LittleEndian>(payload)
+                        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+                rust_msg.into_py_message(py)
+            }
+        });
+    }
+
+    quote! {
+        /// Direct CDR deserialization - bypasses the Python registry.
+        pub fn deserialize_direct(type_name: &str, py: Python, bytes: &[u8]) -> PyResult<PyObject> {
+            use ::hiroz::python_bridge::IntoPyMessage;
+            // Skip 4-byte CDR encapsulation header
+            if bytes.len() < 4 {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "CDR data too short: missing encapsulation header"
+                ));
+            }
+            let payload = &bytes[4..];
+            match type_name {
+                #(#match_arms)*
+                _ => Err(pyo3::exceptions::PyValueError::new_err(
+                    format!("Unknown message type: {}", type_name)
+                )),
+            }
+        }
     }
 }
 

--- a/crates/hiroz-derive/src/lib.rs
+++ b/crates/hiroz-derive/src/lib.rs
@@ -249,8 +249,30 @@ fn impl_into_py_message(input: &DeriveInput) -> syn::Result<TokenStream2> {
         impl ::hiroz::python_bridge::IntoPyMessage for #name {
             fn into_py_message(&self, py: ::pyo3::Python) -> ::pyo3::PyResult<::pyo3::PyObject> {
                 use ::pyo3::types::{PyAnyMethods, PyDictMethods, PyModuleMethods};
-                let module = ::pyo3::types::PyModule::import_bound(py, #module_path)?;
-                let class = module.getattr(#name_str)?;
+
+                // The msgspec class is fixed at codegen time, but this used to
+                // re-resolve it on EVERY message:
+                //
+                //     PyModule::import_bound(py, "<module>")  ->  getattr("<Name>")
+                //
+                // `import_bound` builds a transient `PyUnicode` from the module
+                // path and walks the import machinery; `getattr` builds another
+                // `PyUnicode`. Both run under the subscriber callback's
+                // re-acquired GIL, once per *nested* message — a `JointState`
+                // pays it three times (JointState, Header, Time). Measured on
+                // this host at ~1.9 us per call, which is the fixed,
+                // payload-independent component of the receive-side cost.
+                //
+                // `GILOnceCell` resolves the class once per interpreter and
+                // hands back a borrowed reference thereafter.
+                static CLASS: ::pyo3::sync::GILOnceCell<::pyo3::Py<::pyo3::PyAny>> =
+                    ::pyo3::sync::GILOnceCell::new();
+                let class = CLASS
+                    .get_or_try_init(py, || -> ::pyo3::PyResult<::pyo3::Py<::pyo3::PyAny>> {
+                        let module = ::pyo3::types::PyModule::import_bound(py, #module_path)?;
+                        Ok(module.getattr(#name_str)?.unbind())
+                    })?
+                    .bind(py);
 
                 let kwargs = ::pyo3::types::PyDict::new_bound(py);
                 #(#field_constructions)*
@@ -540,17 +562,17 @@ fn generate_field_construction(
             {
                 let zbuf_view = ::hiroz::zbuf_view::ZBufView::new(self.#field_name.clone());
                 let py_view = ::pyo3::Py::new(py, zbuf_view)?;
-                kwargs.set_item(#field_name_str, py_view)?;
+                kwargs.set_item(::pyo3::intern!(py, #field_name_str), py_view)?;
             }
         });
     }
 
     match classify_type(field_type) {
         TypeClass::Primitive => Ok(quote! {
-            kwargs.set_item(#field_name_str, self.#field_name)?;
+            kwargs.set_item(::pyo3::intern!(py, #field_name_str), self.#field_name)?;
         }),
         TypeClass::String => Ok(quote! {
-            kwargs.set_item(#field_name_str, &self.#field_name)?;
+            kwargs.set_item(::pyo3::intern!(py, #field_name_str), &self.#field_name)?;
         }),
         TypeClass::Vec(inner) => {
             let inner_class = classify_type(&inner);
@@ -558,11 +580,11 @@ fn generate_field_construction(
                 TypeClass::Primitive if is_u8_type(&inner) => Ok(quote! {
                     {
                         let py_bytes = ::pyo3::types::PyBytes::new_bound(py, &self.#field_name);
-                        kwargs.set_item(#field_name_str, py_bytes)?;
+                        kwargs.set_item(::pyo3::intern!(py, #field_name_str), py_bytes)?;
                     }
                 }),
                 TypeClass::Primitive | TypeClass::String => Ok(quote! {
-                    kwargs.set_item(#field_name_str, &self.#field_name)?;
+                    kwargs.set_item(::pyo3::intern!(py, #field_name_str), &self.#field_name)?;
                 }),
                 _ => Ok(quote! {
                     {
@@ -573,7 +595,7 @@ fn generate_field_construction(
                                 <#inner as ::hiroz::python_bridge::IntoPyMessage>::into_py_message(item, py)?
                             )?;
                         }
-                        kwargs.set_item(#field_name_str, py_list)?;
+                        kwargs.set_item(::pyo3::intern!(py, #field_name_str), py_list)?;
                     }
                 }),
             }
@@ -582,7 +604,7 @@ fn generate_field_construction(
             let inner_class = classify_type(&inner);
             match inner_class {
                 TypeClass::Primitive | TypeClass::String => Ok(quote! {
-                    kwargs.set_item(#field_name_str, self.#field_name.to_vec())?;
+                    kwargs.set_item(::pyo3::intern!(py, #field_name_str), self.#field_name.to_vec())?;
                 }),
                 _ => Ok(quote! {
                     {
@@ -593,14 +615,14 @@ fn generate_field_construction(
                                 <#inner as ::hiroz::python_bridge::IntoPyMessage>::into_py_message(item, py)?
                             )?;
                         }
-                        kwargs.set_item(#field_name_str, py_list)?;
+                        kwargs.set_item(::pyo3::intern!(py, #field_name_str), py_list)?;
                     }
                 }),
             }
         }
         TypeClass::Nested => Ok(quote! {
             kwargs.set_item(
-                #field_name_str,
+                ::pyo3::intern!(py, #field_name_str),
                 <#field_type as ::hiroz::python_bridge::IntoPyMessage>::into_py_message(&self.#field_name, py)?
             )?;
         }),
@@ -609,7 +631,7 @@ fn generate_field_construction(
                 use ::zenoh_buffers::buffer::SplitBuffer;
                 let bytes = self.#field_name.contiguous();
                 let py_bytes = ::pyo3::types::PyBytes::new_bound(py, bytes.as_ref());
-                kwargs.set_item(#field_name_str, py_bytes)?;
+                kwargs.set_item(::pyo3::intern!(py, #field_name_str), py_bytes)?;
             }
         }),
     }

--- a/crates/hiroz-py/tests/test_deserialize_dispatch.py
+++ b/crates/hiroz-py/tests/test_deserialize_dispatch.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Guard that the subscriber decode path does not go through the Python REGISTRY.
+
+``serialize_to_zbuf`` dispatches on the type name with a Rust ``match``,
+deliberately bypassing ``hiroz_py.hiroz_msgs.REGISTRY``. ``deserialize_from_cdr``
+must mirror it: it dispatches through the generated ``deserialize_direct``, so a
+subscriber decodes an incoming sample without touching Python state at all.
+
+The detector: empty the REGISTRY, then push a message through a **real
+subscriber**. Direct dispatch is unaffected and the message arrives; a registry
+walk cannot resolve anything and the message is dropped (the callback path logs
+``deserialization error in callback`` and never fires; the ``recv`` path raises).
+
+Note that the exported ``hiroz_msgs.deserialize_message`` pyfunction is
+intentionally still registry-backed — it is the public escape hatch for types
+resolved at runtime. Asserting on *it* would fail on both a patched and an
+unpatched build and prove nothing, so these tests deliberately go through
+``node.create_subscriber`` instead, which is the path
+``crates/hiroz-py/src/node.rs`` and ``pubsub.rs`` actually use.
+"""
+
+import threading
+import time
+
+import pytest
+
+from hiroz_py import hiroz_msgs, std_msgs
+
+
+@pytest.fixture
+def empty_registry():
+    """Empty ``hiroz_msgs.REGISTRY`` for one test, then restore it.
+
+    Restoration is mandatory: the REGISTRY is module-global, so leaking an empty
+    one would break every later test that legitimately resolves through it.
+    """
+    saved = dict(hiroz_msgs.REGISTRY)
+    assert saved, "REGISTRY was already empty - the detector would be vacuous"
+    hiroz_msgs.REGISTRY.clear()
+    try:
+        yield
+    finally:
+        hiroz_msgs.REGISTRY.update(saved)
+
+
+def test_callback_subscriber_decodes_without_registry(node, empty_registry):
+    """The callback decode path (node.rs) must not consult the REGISTRY."""
+    received = []
+    arrived = threading.Event()
+
+    def on_msg(msg):
+        received.append(msg)
+        arrived.set()
+
+    # Build the endpoints before emptying matters: type info comes from the
+    # class's __msgtype__, not the REGISTRY, so ordering is not load-bearing -
+    # but keeping it explicit documents what the detector is and is not probing.
+    sub = node.create_subscriber("/dispatch_cb", std_msgs.String, callback=on_msg)
+    assert sub is not None
+    pub = node.create_publisher("/dispatch_cb", std_msgs.String)
+    time.sleep(0.5)
+
+    payload = "registry-free callback decode"
+    pub.publish(std_msgs.String(data=payload))
+
+    assert arrived.wait(timeout=5.0), (
+        "no message reached the callback with an empty REGISTRY - the subscriber "
+        "decode path is resolving through hiroz_msgs.REGISTRY instead of "
+        "dispatching directly"
+    )
+    assert received[0].data == payload
+
+
+def test_recv_subscriber_decodes_without_registry(node, empty_registry):
+    """The recv decode path (pubsub.rs) must not consult the REGISTRY either."""
+    sub = node.create_subscriber("/dispatch_recv", std_msgs.String)
+    pub = node.create_publisher("/dispatch_recv", std_msgs.String)
+    time.sleep(0.5)
+
+    payload = "registry-free recv decode"
+    pub.publish(std_msgs.String(data=payload))
+
+    msg = sub.recv(timeout=5.0)
+    assert msg is not None, (
+        "recv returned nothing with an empty REGISTRY - the subscriber decode "
+        "path is resolving through hiroz_msgs.REGISTRY instead of dispatching "
+        "directly"
+    )
+    assert msg.data == payload
+
+
+def test_exported_deserialize_message_still_uses_registry():
+    """Pin the deliberate asymmetry, so the two paths are not "fixed" together.
+
+    The exported ``serialize_message``/``deserialize_message`` pair is the
+    runtime-dispatch escape hatch and *both* halves resolve through the REGISTRY.
+    The subscriber path above is the codegen-time one and resolves through
+    neither. If this test ever starts passing, the escape hatch has been rewired
+    and types registered at runtime will no longer round-trip.
+
+    The message must be serialized *before* the REGISTRY is emptied - the encode
+    half needs it too, so this test cannot use the ``empty_registry`` fixture.
+    """
+    type_name = "std_msgs/msg/String"
+    raw = bytes(hiroz_msgs.serialize_message(type_name, std_msgs.String(data="x")))
+
+    saved = dict(hiroz_msgs.REGISTRY)
+    hiroz_msgs.REGISTRY.clear()
+    try:
+        with pytest.raises(Exception, match="Unknown message type"):
+            hiroz_msgs.deserialize_message(type_name, raw)
+    finally:
+        hiroz_msgs.REGISTRY.update(saved)

--- a/crates/hiroz-py/tests/test_deserialize_dispatch.py
+++ b/crates/hiroz-py/tests/test_deserialize_dispatch.py
@@ -3,8 +3,14 @@
 
 ``serialize_to_zbuf`` dispatches on the type name with a Rust ``match``,
 deliberately bypassing ``hiroz_py.hiroz_msgs.REGISTRY``. ``deserialize_from_cdr``
-must mirror it: it dispatches through the generated ``deserialize_direct``, so a
-subscriber decodes an incoming sample without touching Python state at all.
+mirrors it for every **codegen-known** type: a subscriber decodes an incoming
+sample of such a type without touching Python state at all.
+
+Types the codegen never saw still resolve through the REGISTRY — the wildcard
+arm of ``deserialize_direct`` falls back to it rather than erroring, preserving
+the runtime-registration path that ``create_subscriber`` advertises. The tests
+below use ``std_msgs/String``, which *is* codegen-known, so they exercise the
+direct path specifically.
 
 The detector: empty the REGISTRY, then push a message through a **real
 subscriber**. Direct dispatch is unaffected and the message arrives; a registry
@@ -94,9 +100,9 @@ def test_exported_deserialize_message_still_uses_registry():
 
     The exported ``serialize_message``/``deserialize_message`` pair is the
     runtime-dispatch escape hatch and *both* halves resolve through the REGISTRY.
-    The subscriber path above is the codegen-time one and resolves through
-    neither. If this test ever starts passing, the escape hatch has been rewired
-    and types registered at runtime will no longer round-trip.
+    The subscriber path above resolves through it only as a fallback. If this
+    test ever *fails*, the escape hatch has been rewired and types registered at
+    runtime will no longer round-trip.
 
     The message must be serialized *before* the REGISTRY is emptied - the encode
     half needs it too, so this test cannot use the ``empty_registry`` fixture.


### PR DESCRIPTION
## Summary

Two independent optimisations of the `hiroz-py` receive path. Both remove per-message Python work that codegen already determines.

> [!NOTE]
> No failing baseline, and none claimed. The justification is the measured saving below. The guard tests stop the optimisation regressing. They do not demonstrate a defect.

| tag | before | after | file |
|---|---|---|---|
| **C1** | `deserialize_message` walked the Python `REGISTRY` per message: six C-API lookups plus one Python-level call | `deserialize_direct` dispatches codegen-known types through a Rust `match`, mirroring `serialize_to_zbuf` | `generate_deserialize_direct` in `python_msgspec_generator.rs` |
| **C2** | `into_py_message` re-resolved its msgspec class per call, once per *nested* message, plus one throwaway `PyUnicode` per kwargs key | class cached in a per-impl `GILOnceCell`; every kwargs key wrapped in `intern!` | `impl_into_py_message` and `generate_field_construction` in `hiroz-derive/src/lib.rs` |

A `sensor_msgs/JointState` paid the C2 cost three times: JointState, Header, Time.

## Design points a reviewer may question

- Each `match` arm delegates to the per-type `deserialize_<name>` that `generate_deserialize_function` already emits. Inlining would give three copies of the same header handling, endianness choice and error mapping.
- The [wildcard arm falls back to the registry](https://github.com/ZettaScaleLabs/hiroz/blob/5e2d6d893ba1a514d5d1555a9a91c2aa285e4845/crates/hiroz-codegen/src/python_msgspec_generator.rs#L727-L735) rather than erroring. `REGISTRY` is a live, mutable Python dict, and `create_subscriber` accepts any class carrying `__msgtype__`. Erroring would silently withdraw runtime registration: hiroz would still create the subscriber, then every callback would raise `Unknown message type`. This is a deliberate asymmetry with `serialize_to_zbuf`, whose wildcard does error.
- `deserialize_direct` validates the 4-byte encapsulation header before dispatch, so the fallback reports the same error as the direct path.
- The exported `deserialize_message` pyfunction stays registry-backed. It is the escape hatch for types resolved at runtime.

## Evidence

**C1** — JointState ping-pong, inter-process through a router, half-trip p50, 5 interleaved reps x 10 s per arm, per-percentile median across reps:

| payload | baseline | patched | saving |
|---|---|---|---|
| empty | 56.0 µs | 52.3 µs | 3.7 µs |
| joint12 | 81.0 µs | 76.7 µs | 4.3 µs |
| joint100 | 134.9 µs | 130.1 µs | 4.9 µs |

The patched build is faster in 15 of 15 paired reps. The per-rep ranges do not overlap at any payload: at joint12, baseline 80.9–82.4 µs against patched 76.0–77.5 µs. The saving stays near-constant while total latency grows from 56 to 135 µs. That is the signature of fixed dispatch overhead, not of serialization work. The mild residual slope (3.7 → 4.9 µs) has a known cause: the old path also built a `PyBytes` copy that scales with size.

**C2** — the generated per-type decoder called directly from Python, 8 000 iterations, 5 interleaved reps per arm, median-of-percentile across reps, µs:

| payload | before | after | delta | per-rep ranges disjoint |
|---|---|---|---|---|
| empty | 2.51 | 0.62 | −1.90 | yes |
| joint1 | 9.79 | 3.27 | −6.52 | yes |
| joint12 | 14.17 | 7.20 | −6.97 | yes |
| joint100 | 46.23 | 37.99 | −8.25 | yes |
| bytes64 | 6.05 | 2.03 | −4.03 | yes |
| bytes4k | 6.28 | 2.22 | −4.06 | yes |
| bytes64k | 9.25 | 4.91 | −4.34 | yes |

The send-side encoder is the control. It does not move (joint12 4.95 → 4.82, joint100 19.59 → 19.48), so the effect is not drift between the two builds. **The saving tracks nesting depth, not payload size**: 1.9 µs for `Empty` (one class), ~4.0 µs for `ByteMultiArray` (two), ~7 µs for `JointState` (three). The JointState saving is the same ~7 µs at 1 field or at 100. A payload-copy removal would show the opposite signature. The two mechanisms are distinguishable from the measurements alone.

`perf` corroborates the named mechanism for C2. Same cell, cycles, leaf attribution:

| symbol | before | after |
|---|---|---|
| `PyImport_ImportModuleLevelObject` | 0.26% | absent |
| `PyImport_Import` | 0.20% | absent |
| `import_get_module` | 0.10% | absent |
| `import_ensure_initialized` | 0.10% | absent |
| `_Py_module_getattro` | 0.05% | absent |
| `_PyObject_GenericGetAttrWithDict` | 0.66% | 0.05% |
| `PyDict_GetItemRef` | 0.50% | 0.02% |
| `PyUnicode_New` | 0.32% | 0.12% |

CI on head commit `5e2d6d893ba1a514d5d1555a9a91c2aa285e4845`: 28 check runs completed, all green; `license/cla` also green. No pending and no failed checks.

### Guard coverage

`crates/hiroz-py/tests/test_deserialize_dispatch.py` adds three tests. They use `std_msgs/String`, which is codegen-known, so they exercise the direct path specifically.

| test | detects |
|---|---|
| `test_callback_subscriber_decodes_without_registry` | empties `REGISTRY`, publishes through a real subscriber; fails on an unpatched build — the callback never fires |
| `test_recv_subscriber_decodes_without_registry` | the same, on the `recv()` path; fails on an unpatched build — `recv` raises out of the registry walk |
| `test_exported_deserialize_message_still_uses_registry` | pins the deliberate asymmetry; passes on both builds by design, and fails only if the escape hatch is rewired |

The fixture restores `REGISTRY` afterwards. It asserts the registry was non-empty first, so the detector cannot be vacuous.

C2 has no dedicated test. The existing `hiroz-py` suite covers it, including `test_complex_messages.py`, which round-trips the nested and sequence-of-nested shapes it touches.

## Breaking changes

None. The table records the behaviour deltas a reviewer may still want to see.

| behaviour | before | after |
|---|---|---|
| Codegen-known types on the subscriber path | resolved through `REGISTRY` at runtime | resolved by a Rust `match`; identical result |
| Types registered at runtime | resolved through `REGISTRY` | unchanged — the wildcard falls back to `REGISTRY` |
| `deserialize_message` pyfunction | registry-backed | unchanged |
| CDR buffer shorter than 4 bytes on the registry path | whatever the Python decoder raised | `ValueError: CDR data too short: missing encapsulation header`, the same message the direct path already used |

> [!NOTE]
> `GILOnceCell` carries the usual caveat that the interpreter does not drop the cached object on finalization. This is the same trade-off `intern!` already makes, and the extension targets a single long-lived interpreter.

## Coverage this does not have

None of these block the change. They bound what green CI proves.

| tag | gap |
|---|---|
| **G1** | No dedicated regression test for C2. Its benefit is measured, not asserted. A future revert would show up as a latency change, not a test failure. |
| **G2** | The measurements are single-host. There are no cross-platform or cross-Python-version numbers. |
| **G3** | The registry fallback arm is exercised only through `deserialize_message`, not through a subscriber on a runtime-registered type. |
| **G4** | `./scripts/check-local.sh` was not re-run after the final three commits. The CI run on the head commit covers the same gates. |
