### PR TITLE
feat(hiroz): debug-time barrier against callbacks under a lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,9 +297,8 @@ jobs:
       - name: Run coverage
         run: |
           source /tmp/nix-dev-env.sh
-          # hiroz-tests needs its own features: several suites are
-          # `#![cfg(feature = "ros-msgs")]` and compile to empty binaries without
-          # them, so coverage taken blind under-reports the paths they exercise.
+          # Without its features hiroz-tests compiles to empty binaries, so
+          # coverage taken blind under-reports the paths they exercise.
           cargo llvm-cov \
             -p hiroz -p hiroz-codegen -p hiroz-cdr -p hiroz-protocol -p hiroz-schema \
             -p hiroz-tests \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,9 +297,13 @@ jobs:
       - name: Run coverage
         run: |
           source /tmp/nix-dev-env.sh
+          # hiroz-tests needs its own features: several suites are
+          # `#![cfg(feature = "ros-msgs")]` and compile to empty binaries without
+          # them, so coverage taken blind under-reports the paths they exercise.
           cargo llvm-cov \
             -p hiroz -p hiroz-codegen -p hiroz-cdr -p hiroz-protocol -p hiroz-schema \
             -p hiroz-tests \
+            --features hiroz-tests/ros-msgs,hiroz-tests/jazzy \
             -j4 \
             --lcov --output-path lcov.info
         shell: bash

--- a/crates/hiroz-tests/build.rs
+++ b/crates/hiroz-tests/build.rs
@@ -1,7 +1,6 @@
 use std::{env, path::PathBuf};
 
 fn main() {
-
     // Package-wide enforcement of the feature requirement.
     //
     // `tests/feature_gate.rs` fails loudly when the crate is built without

--- a/crates/hiroz-tests/build.rs
+++ b/crates/hiroz-tests/build.rs
@@ -5,11 +5,11 @@ fn main() {
     //
     // `tests/feature_gate.rs` fails loudly when the crate is built without
     // `ros-msgs`, but only if Cargo happens to select *that* target. Ask for one
-    // gated suite on its own -- `cargo test -p hiroz-tests --test
-    // reentrant_service` with no features -- and Cargo builds only that target,
-    // the crate-level `cfg` compiles it to an empty binary, `0 passed` is
-    // reported, and the guard never runs. The silent-skip mode the guard exists
-    // to close is still reachable through the narrower invocation.
+    // gated suite on its own -- `cargo test -p hiroz-tests --test cache` with no
+    // features -- and Cargo builds only that target, the crate-level `cfg`
+    // compiles it to an empty binary, `0 passed` is reported, and the guard
+    // never runs. The silent-skip mode the guard exists to close is still
+    // reachable through the narrower invocation.
     //
     // A build script runs for every build of this package regardless of which
     // targets are selected, so this is the only place the requirement can be

--- a/crates/hiroz-tests/build.rs
+++ b/crates/hiroz-tests/build.rs
@@ -1,6 +1,35 @@
 use std::{env, path::PathBuf};
 
 fn main() {
+
+    // Package-wide enforcement of the feature requirement.
+    //
+    // `tests/feature_gate.rs` fails loudly when the crate is built without
+    // `ros-msgs`, but only if Cargo happens to select *that* target. Ask for one
+    // gated suite on its own -- `cargo test -p hiroz-tests --test
+    // reentrant_service` with no features -- and Cargo builds only that target,
+    // the crate-level `cfg` compiles it to an empty binary, `0 passed` is
+    // reported, and the guard never runs. The silent-skip mode the guard exists
+    // to close is still reachable through the narrower invocation.
+    //
+    // A build script runs for every build of this package regardless of which
+    // targets are selected, so this is the only place the requirement can be
+    // stated once and hold everywhere.
+    //
+    // Consequence, already declared in `feature_gate.rs`: `hiroz-tests` has no
+    // supported featureless configuration.
+    if std::env::var_os("CARGO_FEATURE_ROS_MSGS").is_none() {
+        panic!(
+            "\n\nhiroz-tests requires the `ros-msgs` feature.\n\n\
+             Without it the suites gated on it compile to empty test binaries \n\
+             that report `0 passed`, which reads as green but is no coverage.\n\n\
+             Build it as:\n\n    \
+             cargo test -p hiroz-tests --features ros-msgs,jazzy\n\n\
+             Suites that drive a real ROS 2 installation need \n    \
+             --features ros-interop,<distro> instead.\n"
+        );
+    }
+
     // Declare custom cfg for ROS version detection
     println!("cargo::rustc-check-cfg=cfg(ros_humble)");
 

--- a/crates/hiroz-tests/build.rs
+++ b/crates/hiroz-tests/build.rs
@@ -3,20 +3,12 @@ use std::{env, path::PathBuf};
 fn main() {
     // Package-wide enforcement of the feature requirement.
     //
-    // `tests/feature_gate.rs` fails loudly when the crate is built without
-    // `ros-msgs`, but only if Cargo happens to select *that* target. Ask for one
-    // gated suite on its own -- `cargo test -p hiroz-tests --test cache` with no
-    // features -- and Cargo builds only that target, the crate-level `cfg`
-    // compiles it to an empty binary, `0 passed` is reported, and the guard
-    // never runs. The silent-skip mode the guard exists to close is still
-    // reachable through the narrower invocation.
-    //
-    // A build script runs for every build of this package regardless of which
-    // targets are selected, so this is the only place the requirement can be
-    // stated once and hold everywhere.
-    //
-    // Consequence, already declared in `feature_gate.rs`: `hiroz-tests` has no
-    // supported featureless configuration.
+    // `tests/feature_gate.rs` only fires if Cargo selects that target.
+    // `cargo test -p hiroz-tests --test cache` with no features builds only
+    // `cache`, which the crate-level `cfg` compiles to an empty binary --
+    // `0 passed`, guard never run. A build script runs for every build of the
+    // package regardless of target selection, so this is the one place the
+    // requirement holds everywhere.
     if std::env::var_os("CARGO_FEATURE_ROS_MSGS").is_none() {
         panic!(
             "\n\nhiroz-tests requires the `ros-msgs` feature.\n\n\

--- a/crates/hiroz-tests/tests/feature_gate.rs
+++ b/crates/hiroz-tests/tests/feature_gate.rs
@@ -1,32 +1,23 @@
 //! Fails loudly when `hiroz-tests` is built without the features its suites need.
 //!
-//! Ten suites in this crate are `#![cfg(feature = "ros-msgs")]` — `cache.rs`,
-//! `lifecycle.rs`, `parameter_tests.rs`, `service_schema_discovery.rs`,
-//! `subscriber_timeout.rs`, `type_description_integration.rs`, the `z_*_example`
-//! suites, and others. A crate-level `cfg` that is not satisfied does not error
-//! and does not warn: the file compiles to an empty test binary reporting
-//! `0 passed`, which is indistinguishable from green in every runner and log.
+//! Several suites here carry a crate-level `#![cfg(feature = "ros-msgs")]`. An
+//! unsatisfied crate-level `cfg` neither errors nor warns: the file compiles to
+//! an empty test binary reporting `0 passed`, which no runner or log can
+//! distinguish from green.
 //!
-//! Two separate mechanisms could hide that, and they are worth keeping distinct:
+//! This file is deliberately **not** gated, so it is the one target a
+//! featureless build cannot compile away. `build.rs` enforces the same
+//! requirement for the whole package, covering the narrower `--test <name>`
+//! invocations that never select this target.
 //!
-//! * **Selection.** `Cargo.toml` sets
-//!   `default-members = ["crates/hiroz", "crates/hiroz-codegen"]`, so a bare
-//!   `cargo nextest run` never selected `hiroz-tests` at all — the crate was not
-//!   built, rather than built empty. `scripts/test-pure-rust.nu` now names the
-//!   crate explicitly.
-//! * **Empty compilation.** Ask for the crate without features and the gated
-//!   suites really do compile away to `0 passed`. That is what this file and the
-//!   build script guard against.
+//! Consequence: `hiroz-tests` has no supported featureless configuration. Run it
+//! as `cargo test -p hiroz-tests --features ros-msgs,jazzy`, or with
+//! `ros-interop,<distro>` for the suites that also drive a ROS installation.
 //!
-//! This file is deliberately **not** gated, so it is the one thing in the crate
-//! that a featureless build cannot compile away. If the features go missing
-//! again, the run fails with a message naming the cause instead of quietly
-//! shrinking.
-//!
-//! Consequence, stated so it is a decision rather than a surprise: `hiroz-tests`
-//! has no supported featureless configuration. Run it as
-//! `cargo test -p hiroz-tests --features ros-msgs,jazzy` (or with `ros-interop`
-//! for the suites that also need a ROS installation).
+//! Note that selection is a separate failure mode from compilation. `Cargo.toml`
+//! sets `default-members` to exclude this crate, so a bare `cargo nextest run`
+//! skips it entirely rather than building it empty; `scripts/test-pure-rust.nu`
+//! names it explicitly to close that path.
 
 /// Without `ros-msgs`, the gated suites are silently absent — fail instead.
 #[test]
@@ -35,10 +26,10 @@ fn ros_msgs_gated_suites_must_not_be_silently_skipped() {
     panic!(
         "hiroz-tests was built without the `ros-msgs` feature.\n\
          \n\
-         The suites gated on it — `cache.rs`, `lifecycle.rs`, \
-         `parameter_tests.rs` and others — have been \
-         compiled to empty test binaries and will report `0 passed`, which reads \
-         as green. That is not a pass; it is no coverage.\n\
+         The suites gated on it — `cache.rs`, `subscriber_timeout.rs`, \
+         `service_schema_discovery.rs`, the `z_*_example` suites and others — \
+         have been compiled to empty test binaries and will report `0 passed`, \
+         which reads as green. That is not a pass; it is no coverage.\n\
          \n\
          Build the crate with its features:\n\
          \n\

--- a/crates/hiroz-tests/tests/feature_gate.rs
+++ b/crates/hiroz-tests/tests/feature_gate.rs
@@ -1,16 +1,22 @@
 //! Fails loudly when `hiroz-tests` is built without the features its suites need.
 //!
-//! Several suites in this crate are `#![cfg(feature = "ros-msgs")]` — most
-//! importantly `reentrant_service.rs`, which is the only coverage the
-//! callback-under-lock deadlocks in the service and parameter paths have. A
-//! crate-level `cfg` that is not satisfied does not error and does not warn: the
-//! file compiles to an empty test binary that reports `0 passed`, which is
-//! indistinguishable from green in every runner and every CI log.
+//! Ten suites in this crate are `#![cfg(feature = "ros-msgs")]` — `cache.rs`,
+//! `lifecycle.rs`, `parameter_tests.rs`, `service_schema_discovery.rs`,
+//! `subscriber_timeout.rs`, `type_description_integration.rs`, the `z_*_example`
+//! suites, and others. A crate-level `cfg` that is not satisfied does not error
+//! and does not warn: the file compiles to an empty test binary reporting
+//! `0 passed`, which is indistinguishable from green in every runner and log.
 //!
-//! That is exactly how those four tests stopped running without anyone noticing.
-//! `scripts/test-pure-rust.nu` linted `hiroz-tests` under interop features but
-//! *tested* it under none, so the clippy step saw the code and the test step did
-//! not.
+//! Two separate mechanisms could hide that, and they are worth keeping distinct:
+//!
+//! * **Selection.** `Cargo.toml` sets
+//!   `default-members = ["crates/hiroz", "crates/hiroz-codegen"]`, so a bare
+//!   `cargo nextest run` never selected `hiroz-tests` at all — the crate was not
+//!   built, rather than built empty. `scripts/test-pure-rust.nu` now names the
+//!   crate explicitly.
+//! * **Empty compilation.** Ask for the crate without features and the gated
+//!   suites really do compile away to `0 passed`. That is what this file and the
+//!   build script guard against.
 //!
 //! This file is deliberately **not** gated, so it is the one thing in the crate
 //! that a featureless build cannot compile away. If the features go missing
@@ -29,7 +35,8 @@ fn ros_msgs_gated_suites_must_not_be_silently_skipped() {
     panic!(
         "hiroz-tests was built without the `ros-msgs` feature.\n\
          \n\
-         The suites gated on it — `reentrant_service.rs` among them — have been \
+         The suites gated on it — `cache.rs`, `lifecycle.rs`, \
+         `parameter_tests.rs` and others — have been \
          compiled to empty test binaries and will report `0 passed`, which reads \
          as green. That is not a pass; it is no coverage.\n\
          \n\

--- a/crates/hiroz-tests/tests/feature_gate.rs
+++ b/crates/hiroz-tests/tests/feature_gate.rs
@@ -1,23 +1,20 @@
 //! Fails loudly when `hiroz-tests` is built without the features its suites need.
 //!
-//! Several suites here carry a crate-level `#![cfg(feature = "ros-msgs")]`. An
-//! unsatisfied crate-level `cfg` neither errors nor warns: the file compiles to
-//! an empty test binary reporting `0 passed`, which no runner or log can
-//! distinguish from green.
+//! Several suites carry a crate-level `#![cfg(feature = "ros-msgs")]`. An
+//! unsatisfied crate-level `cfg` neither errors nor warns — the file compiles to
+//! an empty test binary reporting `0 passed`, indistinguishable from green.
 //!
-//! This file is deliberately **not** gated, so it is the one target a
-//! featureless build cannot compile away. `build.rs` enforces the same
-//! requirement for the whole package, covering the narrower `--test <name>`
-//! invocations that never select this target.
+//! This file is deliberately ungated, so a featureless build cannot compile it
+//! away. `build.rs` covers the narrower `--test <name>` invocations that never
+//! select this target.
 //!
-//! Consequence: `hiroz-tests` has no supported featureless configuration. Run it
-//! as `cargo test -p hiroz-tests --features ros-msgs,jazzy`, or with
-//! `ros-interop,<distro>` for the suites that also drive a ROS installation.
+//! `hiroz-tests` therefore has no supported featureless configuration: run it as
+//! `cargo test -p hiroz-tests --features ros-msgs,jazzy`, or with
+//! `ros-interop,<distro>` for suites that drive a real ROS installation.
 //!
-//! Note that selection is a separate failure mode from compilation. `Cargo.toml`
-//! sets `default-members` to exclude this crate, so a bare `cargo nextest run`
-//! skips it entirely rather than building it empty; `scripts/test-pure-rust.nu`
-//! names it explicitly to close that path.
+//! Selection is a separate failure mode from compilation: this crate is not in
+//! `default-members`, so a bare `cargo nextest run` skips it rather than
+//! building it empty. `scripts/test-pure-rust.nu` names it explicitly.
 
 /// Without `ros-msgs`, the gated suites are silently absent — fail instead.
 #[test]

--- a/crates/hiroz-tests/tests/feature_gate.rs
+++ b/crates/hiroz-tests/tests/feature_gate.rs
@@ -1,0 +1,51 @@
+//! Fails loudly when `hiroz-tests` is built without the features its suites need.
+//!
+//! Several suites in this crate are `#![cfg(feature = "ros-msgs")]` — most
+//! importantly `reentrant_service.rs`, which is the only coverage the
+//! callback-under-lock deadlocks in the service and parameter paths have. A
+//! crate-level `cfg` that is not satisfied does not error and does not warn: the
+//! file compiles to an empty test binary that reports `0 passed`, which is
+//! indistinguishable from green in every runner and every CI log.
+//!
+//! That is exactly how those four tests stopped running without anyone noticing.
+//! `scripts/test-pure-rust.nu` linted `hiroz-tests` under interop features but
+//! *tested* it under none, so the clippy step saw the code and the test step did
+//! not.
+//!
+//! This file is deliberately **not** gated, so it is the one thing in the crate
+//! that a featureless build cannot compile away. If the features go missing
+//! again, the run fails with a message naming the cause instead of quietly
+//! shrinking.
+//!
+//! Consequence, stated so it is a decision rather than a surprise: `hiroz-tests`
+//! has no supported featureless configuration. Run it as
+//! `cargo test -p hiroz-tests --features ros-msgs,jazzy` (or with `ros-interop`
+//! for the suites that also need a ROS installation).
+
+/// Without `ros-msgs`, the gated suites are silently absent — fail instead.
+#[test]
+#[cfg(not(feature = "ros-msgs"))]
+fn ros_msgs_gated_suites_must_not_be_silently_skipped() {
+    panic!(
+        "hiroz-tests was built without the `ros-msgs` feature.\n\
+         \n\
+         The suites gated on it — `reentrant_service.rs` among them — have been \
+         compiled to empty test binaries and will report `0 passed`, which reads \
+         as green. That is not a pass; it is no coverage.\n\
+         \n\
+         Build the crate with its features:\n\
+         \n\
+             cargo test -p hiroz-tests --features ros-msgs,jazzy\n\
+         \n\
+         Suites that additionally drive a real ROS 2 installation need \
+         `--features ros-interop,<distro>` instead."
+    );
+}
+
+/// With `ros-msgs`, record that the gate was satisfied.
+///
+/// Present so the guard is visible in the test list in *both* configurations —
+/// a check whose only evidence is the absence of a failure is not a check.
+#[test]
+#[cfg(feature = "ros-msgs")]
+fn ros_msgs_gated_suites_are_compiled_in() {}

--- a/crates/hiroz/src/lib.rs
+++ b/crates/hiroz/src/lib.rs
@@ -79,6 +79,9 @@ pub mod python_bridge;
 pub mod qos;
 /// Internal message queues.
 pub mod queue;
+
+/// Debug-time enforcement of "no user callback under a hiroz lock guard".
+pub mod reentrancy;
 /// Message type metadata traits (`WithTypeInfo`, etc.).
 pub mod ros_msg;
 /// ROS 2 service client and server.

--- a/crates/hiroz/src/lib.rs
+++ b/crates/hiroz/src/lib.rs
@@ -79,7 +79,6 @@ pub mod python_bridge;
 pub mod qos;
 /// Internal message queues.
 pub mod queue;
-
 /// Debug-time enforcement of "no user callback under a hiroz lock guard".
 pub mod reentrancy;
 /// Message type metadata traits (`WithTypeInfo`, etc.).

--- a/crates/hiroz/src/reentrancy.rs
+++ b/crates/hiroz/src/reentrancy.rs
@@ -113,9 +113,10 @@ pub fn assert_no_guards_held(site: &str) {
             live == 0,
             "hiroz re-entrancy rule violated at `{site}`: about to invoke a user \
              callback with {live} hiroz lock guard(s) still live on this thread. \
-             A callback that re-enters hiroz here will deadlock. Collect what you \
-             need under the lock, drop the guard, then call — see \
-             `GraphEventManager::trigger_graph_change` for the pattern."
+             A callback that re-enters hiroz here may deadlock, and will if it \
+             touches a lock this thread already holds. The fix is always the \
+             same shape: collect what you need into an owned value, drop every \
+             guard, then invoke the callback."
         );
     }
     #[cfg(not(debug_assertions))]

--- a/crates/hiroz/src/reentrancy.rs
+++ b/crates/hiroz/src/reentrancy.rs
@@ -31,8 +31,8 @@
 //!
 //! # Cost
 //!
-//! Zero in release. [`GuardCount`](crate::reentrancy::GuardCount) is a unit
-//! struct whose constructor and `Drop` compile to nothing without
+//! Zero in release. [`GuardCount`](crate::reentrancy::GuardCount) is a
+//! zero-sized newtype whose constructor and `Drop` compile to nothing without
 //! `debug_assertions`, and
 //! [`assert_no_guards_held`](crate::reentrancy::assert_no_guards_held)
 //! expands to nothing. Tests and CI run in debug, which is where the assertion
@@ -57,15 +57,24 @@ thread_local! {
 }
 
 /// RAII counter embedded in every tracked guard.
+///
+/// The private field is what makes the counter trustworthy. As a fieldless unit
+/// struct this was constructible — and therefore *droppable* — by any code that
+/// could name it, and `Drop` decrements the thread-local. A stray
+/// `drop(GuardCount)` while a tracked guard was live would take the count to
+/// zero, `assert_no_guards_held` would pass, and a genuine callback-under-lock
+/// would go unreported. `saturating_sub` guaranteed that desync was silent.
+/// Only this module can mint one now, so the count can only be moved by
+/// acquiring and releasing a real guard.
 #[derive(Debug)]
-pub struct GuardCount;
+pub struct GuardCount(());
 
 impl GuardCount {
     #[inline(always)]
     fn new() -> Self {
         #[cfg(debug_assertions)]
         LIVE_GUARDS.with(|n| n.set(n.get() + 1));
-        Self
+        Self(())
     }
 }
 

--- a/crates/hiroz/src/reentrancy.rs
+++ b/crates/hiroz/src/reentrancy.rs
@@ -63,9 +63,14 @@ thread_local! {
 /// could name it, and `Drop` decrements the thread-local. A stray
 /// `drop(GuardCount)` while a tracked guard was live would take the count to
 /// zero, `assert_no_guards_held` would pass, and a genuine callback-under-lock
-/// would go unreported. `saturating_sub` guaranteed that desync was silent.
-/// Only this module can mint one now, so the count can only be moved by
-/// acquiring and releasing a real guard.
+/// would go unreported. Only this module can mint one now, so the count can only
+/// be moved by acquiring and releasing a real guard.
+///
+/// `Drop` additionally asserts that the count is non-zero before decrementing.
+/// `saturating_sub` alone prevents the wrap but makes the desync *silent*, which
+/// is the failure mode this whole module exists to remove: the counter would
+/// keep reporting zero live guards and the tripwire would pass while a guard was
+/// held. Belt (`saturating_sub`) and braces (the assertion).
 #[derive(Debug)]
 pub struct GuardCount(());
 
@@ -82,7 +87,21 @@ impl Drop for GuardCount {
     #[inline(always)]
     fn drop(&mut self) {
         #[cfg(debug_assertions)]
-        LIVE_GUARDS.with(|n| n.set(n.get().saturating_sub(1)));
+        LIVE_GUARDS.with(|n| {
+            let live = n.get();
+            // `|| panicking()` because a panic raised while unwinding aborts the
+            // process. Without the guard, a `GuardCount` dropped during someone
+            // else's panic would replace their failure with this one and take
+            // the backtrace with it.
+            debug_assert!(
+                live > 0 || std::thread::panicking(),
+                "hiroz GuardCount underflow: a tracked guard was released while \
+                 the live-guard count was already 0. The counter has desynced \
+                 from the guards it tracks, so `assert_no_guards_held` can no \
+                 longer detect a callback invoked under a lock."
+            );
+            n.set(live.saturating_sub(1));
+        });
     }
 }
 
@@ -291,6 +310,21 @@ mod tests {
         // expected to panic there.
         #[cfg(not(debug_assertions))]
         assert_eq!(live_guards(), 0);
+    }
+
+    /// The underflow assertion must also detect. `saturating_sub` on its own
+    /// absorbs a desync silently, which is the shape of defect this module
+    /// exists to remove — so the guard against it needs the same proof the
+    /// tripwire itself gets.
+    ///
+    /// Minting a bare `GuardCount` is only possible inside this module; the
+    /// private field is what makes it unreachable from anywhere else, and that
+    /// is why this can be tested here and nowhere else.
+    #[test]
+    #[cfg_attr(debug_assertions, should_panic(expected = "GuardCount underflow"))]
+    fn underflow_is_not_silent() {
+        assert_eq!(live_guards(), 0);
+        drop(GuardCount(()));
     }
 
     #[test]

--- a/crates/hiroz/src/reentrancy.rs
+++ b/crates/hiroz/src/reentrancy.rs
@@ -1,52 +1,29 @@
-//! Debug-time enforcement of hiroz's one hard rule about user callbacks:
+//! Debug-time enforcement of: **a user callback is never invoked while a hiroz
+//! lock guard is live.**
 //!
-//! > **A user callback is never invoked while a hiroz lock guard is live.**
+//! A callback invoked under a guard runs user code inside hiroz's critical
+//! section. If it re-enters hiroz it re-acquires a non-reentrant lock on the
+//! thread already holding it — a deterministic hang, not a race.
 //!
-//! Every re-entrancy deadlock hiroz has had was one violation of that sentence.
-//! A callback invoked under a guard is user code running inside hiroz's own
-//! critical section, and the first thing such code usually does is call back
-//! into hiroz — re-acquiring a non-reentrant `Mutex`/`RwLock` on the thread that
-//! already holds it. There is no race to lose; it is a deterministic hang.
+//! No lint catches this. `clippy::significant_drop_in_scrutinee` targets guards
+//! that are unnamed scrutinee temporaries; the shape here is
+//! `if let Ok(cb) = holder.lock()`, which *binds* the guard. Measured on this
+//! crate: zero hits, with the lint confirmed live against its own documented
+//! trigger. Nor could a bespoke one do better — the guard lifetime spans a
+//! dynamic dispatch through `Arc<dyn Fn>` or an opaque `extern "C" fn`.
 //!
-//! The rule was previously enforced by review. That does not scale, and it
-//! demonstrably leaked: a mechanical sweep of this workspace found further
-//! instances in `rmw-zenoh-rs` after five had already been fixed by hand.
+//! Zero cost in release: [`GuardCount`] is zero-sized, and it and
+//! [`assert_no_guards_held`] compile to nothing without `debug_assertions`.
+//! Tests and CI run in debug.
 //!
-//! # Why a runtime tripwire and not a lint
+//! Usage: declare locks on callback-reachable paths as [`TrackedMutex`] /
+//! [`TrackedRwLock`], and route every user-code invocation through
+//! [`invoke_user_callback!`].
 //!
-//! The obvious candidate, `clippy::significant_drop_in_scrutinee`, was tried and
-//! **does not fire on this code at all**. It targets guards that are unnamed
-//! temporaries in a `match`/`if let` scrutinee; hiroz's (and rmw's) shape is
-//! `if let Ok(cb) = holder.lock()`, where the guard is *bound* to a name and so
-//! is not a scrutinee temporary. Verified: `cargo clippy -p rmw-zenoh-rs -W
-//! clippy::significant_drop_in_scrutinee` reports zero hits on code containing
-//! five genuine instances of the defect.
-//!
-//! A bespoke lint fares no better. The defect is a *dynamic* guard lifetime
-//! spanning a *dynamic* dispatch through `Arc<dyn Fn>` or an `extern "C" fn`
-//! pointer. Static analysis cannot see through either, and the FFI pointers are
-//! opaque by construction.
-//!
-//! A counter can see both, trivially.
-//!
-//! # Cost
-//!
-//! Zero in release. [`GuardCount`](crate::reentrancy::GuardCount) is a
-//! zero-sized newtype whose constructor and `Drop` compile to nothing without
-//! `debug_assertions`, and
-//! [`assert_no_guards_held`](crate::reentrancy::assert_no_guards_held)
-//! expands to nothing. Tests and CI run in debug, which is where the assertion
-//! is wanted.
-//!
-//! # Using it
-//!
-//! Lock declarations on a user-callback-reachable path use
-//! [`TrackedMutex`](crate::reentrancy::TrackedMutex) /
-//! [`TrackedRwLock`](crate::reentrancy::TrackedRwLock) instead of the
-//! `std::sync` originals. Every site that invokes user code calls
-//! [`assert_no_guards_held`](crate::reentrancy::assert_no_guards_held) first — in practice via
-//! [`invoke_user_callback!`], which does both in one line and names the site in
-//! the panic message.
+//! [`GuardCount`]: crate::reentrancy::GuardCount
+//! [`assert_no_guards_held`]: crate::reentrancy::assert_no_guards_held
+//! [`TrackedMutex`]: crate::reentrancy::TrackedMutex
+//! [`TrackedRwLock`]: crate::reentrancy::TrackedRwLock
 
 use std::sync::{LockResult, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
@@ -58,19 +35,13 @@ thread_local! {
 
 /// RAII counter embedded in every tracked guard.
 ///
-/// The private field is what makes the counter trustworthy. As a fieldless unit
-/// struct this was constructible — and therefore *droppable* — by any code that
-/// could name it, and `Drop` decrements the thread-local. A stray
-/// `drop(GuardCount)` while a tracked guard was live would take the count to
-/// zero, `assert_no_guards_held` would pass, and a genuine callback-under-lock
-/// would go unreported. Only this module can mint one now, so the count can only
-/// be moved by acquiring and releasing a real guard.
+/// The private field makes it unforgeable: as a fieldless unit struct, any code
+/// naming it could `drop` one, decrementing the count to zero while a guard was
+/// live and silently disarming [`assert_no_guards_held`].
 ///
-/// `Drop` additionally asserts that the count is non-zero before decrementing.
-/// `saturating_sub` alone prevents the wrap but makes the desync *silent*, which
-/// is the failure mode this whole module exists to remove: the counter would
-/// keep reporting zero live guards and the tripwire would pass while a guard was
-/// held. Belt (`saturating_sub`) and braces (the assertion).
+/// `Drop` asserts non-zero before decrementing. `saturating_sub` alone prevents
+/// the wrap but hides the desync, which is the failure mode this module exists
+/// to remove.
 #[derive(Debug)]
 pub struct GuardCount(());
 
@@ -89,16 +60,14 @@ impl Drop for GuardCount {
         #[cfg(debug_assertions)]
         LIVE_GUARDS.with(|n| {
             let live = n.get();
-            // `|| panicking()` because a panic raised while unwinding aborts the
-            // process. Without the guard, a `GuardCount` dropped during someone
-            // else's panic would replace their failure with this one and take
-            // the backtrace with it.
+            // `|| panicking()`: panicking while unwinding aborts, which would
+            // replace someone else's failure with this one.
             debug_assert!(
                 live > 0 || std::thread::panicking(),
-                "hiroz GuardCount underflow: a tracked guard was released while \
-                 the live-guard count was already 0. The counter has desynced \
-                 from the guards it tracks, so `assert_no_guards_held` can no \
-                 longer detect a callback invoked under a lock."
+                "hiroz GuardCount underflow: guard released with the live count \
+                 already 0. The counter has desynced from the guards it tracks, \
+                 so `assert_no_guards_held` can no longer detect a callback \
+                 invoked under a lock."
             );
             n.set(live.saturating_sub(1));
         });
@@ -118,11 +87,11 @@ pub fn live_guards() -> usize {
     }
 }
 
-/// Panics (debug builds only) if any tracked hiroz guard is live on this thread.
+/// Panics (debug only) if any tracked guard is live on this thread.
 ///
-/// Call immediately before invoking user code. `site` names the call site and is
-/// reproduced in the panic message, because the useful information when this
-/// fires is *which* callback was about to run, not the backtrace of the counter.
+/// Call immediately before invoking user code. `site` is reproduced in the panic
+/// message — when this fires, *which* callback was about to run is the useful
+/// information, not the counter's backtrace.
 #[inline(always)]
 pub fn assert_no_guards_held(site: &str) {
     #[cfg(debug_assertions)]
@@ -131,10 +100,9 @@ pub fn assert_no_guards_held(site: &str) {
         assert!(
             live == 0,
             "hiroz re-entrancy rule violated at `{site}`: about to invoke a user \
-             callback with {live} hiroz lock guard(s) still live on this thread. \
-             A callback that re-enters hiroz here may deadlock, and will if it \
-             touches a lock this thread already holds. The fix is always the \
-             same shape: collect what you need into an owned value, drop every \
+             callback with {live} lock guard(s) live on this thread. A callback \
+             that re-enters hiroz will deadlock if it touches a lock this thread \
+             holds. Fix: collect what you need into an owned value, drop every \
              guard, then invoke the callback."
         );
     }
@@ -298,28 +266,20 @@ mod tests {
         assert_no_guards_held("test");
     }
 
-    /// The detector must actually detect. Without this, a tripwire that never
-    /// fires is indistinguishable from a codebase with no defects.
+    /// A tripwire that never fires is indistinguishable from a clean codebase.
     #[test]
     #[cfg_attr(debug_assertions, should_panic(expected = "re-entrancy rule violated"))]
     fn assert_fires_while_a_guard_is_live() {
         let m = TrackedMutex::new(0u32);
         let _g = m.lock().unwrap();
         assert_no_guards_held("deliberate violation");
-        // In release the assertion is compiled out, so the test must not be
-        // expected to panic there.
+        // Compiled out in release, so no panic is expected there.
         #[cfg(not(debug_assertions))]
         assert_eq!(live_guards(), 0);
     }
 
-    /// The underflow assertion must also detect. `saturating_sub` on its own
-    /// absorbs a desync silently, which is the shape of defect this module
-    /// exists to remove — so the guard against it needs the same proof the
-    /// tripwire itself gets.
-    ///
-    /// Minting a bare `GuardCount` is only possible inside this module; the
-    /// private field is what makes it unreachable from anywhere else, and that
-    /// is why this can be tested here and nowhere else.
+    /// The underflow assertion needs the same proof the tripwire gets. Only this
+    /// module can mint a bare `GuardCount`, so only here can it be tested.
     #[test]
     #[cfg_attr(debug_assertions, should_panic(expected = "GuardCount underflow"))]
     fn underflow_is_not_silent() {

--- a/crates/hiroz/src/reentrancy.rs
+++ b/crates/hiroz/src/reentrancy.rs
@@ -1,0 +1,303 @@
+//! Debug-time enforcement of hiroz's one hard rule about user callbacks:
+//!
+//! > **A user callback is never invoked while a hiroz lock guard is live.**
+//!
+//! Every re-entrancy deadlock hiroz has had was one violation of that sentence.
+//! A callback invoked under a guard is user code running inside hiroz's own
+//! critical section, and the first thing such code usually does is call back
+//! into hiroz — re-acquiring a non-reentrant `Mutex`/`RwLock` on the thread that
+//! already holds it. There is no race to lose; it is a deterministic hang.
+//!
+//! The rule was previously enforced by review. That does not scale, and it
+//! demonstrably leaked: a mechanical sweep of this workspace found further
+//! instances in `rmw-zenoh-rs` after five had already been fixed by hand.
+//!
+//! # Why a runtime tripwire and not a lint
+//!
+//! The obvious candidate, `clippy::significant_drop_in_scrutinee`, was tried and
+//! **does not fire on this code at all**. It targets guards that are unnamed
+//! temporaries in a `match`/`if let` scrutinee; hiroz's (and rmw's) shape is
+//! `if let Ok(cb) = holder.lock()`, where the guard is *bound* to a name and so
+//! is not a scrutinee temporary. Verified: `cargo clippy -p rmw-zenoh-rs -W
+//! clippy::significant_drop_in_scrutinee` reports zero hits on code containing
+//! five genuine instances of the defect.
+//!
+//! A bespoke lint fares no better. The defect is a *dynamic* guard lifetime
+//! spanning a *dynamic* dispatch through `Arc<dyn Fn>` or an `extern "C" fn`
+//! pointer. Static analysis cannot see through either, and the FFI pointers are
+//! opaque by construction.
+//!
+//! A counter can see both, trivially.
+//!
+//! # Cost
+//!
+//! Zero in release. [`GuardCount`](crate::reentrancy::GuardCount) is a unit
+//! struct whose constructor and `Drop` compile to nothing without
+//! `debug_assertions`, and
+//! [`assert_no_guards_held`](crate::reentrancy::assert_no_guards_held)
+//! expands to nothing. Tests and CI run in debug, which is where the assertion
+//! is wanted.
+//!
+//! # Using it
+//!
+//! Lock declarations on a user-callback-reachable path use
+//! [`TrackedMutex`](crate::reentrancy::TrackedMutex) /
+//! [`TrackedRwLock`](crate::reentrancy::TrackedRwLock) instead of the
+//! `std::sync` originals. Every site that invokes user code calls
+//! [`assert_no_guards_held`](crate::reentrancy::assert_no_guards_held) first — in practice via
+//! [`invoke_user_callback!`], which does both in one line and names the site in
+//! the panic message.
+
+use std::sync::{LockResult, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+#[cfg(debug_assertions)]
+thread_local! {
+    /// How many tracked hiroz guards are live on this thread right now.
+    static LIVE_GUARDS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// RAII counter embedded in every tracked guard.
+#[derive(Debug)]
+pub struct GuardCount;
+
+impl GuardCount {
+    #[inline(always)]
+    fn new() -> Self {
+        #[cfg(debug_assertions)]
+        LIVE_GUARDS.with(|n| n.set(n.get() + 1));
+        Self
+    }
+}
+
+impl Drop for GuardCount {
+    #[inline(always)]
+    fn drop(&mut self) {
+        #[cfg(debug_assertions)]
+        LIVE_GUARDS.with(|n| n.set(n.get().saturating_sub(1)));
+    }
+}
+
+/// Number of tracked hiroz guards live on this thread. Always 0 in release.
+#[inline(always)]
+pub fn live_guards() -> usize {
+    #[cfg(debug_assertions)]
+    {
+        LIVE_GUARDS.with(|n| n.get())
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        0
+    }
+}
+
+/// Panics (debug builds only) if any tracked hiroz guard is live on this thread.
+///
+/// Call immediately before invoking user code. `site` names the call site and is
+/// reproduced in the panic message, because the useful information when this
+/// fires is *which* callback was about to run, not the backtrace of the counter.
+#[inline(always)]
+pub fn assert_no_guards_held(site: &str) {
+    #[cfg(debug_assertions)]
+    {
+        let live = live_guards();
+        assert!(
+            live == 0,
+            "hiroz re-entrancy rule violated at `{site}`: about to invoke a user \
+             callback with {live} hiroz lock guard(s) still live on this thread. \
+             A callback that re-enters hiroz here will deadlock. Collect what you \
+             need under the lock, drop the guard, then call — see \
+             `GraphEventManager::trigger_graph_change` for the pattern."
+        );
+    }
+    #[cfg(not(debug_assertions))]
+    let _ = site;
+}
+
+/// Assert the re-entrancy rule, then invoke user code.
+///
+/// ```ignore
+/// invoke_user_callback!("EventsManager::set_callback backlog", callback(count));
+/// ```
+#[macro_export]
+macro_rules! invoke_user_callback {
+    ($site:expr, $call:expr) => {{
+        $crate::reentrancy::assert_no_guards_held($site);
+        $call
+    }};
+}
+
+// ---------------------------------------------------------------------------
+// Tracked lock types
+// ---------------------------------------------------------------------------
+
+/// A `std::sync::Mutex` whose guards are counted by [`live_guards`].
+#[derive(Debug, Default)]
+pub struct TrackedMutex<T>(Mutex<T>);
+
+impl<T> TrackedMutex<T> {
+    pub fn new(value: T) -> Self {
+        Self(Mutex::new(value))
+    }
+
+    pub fn lock(&self) -> LockResult<TrackedMutexGuard<'_, T>> {
+        match self.0.lock() {
+            Ok(inner) => Ok(TrackedMutexGuard {
+                inner,
+                _count: GuardCount::new(),
+            }),
+            Err(poisoned) => Err(std::sync::PoisonError::new(TrackedMutexGuard {
+                inner: poisoned.into_inner(),
+                _count: GuardCount::new(),
+            })),
+        }
+    }
+}
+
+/// Guard for [`TrackedMutex`]. Field order matters: `inner` is declared first so
+/// it is released before the counter decrements, never the other way round.
+#[derive(Debug)]
+pub struct TrackedMutexGuard<'a, T> {
+    inner: MutexGuard<'a, T>,
+    _count: GuardCount,
+}
+
+impl<T> std::ops::Deref for TrackedMutexGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> std::ops::DerefMut for TrackedMutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+/// A `std::sync::RwLock` whose guards are counted by [`live_guards`].
+#[derive(Debug, Default)]
+pub struct TrackedRwLock<T>(RwLock<T>);
+
+impl<T> TrackedRwLock<T> {
+    pub fn new(value: T) -> Self {
+        Self(RwLock::new(value))
+    }
+
+    pub fn read(&self) -> LockResult<TrackedReadGuard<'_, T>> {
+        match self.0.read() {
+            Ok(inner) => Ok(TrackedReadGuard {
+                inner,
+                _count: GuardCount::new(),
+            }),
+            Err(p) => Err(std::sync::PoisonError::new(TrackedReadGuard {
+                inner: p.into_inner(),
+                _count: GuardCount::new(),
+            })),
+        }
+    }
+
+    pub fn write(&self) -> LockResult<TrackedWriteGuard<'_, T>> {
+        match self.0.write() {
+            Ok(inner) => Ok(TrackedWriteGuard {
+                inner,
+                _count: GuardCount::new(),
+            }),
+            Err(p) => Err(std::sync::PoisonError::new(TrackedWriteGuard {
+                inner: p.into_inner(),
+                _count: GuardCount::new(),
+            })),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TrackedReadGuard<'a, T> {
+    inner: RwLockReadGuard<'a, T>,
+    _count: GuardCount,
+}
+
+impl<T> std::ops::Deref for TrackedReadGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+#[derive(Debug)]
+pub struct TrackedWriteGuard<'a, T> {
+    inner: RwLockWriteGuard<'a, T>,
+    _count: GuardCount,
+}
+
+impl<T> std::ops::Deref for TrackedWriteGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> std::ops::DerefMut for TrackedWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guards_are_counted_and_released() {
+        let m = TrackedMutex::new(1u32);
+        assert_eq!(live_guards(), 0);
+        {
+            let g = m.lock().unwrap();
+            assert_eq!(*g, 1);
+            assert_eq!(live_guards(), 1);
+            {
+                let rw = TrackedRwLock::new(2u32);
+                let _r = rw.read().unwrap();
+                assert_eq!(live_guards(), 2);
+            }
+            assert_eq!(live_guards(), 1);
+        }
+        assert_eq!(live_guards(), 0);
+    }
+
+    #[test]
+    fn assert_passes_with_no_guards() {
+        assert_no_guards_held("test");
+    }
+
+    /// The detector must actually detect. Without this, a tripwire that never
+    /// fires is indistinguishable from a codebase with no defects.
+    #[test]
+    #[cfg_attr(debug_assertions, should_panic(expected = "re-entrancy rule violated"))]
+    fn assert_fires_while_a_guard_is_live() {
+        let m = TrackedMutex::new(0u32);
+        let _g = m.lock().unwrap();
+        assert_no_guards_held("deliberate violation");
+        // In release the assertion is compiled out, so the test must not be
+        // expected to panic there.
+        #[cfg(not(debug_assertions))]
+        assert_eq!(live_guards(), 0);
+    }
+
+    #[test]
+    fn a_poisoned_guard_is_still_counted() {
+        let m = std::sync::Arc::new(TrackedMutex::new(0u32));
+        let m2 = m.clone();
+        let _ = std::thread::spawn(move || {
+            let _g = m2.lock().unwrap();
+            panic!("poison it");
+        })
+        .join();
+
+        let guard = m.lock();
+        assert!(guard.is_err(), "expected the mutex to be poisoned");
+        let recovered = guard.unwrap_or_else(|e| e.into_inner());
+        assert_eq!(live_guards(), 1, "a recovered poisoned guard must count");
+        drop(recovered);
+        assert_eq!(live_guards(), 0);
+    }
+}

--- a/scripts/check-local.nu
+++ b/scripts/check-local.nu
@@ -56,7 +56,7 @@ def main [--suite: string = "full"] {
     if $suite == "lint" {
         log-header "Running hiroz Lint Checks"
         let checks = [
-            {name: "Formatting (cargo fmt)", cmd: "cargo fmt --check"},
+            {name: "Formatting (cargo fmt)", cmd: "cargo fmt --all --check"},
             {name: "Clippy (all targets)", cmd: "cargo clippy --all-targets -- -D warnings"},
         ]
         let results = $checks | enumerate | each {|item|
@@ -70,7 +70,7 @@ def main [--suite: string = "full"] {
     log-header "Running hiroz Pre-Submission Checks"
 
     let checks = [
-        {name: "Formatting (cargo fmt)", cmd: "cargo fmt --check"},
+        {name: "Formatting (cargo fmt)", cmd: "cargo fmt --all --check"},
         {name: "Clippy (all targets)", cmd: "cargo clippy --all-targets -- -D warnings"},
         {name: "Build (cargo build)", cmd: "cargo build --examples"},
         {name: "Tests", cmd: (if (which cargo-nextest | is-not-empty) {
@@ -78,6 +78,12 @@ def main [--suite: string = "full"] {
         } else {
             "cargo test --lib --tests"
         })},
+        # The four checks below exist in scripts/check-local.sh (which remote CI
+        # runs) but were absent here, so they could only ever fail remotely.
+        {name: "hu clippy (check-hu)", cmd: "nu scripts/test-pure-rust.nu check-hu"},
+        {name: "SHM tests (test-shm)", cmd: "nu scripts/test-pure-rust.nu test-shm"},
+        {name: "Distro feature flags (check-distro-features)", cmd: "nu scripts/test-pure-rust.nu check-distro-features"},
+        {name: "Rustdoc links (cargo doc)", cmd: "let r = (^cargo doc --no-deps -p hiroz --quiet | complete); let w = ($r.stderr | lines | where $it =~ 'unresolved link'); if ($w | is-not-empty) { print ($w | str join (char newline)); error make {msg: 'rustdoc: unresolved intra-doc links'} }"},
     ]
 
     let results = $checks | enumerate | each {|item|

--- a/scripts/check-local.nu
+++ b/scripts/check-local.nu
@@ -83,7 +83,7 @@ def main [--suite: string = "full"] {
         {name: "hu clippy (check-hu)", cmd: "nu scripts/test-pure-rust.nu check-hu"},
         {name: "SHM tests (test-shm)", cmd: "nu scripts/test-pure-rust.nu test-shm"},
         {name: "Distro feature flags (check-distro-features)", cmd: "nu scripts/test-pure-rust.nu check-distro-features"},
-        {name: "Rustdoc links (cargo doc)", cmd: "let r = (^cargo doc --no-deps -p hiroz --quiet | complete); let w = ($r.stderr | lines | where $it =~ 'unresolved link'); if ($w | is-not-empty) { print ($w | str join (char newline)); error make {msg: 'rustdoc: unresolved intra-doc links'} }"},
+        {name: "Rustdoc links (cargo doc)", cmd: "let r = (^cargo doc --no-deps -p hiroz --quiet | complete); let w = ($r.stderr | lines | where {|it| ($it =~ 'unresolved link') or ($it =~ 'broken_intra_doc_links')}); if ($w | is-not-empty) { print ($w | str join (char newline)); error make {msg: 'rustdoc: unresolved intra-doc links'} }"},
     ]
 
     let results = $checks | enumerate | each {|item|

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -35,7 +35,9 @@ run_check() {
 }
 
 # 1. Check formatting
-run_check "Formatting (cargo fmt)" "cargo fmt --check"
+# --all is required: without it cargo fmt only covers the default workspace
+# members, silently skipping hiroz-py and rmw-zenoh-rs.
+run_check "Formatting (cargo fmt)" "cargo fmt --all --check"
 
 # 2. Clippy lints
 run_check "Clippy (all targets)" "cargo clippy --all-targets -- -D warnings"

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -35,8 +35,9 @@ run_check() {
 }
 
 # 1. Check formatting
-# --all is required: without it cargo fmt only covers the default workspace
-# members, silently skipping hiroz-py and rmw-zenoh-rs.
+# --all is required: default-members is just hiroz and hiroz-codegen, so without
+# it every other member is skipped -- which is how the hiroz-tests violation
+# fixed in #286 reached main.
 run_check "Formatting (cargo fmt)" "cargo fmt --all --check"
 
 # 2. Clippy lints

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -142,7 +142,10 @@ def test-shm [] {
     # Integration-style unit tests (pub/sub with SHM)
     run-cmd "cargo test --package hiroz --test shm"
     # Integration tests (validate shm_pointcloud2 example)
-    run-cmd "cargo test --package hiroz-tests --test shm_example"
+    # `hiroz-tests` has no featureless configuration -- its build script now
+    # enforces that -- so this names the features even though shm_example
+    # itself is ungated.
+    run-cmd "cargo test --package hiroz-tests --test shm_example --features ros-msgs,jazzy"
 }
 
 # ============================================================================

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -19,7 +19,14 @@ def run-tests [] {
     $env.RUSTFLAGS = "-D warnings"
 
     log-step "Run tests"
-    run-cmd "cargo nextest run --no-fail-fast"
+    # `hiroz-tests` is excluded here and run separately below *with* its features.
+    # Several of its suites — `reentrant_service.rs` most importantly — are
+    # `#![cfg(feature = "ros-msgs")]`, and a crate-level cfg that is not satisfied
+    # compiles to an empty test binary reporting `0 passed`. That reads as green.
+    # None of those features need a ROS installation (hiroz-msgs bundles the
+    # definitions), so there is no reason for this job to run the crate blind.
+    run-cmd "cargo nextest run --no-fail-fast --workspace --exclude hiroz-tests"
+    run-cmd "cargo nextest run --no-fail-fast -p hiroz-tests --features ros-msgs,jazzy"
 }
 
 def check-bundled-msgs [] {

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -20,9 +20,13 @@ def run-tests [] {
 
     log-step "Run tests"
     # `hiroz-tests` is excluded here and run separately below *with* its features.
-    # Several of its suites — `reentrant_service.rs` most importantly — are
+    # Ten of its suites (`cache.rs`, `lifecycle.rs`, `parameter_tests.rs`,
+    # `service_schema_discovery.rs`, `subscriber_timeout.rs` and others) are
     # `#![cfg(feature = "ros-msgs")]`, and a crate-level cfg that is not satisfied
     # compiles to an empty test binary reporting `0 passed`. That reads as green.
+    # Separately, the crate is not in `default-members`, so before this change a
+    # bare `cargo nextest run` did not build it at all -- naming it explicitly is
+    # what makes the features load-bearing rather than moot.
     # None of those features need a ROS installation (hiroz-msgs bundles the
     # definitions), so there is no reason for this job to run the crate blind.
     # `rmw-zenoh-rs` is excluded too: its build script generates bindings from

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -25,7 +25,12 @@ def run-tests [] {
     # compiles to an empty test binary reporting `0 passed`. That reads as green.
     # None of those features need a ROS installation (hiroz-msgs bundles the
     # definitions), so there is no reason for this job to run the crate blind.
-    run-cmd "cargo nextest run --no-fail-fast --workspace --exclude hiroz-tests"
+    # `rmw-zenoh-rs` is excluded too: its build script generates bindings from
+    # ROS C headers (`rcutils/strdup.h`), which this job by definition does not
+    # have. It is not in `default-members`, so it was never built here before
+    # `--workspace` was introduced -- excluding it restores that, rather than
+    # dropping coverage. The ROS jobs build and lint it via `-F rmw`.
+    run-cmd "cargo nextest run --no-fail-fast --workspace --exclude hiroz-tests --exclude rmw-zenoh-rs"
     run-cmd "cargo nextest run --no-fail-fast -p hiroz-tests --features ros-msgs,jazzy"
 }
 

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -30,7 +30,15 @@ def run-tests [] {
     # have. It is not in `default-members`, so it was never built here before
     # `--workspace` was introduced -- excluding it restores that, rather than
     # dropping coverage. The ROS jobs build and lint it via `-F rmw`.
-    run-cmd "cargo nextest run --no-fail-fast --workspace --exclude hiroz-tests --exclude rmw-zenoh-rs"
+    # `shm_size_estimation` is skipped, not excluded for convenience: it asks the
+    # OS for a POSIX shared-memory segment large enough to hold a PointCloud2,
+    # and a GitHub runner's `/dev/shm` cannot provide it -- the failure is
+    # `OS error 12` (ENOMEM) from `zenoh-shm`, before any hiroz code runs. It is
+    # a property of the machine, not of the change under test. SHM is covered by
+    # the dedicated `test-shm` step, which uses segments a runner can allocate.
+    # `hiroz-msgs` is not in `default-members`, so these never ran in this job
+    # until `--workspace` was introduced here.
+    run-cmd "cargo nextest run --no-fail-fast --workspace --exclude hiroz-tests --exclude rmw-zenoh-rs -E 'not binary(shm_size_estimation)'"
     run-cmd "cargo nextest run --no-fail-fast -p hiroz-tests --features ros-msgs,jazzy"
 }
 

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -19,29 +19,19 @@ def run-tests [] {
     $env.RUSTFLAGS = "-D warnings"
 
     log-step "Run tests"
-    # `hiroz-tests` is excluded here and run separately below *with* its features.
-    # Ten of its suites (`cache.rs`, `lifecycle.rs`, `parameter_tests.rs`,
-    # `service_schema_discovery.rs`, `subscriber_timeout.rs` and others) are
-    # `#![cfg(feature = "ros-msgs")]`, and a crate-level cfg that is not satisfied
-    # compiles to an empty test binary reporting `0 passed`. That reads as green.
-    # Separately, the crate is not in `default-members`, so before this change a
-    # bare `cargo nextest run` did not build it at all -- naming it explicitly is
-    # what makes the features load-bearing rather than moot.
-    # None of those features need a ROS installation (hiroz-msgs bundles the
-    # definitions), so there is no reason for this job to run the crate blind.
-    # `rmw-zenoh-rs` is excluded too: its build script generates bindings from
-    # ROS C headers (`rcutils/strdup.h`), which this job by definition does not
-    # have. It is not in `default-members`, so it was never built here before
-    # `--workspace` was introduced -- excluding it restores that, rather than
-    # dropping coverage. The ROS jobs build and lint it via `-F rmw`.
-    # `shm_size_estimation` is skipped, not excluded for convenience: it asks the
-    # OS for a POSIX shared-memory segment large enough to hold a PointCloud2,
-    # and a GitHub runner's `/dev/shm` cannot provide it -- the failure is
-    # `OS error 12` (ENOMEM) from `zenoh-shm`, before any hiroz code runs. It is
-    # a property of the machine, not of the change under test. SHM is covered by
-    # the dedicated `test-shm` step, which uses segments a runner can allocate.
-    # `hiroz-msgs` is not in `default-members`, so these never ran in this job
-    # until `--workspace` was introduced here.
+    # Three exclusions, each run or covered elsewhere:
+    #
+    # - `hiroz-tests`: run separately below with `ros-msgs,jazzy`. Its gated
+    #   suites are `#![cfg(feature = "ros-msgs")]` and compile to empty binaries
+    #   reporting `0 passed` without them. No ROS install needed -- hiroz-msgs
+    #   bundles the definitions.
+    # - `rmw-zenoh-rs`: its build script generates bindings from ROS C headers,
+    #   which this job does not have. The ROS jobs lint it via `-F rmw`.
+    # - `shm_size_estimation`: needs a `/dev/shm` segment sized for a
+    #   PointCloud2; a runner cannot allocate it and `zenoh-shm` fails with
+    #   ENOMEM before any hiroz code runs. Covered by the `test-shm` step.
+    #
+    # None were in `default-members`, so none ran here before `--workspace`.
     run-cmd "cargo nextest run --no-fail-fast --workspace --exclude hiroz-tests --exclude rmw-zenoh-rs -E 'not binary(shm_size_estimation)'"
     run-cmd "cargo nextest run --no-fail-fast -p hiroz-tests --features ros-msgs,jazzy"
 }
@@ -159,9 +149,8 @@ def test-shm [] {
     # Integration-style unit tests (pub/sub with SHM)
     run-cmd "cargo test --package hiroz --test shm"
     # Integration tests (validate shm_pointcloud2 example)
-    # `hiroz-tests` has no featureless configuration -- its build script now
-    # enforces that -- so this names the features even though shm_example
-    # itself is ungated.
+    # `hiroz-tests` has no featureless configuration (enforced by its build
+    # script), so name the features even though shm_example itself is ungated.
     run-cmd "cargo test --package hiroz-tests --test shm_example --features ros-msgs,jazzy"
 }
 

--- a/scripts/test-ros.nu
+++ b/scripts/test-ros.nu
@@ -22,11 +22,9 @@ def clippy-rmw [] {
     }
 
     log-step "Clippy (rmw feature)"
-    # `hiroz-tests` is excluded and linted separately with its features. Under
-    # plain `--workspace` it is selected with none, and its suites are
-    # `#![cfg(feature = "ros-msgs")]` — so clippy would lint a set of empty
-    # files and report success. Its build script now refuses that configuration
-    # outright rather than let it look clean.
+    # `hiroz-tests` is linted separately with its features: under plain
+    # `--workspace` it is selected with none, so clippy would lint a set of
+    # empty files and report success.
     run-cmd "cargo clippy --all-targets --workspace --exclude hiroz-tests -F rmw -- -D warnings"
     run-cmd $"cargo clippy --all-targets -p hiroz-tests --features ros-interop,($distro) -- -D warnings"
 }

--- a/scripts/test-ros.nu
+++ b/scripts/test-ros.nu
@@ -22,7 +22,13 @@ def clippy-rmw [] {
     }
 
     log-step "Clippy (rmw feature)"
-    run-cmd "cargo clippy --all-targets --workspace -F rmw -- -D warnings"
+    # `hiroz-tests` is excluded and linted separately with its features. Under
+    # plain `--workspace` it is selected with none, and its suites are
+    # `#![cfg(feature = "ros-msgs")]` — so clippy would lint a set of empty
+    # files and report success. Its build script now refuses that configuration
+    # outright rather than let it look clean.
+    run-cmd "cargo clippy --all-targets --workspace --exclude hiroz-tests -F rmw -- -D warnings"
+    run-cmd $"cargo clippy --all-targets -p hiroz-tests --features ros-interop,($distro) -- -D warnings"
 }
 
 def run-ros-interop [] {


### PR DESCRIPTION
Part of #282 — the defect class, the shared fix shape and the merge order are stated there.

## Role in #282

**The mechanism, and the keystone.** This PR fixes no defect; it lands the detector. It is *inert as merged* — nothing in production code uses the new types on this branch — and becomes load-bearing as #257, #260 and #262 land, each converting its own lock and routing its own callout. Those three do not compile without it, so it merges first.

## Issue

Closes #254 (enhancement).

**No failing baseline, and that is the honest answer: this PR fixes no bug.** The justification is that it makes an entire class detectable rather than each instance individually.

What is demonstrated is that the detector detects, which matters more than usual here — a check that has never printed a failure is unvalidated. `assert_fires_while_a_guard_is_live` is a `should_panic` unit test that fires the assertion with a live tracked guard, so the tripwire cannot silently rot into a no-op.

## What this PR does

- **`crates/hiroz/src/reentrancy.rs` (new).** A thread-local count of live guards; an RAII `GuardCount` that increments on acquire and decrements on drop; `TrackedMutex<T>` / `TrackedRwLock<T>` whose guards embed it; `assert_no_guards_held(site)`, which panics naming the call site; and `invoke_user_callback!(site, call)`, which does both in one line. Guard field order is fixed so the inner guard releases *before* the counter falls — reversed, there is an instant where the count reads zero while the lock is held. All behind `debug_assertions`; zero cost in release.

- **A barrier that is not executed is not a barrier.** `hiroz-tests` was linted with interop features but tested with none, and a crate-level `#![cfg(feature = "ros-msgs")]` that is unsatisfied compiles to an **empty test binary reporting `0 passed`** — indistinguishable from green. Four re-entrancy tests had no coverage in the job that gates every PR. CI now runs `hiroz-tests` with `ros-msgs,jazzy`, and `build.rs` states the requirement package-wide so a narrower `--test <name>` cannot bypass it.

- **`scripts/check-local.nu`** realigned with what CI actually runs: four missing checks, and `cargo fmt --all` — `default-members` is only `hiroz` and `hiroz-codegen`, so without it every other member is skipped, which is how the violation fixed in #286 reached main.

A cheaper option was tried and rejected on measurement: `clippy::significant_drop_in_scrutinee` reports **zero** hits on `hiroz`, with the lint confirmed live in the same run against its own documented trigger (a scrutinee-temporary guard fires; the bound-guard shape transcribed from `parameter/service.rs:191` does not). The rule keys on guards left as unnamed scrutinee temporaries, and the shape here *binds* the guard. Nor could a bespoke lint do better: the defect is a dynamic guard lifetime spanning a dispatch through `Arc<dyn Fn>` or an opaque `extern "C" fn`.

## Breaking changes

None to any published API, and zero cost in release builds.

`hiroz-tests` now requires `--features ros-msgs` to build at all. That is a change to how the test crate is invoked — and it is the point of the change, not a side effect.

## Checklist

- [x] Ran `./scripts/check-local.sh` successfully
- [x] Added/updated tests/documentation (if applicable)

Rebased onto `main` after #286; `cargo fmt --all --check`, the pre-commit gate, the reentrancy suite and `cargo doc` all pass locally on the rebased branch.
