### PR TITLE
fix(event,graph): run event callbacks outside the locks they live under

### DIFF
--- a/crates/hiroz-tests/tests/reentrant_event_status.rs
+++ b/crates/hiroz-tests/tests/reentrant_event_status.rs
@@ -19,6 +19,14 @@
 //! Each scenario runs on a dedicated thread behind a hard deadline, so a
 //! re-entrancy deadlock fails the test instead of wedging the suite — the same
 //! shape as `reentrant_graph_event.rs`.
+//!
+//! # These are not A/B detectors
+//!
+//! Both tests call `update_shared_event_status`, which this change introduces.
+//! Reverting the production code does not make them fail — it makes this file
+//! stop compiling. They show the new entry point is re-entrancy-safe; they are
+//! not evidence that the old shape deadlocked. The detectors for that live in
+//! `reentrant_graph_event.rs`, which does go red on a revert.
 
 use std::{
     sync::{

--- a/crates/hiroz-tests/tests/reentrant_event_status.rs
+++ b/crates/hiroz-tests/tests/reentrant_event_status.rs
@@ -1,0 +1,155 @@
+//! Re-entrancy audit for endpoint event-status updates.
+//!
+//! An `EventsManager` lives behind an `Arc<Mutex<..>>` that its owners share
+//! with `RmEventHandle`. `update_event_status` takes `&mut self`, so every
+//! caller necessarily holds that outer mutex — and the method fires the
+//! registered callback. The callback is user code: the rmw layer hands it
+//! straight to an rclcpp executor, and the first thing such a callback does is
+//! usually ask the handle that fired for the status behind it
+//! (`rmw_take_event` → `RmEventHandle::take_event`), which locks the very same
+//! mutex. On a non-reentrant `std::sync::Mutex` that is a self-deadlock on the
+//! thread already holding the guard, with no race needed.
+//!
+//! The fix is the shape used throughout this module and by zenoh core in
+//! `resolve_put`: record under the lock, drop the guard, then invoke.
+//! `EventsManager::record_event_status_with_policy` returns the callback
+//! instead of calling it, and `update_shared_event_status[_with_policy]` is the
+//! entry point every `Arc<Mutex<EventsManager>>` holder uses.
+//!
+//! Each scenario runs on a dedicated thread behind a hard deadline, so a
+//! re-entrancy deadlock fails the test instead of wedging the suite — the same
+//! shape as `reentrant_graph_event.rs`.
+
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicI32, Ordering},
+        mpsc,
+    },
+    thread,
+    time::Duration,
+};
+
+use hiroz::{
+    GidArray,
+    event::{
+        EventsManager, RmEventHandle, ZenohEventType, update_shared_event_status,
+        update_shared_event_status_with_policy,
+    },
+};
+
+/// Budget for one scenario. Generous relative to the work done — anything
+/// slower than this is a hang, not slowness.
+const SCENARIO_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Run `scenario` on its own thread; fail (rather than hang) past the deadline.
+///
+/// On timeout the worker is deliberately left running: it is blocked on a lock
+/// that will never be released, and there is no sound way to unwind it.
+fn with_deadline(name: &'static str, scenario: impl FnOnce() + Send + 'static) {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        scenario();
+        let _ = tx.send(());
+    });
+    match rx.recv_timeout(SCENARIO_TIMEOUT) {
+        Ok(()) => {}
+        // The worker panicked and dropped the sender. That is an assertion
+        // failure inside the scenario, NOT a deadlock — reporting it as one
+        // would turn every ordinary test failure into a false deadlock report.
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("{name}: scenario panicked — see the worker thread's panic above")
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!("{name}: scenario did not finish within {SCENARIO_TIMEOUT:?} — deadlock")
+        }
+    }
+}
+
+fn gid(n: u8) -> GidArray {
+    let mut g = [0u8; 16];
+    g[0] = n;
+    g
+}
+
+/// The canonical rmw shape: the matched-event callback immediately takes the
+/// status that triggered it.
+///
+/// `take_event` locks the same `Arc<Mutex<EventsManager>>` the update path
+/// holds, so with the callback invoked under that guard this never returns.
+#[test]
+fn event_callback_taking_its_own_status_does_not_deadlock() {
+    with_deadline("event_callback_take_event", || {
+        let mgr = Arc::new(Mutex::new(EventsManager::new(gid(1))));
+        let handle = Arc::new(RmEventHandle::new(
+            mgr.clone(),
+            ZenohEventType::SubscriptionMatched,
+        ));
+
+        let observed = Arc::new(AtomicI32::new(-1));
+        {
+            let handle_in_cb = handle.clone();
+            let observed = observed.clone();
+            handle.set_callback(move |_change| {
+                let status = handle_in_cb.take_event();
+                observed.store(status.total_count, Ordering::SeqCst);
+            });
+        }
+
+        update_shared_event_status(&mgr, ZenohEventType::SubscriptionMatched, 1);
+
+        assert_eq!(
+            observed.load(Ordering::SeqCst),
+            1,
+            "the callback did not observe the status change that triggered it"
+        );
+        // The callback consumed the change counters via `take_event`.
+        assert!(
+            !handle.is_ready(),
+            "take_event inside the callback should have cleared the changed flag"
+        );
+    });
+}
+
+/// A QoS-incompatibility callback that re-arms itself.
+///
+/// `set_callback` locks the manager to install, so a callback that replaces
+/// itself re-enters the outer mutex exactly like `take_event` does. This also
+/// covers the `_with_policy` entry point, which carries the encoded policy kind.
+#[test]
+fn event_callback_reinstalling_itself_does_not_deadlock() {
+    with_deadline("event_callback_reinstall", || {
+        let mgr = Arc::new(Mutex::new(EventsManager::new(gid(2))));
+        let handle = Arc::new(RmEventHandle::new(
+            mgr.clone(),
+            ZenohEventType::RequestedQosIncompatible,
+        ));
+
+        let fired = Arc::new(AtomicI32::new(0));
+        {
+            let handle_in_cb = handle.clone();
+            let fired = fired.clone();
+            handle.set_callback(move |_change| {
+                fired.fetch_add(1, Ordering::SeqCst);
+                // Re-arm with a no-op. Installing takes the manager lock.
+                handle_in_cb.set_callback(|_| {});
+            });
+        }
+
+        update_shared_event_status_with_policy(
+            &mgr,
+            ZenohEventType::RequestedQosIncompatible,
+            1,
+            42,
+        );
+
+        assert_eq!(
+            fired.load(Ordering::SeqCst),
+            1,
+            "the re-arming callback did not run"
+        );
+        let status = handle.take_event();
+        assert_eq!(status.total_count, 1);
+        assert_eq!(status.last_policy_kind, 42);
+    });
+}

--- a/crates/hiroz-tests/tests/reentrant_event_status.rs
+++ b/crates/hiroz-tests/tests/reentrant_event_status.rs
@@ -1,32 +1,30 @@
 //! Re-entrancy audit for endpoint event-status updates.
 //!
-//! An `EventsManager` lives behind an `Arc<Mutex<..>>` that its owners share
-//! with `RmEventHandle`. `update_event_status` takes `&mut self`, so every
-//! caller necessarily holds that outer mutex — and the method fires the
-//! registered callback. The callback is user code: the rmw layer hands it
-//! straight to an rclcpp executor, and the first thing such a callback does is
-//! usually ask the handle that fired for the status behind it
-//! (`rmw_take_event` → `RmEventHandle::take_event`), which locks the very same
-//! mutex. On a non-reentrant `std::sync::Mutex` that is a self-deadlock on the
-//! thread already holding the guard, with no race needed.
+//! `EventsManager` is shared as `Arc<Mutex<..>>`, so `&mut self` proves the
+//! caller holds that mutex — and `update_event_status` fired the callback from
+//! there. The callback is user code the rmw layer hands to an rclcpp executor,
+//! and the first thing it usually does is ask the handle that fired for its
+//! status (`rmw_take_event` → `RmEventHandle::take_event`), locking the same
+//! mutex on the same thread. Non-reentrant, no race needed.
 //!
-//! The fix is the shape used throughout this module and by zenoh core in
-//! `resolve_put`: record under the lock, drop the guard, then invoke.
-//! `EventsManager::record_event_status_with_policy` returns the callback
-//! instead of calling it, and `update_shared_event_status[_with_policy]` is the
-//! entry point every `Arc<Mutex<EventsManager>>` holder uses.
+//! Fix: record under the lock, drop the guard, invoke.
+//! `record_event_status_with_policy` returns the callback rather than calling
+//! it, and `update_shared_event_status[_with_policy]` is what holders use.
 //!
-//! Each scenario runs on a dedicated thread behind a hard deadline, so a
-//! re-entrancy deadlock fails the test instead of wedging the suite — the same
-//! shape as `reentrant_graph_event.rs`.
+//! Each scenario runs on its own thread behind a deadline, so a deadlock fails
+//! the test instead of wedging the suite.
 //!
-//! # These are not A/B detectors
+//! # What these detect, and what they do not
 //!
-//! Both tests call `update_shared_event_status`, which this change introduces.
-//! Reverting the production code does not make them fail — it makes this file
-//! stop compiling. They show the new entry point is re-entrancy-safe; they are
-//! not evidence that the old shape deadlocked. The detectors for that live in
-//! `reentrant_graph_event.rs`, which does go red on a revert.
+//! Both call `update_shared_event_status`, which this change *introduces* — so
+//! a wholesale revert does not turn them red, it stops this file compiling.
+//! They are not evidence the old shape deadlocked; `reentrant_graph_event.rs`
+//! carries that.
+//!
+//! They are still detectors, for the property rather than the history:
+//! reinstate the callout inside `update_shared_event_status_with_policy` and
+//! both fail on their deadline. That is the regression worth guarding, since
+//! the old entry point is gone.
 
 use std::{
     sync::{

--- a/crates/hiroz-tests/tests/reentrant_graph_event.rs
+++ b/crates/hiroz-tests/tests/reentrant_graph_event.rs
@@ -292,10 +292,18 @@ fn graph_change_callback_querying_the_graph_does_not_deadlock() {
             "the graph-change callback never ran for the remote publisher — \
              the scenario proved nothing"
         );
+        // Two, not one. `local_pub` is on this node for the whole scenario, so
+        // `>= 1` was satisfiable without the remote publisher ever being in the
+        // graph — which is precisely the regression this is meant to catch: a
+        // callback invoked *before* the entity is inserted would still observe
+        // the local publisher and pass. Requiring both makes the assertion
+        // actually depend on the ordering it claims to verify.
         assert!(
-            counted.load(Ordering::SeqCst) >= 1,
-            "the re-entrant graph query returned {} publishers; it should see at \
-             least the remote one",
+            counted.load(Ordering::SeqCst) >= 2,
+            "the re-entrant graph query saw {} publisher(s) on the topic; it must \
+             see both the local one and the remote one whose appearance triggered \
+             this callback. Seeing exactly 1 means the callback ran before the \
+             remote entity was inserted into the graph",
             counted.load(Ordering::SeqCst)
         );
     });

--- a/crates/hiroz-tests/tests/reentrant_graph_event.rs
+++ b/crates/hiroz-tests/tests/reentrant_graph_event.rs
@@ -1,0 +1,302 @@
+//! Re-entrancy audit for graph-change and endpoint event callbacks.
+//!
+//! `GraphEventManager` invoked its registered callbacks *while holding the
+//! registries they are registered in*: `trigger_event_with_policy` called the
+//! callback under the `event_callbacks` guard, and `trigger_graph_change` held
+//! both `event_callbacks` and `entity_topics` for the whole notification loop.
+//!
+//! Worse, the hot path into `trigger_graph_change` is the liveliness subscriber
+//! installed by `Graph::new_with_pattern`, which used to hold the `GraphData`
+//! mutex across the call. So on every liveliness token the callback ran with
+//! three or four non-reentrant locks held — and these callbacks are user code:
+//! the rmw layer hands them straight to an rclcpp executor. Any callback that
+//! re-entered hiroz (counting publishers, unregistering an entity, registering a
+//! new one) self-deadlocked on the thread that already held the guard.
+//!
+//! The fix is the same shape zenoh core itself uses in `resolve_put`: collect
+//! the callbacks under the lock, drop every guard, then invoke. Callbacks are
+//! `Arc` rather than `Box` so they can be cloned out cheaply.
+//!
+//! Every scenario runs on a dedicated thread behind a hard deadline, so a
+//! re-entrancy deadlock fails the test instead of wedging the suite — the same
+//! shape as `reentrant_publish.rs` and `reentrant_service.rs`.
+
+mod common;
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        mpsc,
+    },
+    thread,
+    time::Duration,
+};
+
+use common::{TestRouter, create_hiroz_context_with_endpoint};
+use hiroz::{
+    Builder, GidArray, TypeHash,
+    entity::EndpointKind,
+    event::{GraphEventManager, ZenohEventType},
+    ros_msg::MessageTypeInfo,
+};
+use serde::{Deserialize, Serialize};
+use serial_test::serial;
+
+/// A self-contained message type, so this file does not depend on the
+/// `ros-msgs` feature. Same shape as `reentrant_publish.rs`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct Tick {
+    counter: u64,
+}
+
+impl MessageTypeInfo for Tick {
+    fn type_name() -> &'static str {
+        "test_msgs::msg::dds_::Tick_"
+    }
+
+    fn type_hash() -> TypeHash {
+        TypeHash::zero()
+    }
+}
+
+impl hiroz::ros_msg::WithTypeInfo for Tick {}
+
+impl hiroz::msg::ZMessage for Tick {
+    type Serdes = hiroz::msg::SerdeCdrSerdes<Tick>;
+}
+
+/// Budget for one scenario. Generous relative to the work done — anything slower
+/// than this is a hang, not slowness.
+const SCENARIO_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Run `scenario` on its own thread; fail (rather than hang) past the deadline.
+///
+/// On timeout the worker is deliberately left running: it is blocked on a lock
+/// that will never be released, and there is no sound way to unwind it.
+fn with_deadline(name: &'static str, scenario: impl FnOnce() + Send + 'static) {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        scenario();
+        let _ = tx.send(());
+    });
+    match rx.recv_timeout(SCENARIO_TIMEOUT) {
+        Ok(()) => {}
+        // The worker panicked and dropped the sender. That is an assertion
+        // failure inside the scenario, NOT a deadlock — reporting it as one
+        // would turn every ordinary test failure into a false deadlock report.
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("{name}: scenario panicked — see the worker thread's panic above")
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!("{name}: scenario did not finish within {SCENARIO_TIMEOUT:?} — deadlock")
+        }
+    }
+}
+
+/// A fixed, valid `ZenohId`. `trigger_graph_change` does not read it.
+fn test_zid() -> zenoh::session::ZenohId {
+    use std::str::FromStr;
+    zenoh::session::ZenohId::from_str("221b72df20924c15b8794c6bdb471150").expect("zid")
+}
+
+fn gid(n: u8) -> GidArray {
+    let mut g = [0u8; 16];
+    g[0] = n;
+    g
+}
+
+// ---------------------------------------------------------------------------
+// Registry-level scenarios (deterministic, no router needed)
+// ---------------------------------------------------------------------------
+
+/// An endpoint event callback that unregisters an entity.
+///
+/// `trigger_event_with_policy` used to hold `event_callbacks` across the call and
+/// `unregister_entity` takes the same `std::sync::Mutex`, so this re-entered a
+/// mutex the calling thread already held — a self-deadlock with no race needed.
+///
+/// Tearing down an endpoint from inside its own matched-event callback is exactly
+/// what an rmw/rclcpp user does when a "publisher went away" event triggers
+/// cleanup, so this is a reachable shape rather than a contrived one.
+#[test]
+fn event_callback_unregistering_does_not_deadlock() {
+    with_deadline("event_callback_unregister", || {
+        let mgr = Arc::new(GraphEventManager::new());
+        let ran = Arc::new(AtomicBool::new(false));
+
+        let ran_c = ran.clone();
+        // Weak, so the callback (owned by the manager) does not keep it alive.
+        let mgr_weak = Arc::downgrade(&mgr);
+        mgr.register_event_callback(
+            gid(1),
+            "/reentrant".to_string(),
+            ZenohEventType::PublicationMatched,
+            move |_change| {
+                ran_c.store(true, Ordering::SeqCst);
+                if let Some(m) = mgr_weak.upgrade() {
+                    // Re-entrant registry access from inside the callback.
+                    m.unregister_entity(&gid(2));
+                }
+            },
+        )
+        .expect("register");
+
+        mgr.trigger_event(&gid(1), ZenohEventType::PublicationMatched, 1);
+
+        assert!(ran.load(Ordering::SeqCst), "the event callback never ran");
+    });
+}
+
+/// A graph-change callback that registers a *new* entity.
+///
+/// `trigger_graph_change` used to hold both `event_callbacks` and `entity_topics`
+/// for the whole notification loop; `register_event_callback` takes both. Same
+/// self-deadlock, on the graph-change path rather than the endpoint-event path.
+#[test]
+fn graph_change_callback_registering_does_not_deadlock() {
+    with_deadline("graph_change_register", || {
+        use hiroz::entity::{EndpointEntity, Entity};
+
+        let mgr = Arc::new(GraphEventManager::new());
+        let ran = Arc::new(AtomicUsize::new(0));
+
+        let ran_c = ran.clone();
+        let mgr_weak = Arc::downgrade(&mgr);
+        mgr.register_event_callback(
+            gid(1),
+            "/reentrant".to_string(),
+            // A Publisher appearing notifies subscriptions.
+            ZenohEventType::SubscriptionMatched,
+            move |_change| {
+                // Only re-enter once, or this registers forever.
+                if ran_c.fetch_add(1, Ordering::SeqCst) == 0
+                    && let Some(m) = mgr_weak.upgrade()
+                {
+                    // Re-entrant registration from inside the callback.
+                    let _ = m.register_event_callback(
+                        gid(9),
+                        "/other".to_string(),
+                        ZenohEventType::SubscriptionMatched,
+                        |_| {},
+                    );
+                }
+            },
+        )
+        .expect("register");
+
+        let appearing = Entity::Endpoint(EndpointEntity {
+            id: 1,
+            node: None,
+            kind: EndpointKind::Publisher,
+            topic: "/reentrant".to_string(),
+            type_info: None,
+            qos: Default::default(),
+        });
+        mgr.trigger_graph_change(&appearing, true, test_zid());
+
+        assert_eq!(
+            ran.load(Ordering::SeqCst),
+            1,
+            "the graph-change callback never ran"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: the liveliness path that holds GraphData
+// ---------------------------------------------------------------------------
+
+/// A graph-change callback that queries the graph, driven by a *remote* entity.
+///
+/// This is the full hazard, not just the registry half. A remote entity arrives
+/// on the liveliness subscriber declared in `Graph::new_with_pattern`, whose
+/// callback held the `GraphData` mutex across `trigger_graph_change`. A
+/// graph-change callback that asks the graph anything — `count`,
+/// `get_topic_names_and_types`, `node_exists` — takes that same mutex on the same
+/// thread and never returns.
+///
+/// Counting matched endpoints from inside a matched-event callback is the
+/// canonical rmw use, so this is the shape that actually ships.
+#[test]
+#[serial]
+fn graph_change_callback_querying_the_graph_does_not_deadlock() {
+    with_deadline("graph_change_query_graph", || {
+        const TOPIC: &str = "/reentrant_graph_event";
+
+        let router = TestRouter::new();
+
+        // Observer side: registers the graph-change callback.
+        let ctx_a =
+            create_hiroz_context_with_endpoint(router.endpoint()).expect("observer context");
+        let node_a = ctx_a
+            .create_node("graph_evt_observer")
+            .build()
+            .expect("node a");
+
+        // A local publisher, only so we can read back the *qualified* topic name
+        // the graph indexes entities under.
+        let local_pub = node_a.create_pub::<Tick>(TOPIC).build().expect("local pub");
+        let qualified_topic = local_pub.entity().topic.clone();
+
+        let graph_a = node_a.graph().clone();
+        let observed = Arc::new(AtomicUsize::new(0));
+        let counted = Arc::new(AtomicUsize::new(0));
+
+        let observed_c = observed.clone();
+        let counted_c = counted.clone();
+        // Weak: the callback is owned by the graph's event manager, which the
+        // graph owns — an Arc here would be a cycle.
+        let graph_weak = Arc::downgrade(&graph_a);
+        graph_a
+            .event_manager
+            .register_event_callback(
+                gid(7),
+                qualified_topic.clone(),
+                // A Publisher appearing notifies subscriptions.
+                ZenohEventType::SubscriptionMatched,
+                move |_change| {
+                    observed_c.fetch_add(1, Ordering::SeqCst);
+                    if let Some(g) = graph_weak.upgrade() {
+                        // Re-entrant graph query from inside the callback: this
+                        // takes the same `GraphData` mutex the liveliness
+                        // callback holds.
+                        let n = g.count(EndpointKind::Publisher, &qualified_topic);
+                        counted_c.store(n, Ordering::SeqCst);
+                    }
+                },
+            )
+            .expect("register graph event callback");
+
+        // Remote side: a second context whose publisher reaches the observer
+        // through a liveliness token, i.e. through the subscriber callback that
+        // used to hold `GraphData`.
+        let ctx_b = create_hiroz_context_with_endpoint(router.endpoint()).expect("remote context");
+        let node_b = ctx_b
+            .create_node("graph_evt_remote")
+            .build()
+            .expect("node b");
+        let _remote_pub = node_b
+            .create_pub::<Tick>(TOPIC)
+            .build()
+            .expect("remote pub");
+
+        // Wait for the liveliness token to propagate and the callback to run.
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while observed.load(Ordering::SeqCst) == 0 && std::time::Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(50));
+        }
+
+        assert!(
+            observed.load(Ordering::SeqCst) >= 1,
+            "the graph-change callback never ran for the remote publisher — \
+             the scenario proved nothing"
+        );
+        assert!(
+            counted.load(Ordering::SeqCst) >= 1,
+            "the re-entrant graph query returned {} publishers; it should see at \
+             least the remote one",
+            counted.load(Ordering::SeqCst)
+        );
+    });
+}

--- a/crates/hiroz/src/event.rs
+++ b/crates/hiroz/src/event.rs
@@ -78,9 +78,10 @@ impl EventsManager {
     /// it. The "outside the lock" this releases is only the *inner*
     /// `event_mutex`.
     ///
-    /// Anyone holding an `Arc<Mutex<EventsManager>>` must use
-    /// [`set_shared_callback`] instead, which is to registration what
-    /// [`update_shared_event_status`] is to status updates.
+    /// Anyone holding an `Arc<Mutex<EventsManager>>` must instead collect the
+    /// backlog under the guard, drop it, and only then call — as
+    /// `RmEventHandle::set_callback` does, and as
+    /// [`update_shared_event_status`] does for status updates.
     pub fn set_callback<F>(&mut self, event_type: ZenohEventType, callback: F)
     where
         F: Fn(i32) + Send + Sync + 'static,
@@ -438,40 +439,6 @@ impl EventWaitData {
 /// outer guard alive across the callback, and the callback is user code handed
 /// to an rclcpp executor which routinely calls straight back into the same
 /// manager (`rmw_take_event` → [`RmEventHandle::take_event`]).
-/// Install a callback on a shared manager, delivering any backlog **after**
-/// the outer guard is released.
-///
-/// The registration counterpart of [`update_shared_event_status`], and the
-/// entry point every holder of an `Arc<Mutex<EventsManager>>` must use.
-/// [`EventsManager::set_callback`] takes `&mut self`, so it can only be called
-/// with the outer mutex already held, and it fires the backlog underneath it —
-/// a callback that re-enters (`RmEventHandle::take_event`) then self-deadlocks
-/// on a non-reentrant `Mutex`. This collects the backlog under the guard, drops
-/// it, and only then calls.
-pub fn set_shared_callback<F>(
-    events_mgr: &Mutex<EventsManager>,
-    event_type: ZenohEventType,
-    callback: F,
-) where
-    F: Fn(i32) + Send + Sync + 'static,
-{
-    let callback: EventCallback = Arc::new(callback);
-
-    // Bound to its own `let` inside a block, for the same reason as
-    // `update_shared_event_status_with_policy`: as a `match`/`if let` scrutinee
-    // the guard would outlive the invocation below and reinstate the deadlock.
-    let unread_count = {
-        let Ok(mut mgr) = events_mgr.lock() else {
-            return;
-        };
-        mgr.install_callback(event_type, callback.clone())
-    };
-
-    if unread_count != 0 {
-        callback(unread_count);
-    }
-}
-
 pub fn update_shared_event_status(
     events_mgr: &Mutex<EventsManager>,
     event_type: ZenohEventType,
@@ -481,6 +448,19 @@ pub fn update_shared_event_status(
 }
 
 /// [`update_shared_event_status`] with a QoS policy kind.
+///
+/// # Known hazard: the callback can outlive `rmw_event_set_callback(.., null)`
+///
+/// Releasing the guard before invoking also releases the mutual exclusion that
+/// used to serialise this against `RmEventHandle::set_callback`. A concurrent
+/// detach can therefore return — and rclcpp can free the object `user_data`
+/// points at — between the clone below and the call. The `Arc` keeps the
+/// *closure* alive; nothing owns the raw C pointer it captured.
+///
+/// Not fixable by re-locking: that is the deadlock this exists to remove, and
+/// callbacks legitimately call `set_callback` on their own thread. Closing it
+/// needs a generation counter or a per-registration token checked inside the
+/// closure. Tracked separately; see the PR description.
 pub fn update_shared_event_status_with_policy(
     events_mgr: &Mutex<EventsManager>,
     event_type: ZenohEventType,

--- a/crates/hiroz/src/event.rs
+++ b/crates/hiroz/src/event.rs
@@ -458,9 +458,16 @@ pub fn update_shared_event_status(
 /// *closure* alive; nothing owns the raw C pointer it captured.
 ///
 /// Not fixable by re-locking: that is the deadlock this exists to remove, and
-/// callbacks legitimately call `set_callback` on their own thread. Closing it
-/// needs a generation counter or a per-registration token checked inside the
-/// closure. Tracked separately; see the PR description.
+/// callbacks legitimately call `set_callback` on their own thread. Nor by a
+/// flag checked in the closure — that only narrows the window, since the free
+/// can still land between the check and the call.
+///
+/// Closing it requires detach to *block* until any in-flight invocation
+/// returns, with a bypass when detach is called from the invoking thread
+/// itself. That is exactly `std::stop_callback`'s destructor contract, and the
+/// same shape as NT rundown protection. Note DDS does not provide this
+/// guarantee either, so it is hardening beyond the RMW contract rather than
+/// conformance to it. Tracked separately; see the PR description.
 pub fn update_shared_event_status_with_policy(
     events_mgr: &Mutex<EventsManager>,
     event_type: ZenohEventType,

--- a/crates/hiroz/src/event.rs
+++ b/crates/hiroz/src/event.rs
@@ -177,19 +177,37 @@ impl EventsManager {
     }
 }
 
-// Callback type for triggering graph guard conditions.
-//
-// `Arc` for the same reason as [`EventCallback`]: it is cloned out of its
-// `Mutex` before being called, so guard-condition triggers never run with the
-// graph-event registry locked.
-pub type GraphGuardConditionTrigger = Arc<dyn Fn(*mut std::ffi::c_void) + Send + Sync>;
+/// A graph guard condition this manager may trigger on a graph change.
+///
+/// Registrations are **owned**, not raw pointers, and that is the whole point.
+/// Triggering happens after the registry lock is released — it has to, because
+/// the trigger is rmw-side code that re-enters hiroz. But a raw pointer cloned
+/// out of the lock is only valid while something guarantees the target outlives
+/// the call, and nothing did: `rmw_destroy_node` unregisters and then
+/// immediately frees the guard condition, so a destroy landing between the
+/// snapshot and the call left the trigger dereferencing freed memory.
+///
+/// Holding an `Arc` for the duration of the call closes that window without
+/// reintroducing the lock: the implementation's state stays alive as long as
+/// this manager holds a reference, even if the C-side handle is destroyed
+/// concurrently. Implementors must therefore keep [`trigger`] valid after the
+/// owning C object is gone — the natural shape is state behind its own `Arc`,
+/// with the C handle holding one reference and this registry another.
+///
+/// [`trigger`]: GraphGuardCondition::trigger
+pub trait GraphGuardCondition: Send + Sync {
+    /// Wake whatever is waiting on this guard condition.
+    ///
+    /// Called with no hiroz lock held, possibly concurrently, and possibly
+    /// after the corresponding C handle has been destroyed.
+    fn trigger(&self);
+}
 
 // GraphCache event integration
 pub struct GraphEventManager {
     event_callbacks: TrackedMutex<HashMap<GidArray, HashMap<ZenohEventType, EventCallback>>>,
     entity_topics: TrackedMutex<HashMap<GidArray, String>>, // Topic name per registered entity
-    graph_guard_conditions: TrackedMutex<Vec<usize>>,       // Pointers as usize for Send
-    trigger_guard_condition: TrackedMutex<Option<GraphGuardConditionTrigger>>,
+    graph_guard_conditions: TrackedMutex<Vec<Arc<dyn GraphGuardCondition>>>,
 }
 
 impl Default for GraphEventManager {
@@ -204,12 +222,7 @@ impl GraphEventManager {
             event_callbacks: TrackedMutex::new(HashMap::new()),
             entity_topics: TrackedMutex::new(HashMap::new()),
             graph_guard_conditions: TrackedMutex::new(Vec::new()),
-            trigger_guard_condition: TrackedMutex::new(None),
         }
-    }
-
-    pub fn set_guard_condition_trigger(&self, trigger: GraphGuardConditionTrigger) {
-        *self.trigger_guard_condition.lock().unwrap() = Some(trigger);
     }
 
     pub fn register_event_callback<F>(
@@ -244,15 +257,27 @@ impl GraphEventManager {
         topics.remove(entity_gid);
     }
 
-    pub fn register_graph_guard_condition(&self, guard_condition: *mut std::ffi::c_void) {
+    /// Register a guard condition to be triggered on every graph change.
+    ///
+    /// The manager keeps the `Arc` alive for as long as it is registered, and
+    /// for the duration of any trigger already in flight — see
+    /// [`GraphGuardCondition`] for why that ownership is load-bearing.
+    pub fn register_graph_guard_condition(&self, guard_condition: Arc<dyn GraphGuardCondition>) {
         let mut conditions = self.graph_guard_conditions.lock().unwrap();
-        conditions.push(guard_condition as usize);
+        conditions.push(guard_condition);
     }
 
-    pub fn unregister_graph_guard_condition(&self, guard_condition: *mut std::ffi::c_void) {
+    /// Stop triggering `guard_condition`.
+    ///
+    /// Identity is `Arc::ptr_eq`, so the caller must pass the same allocation it
+    /// registered. Returning does **not** mean no trigger is in flight: a
+    /// concurrent [`Self::trigger_graph_change`] may already hold its own clone
+    /// and be calling into it. That is exactly why the registration is owned —
+    /// the in-flight call keeps the target alive, so a caller that frees its own
+    /// handle immediately after this returns is still safe.
+    pub fn unregister_graph_guard_condition(&self, guard_condition: &Arc<dyn GraphGuardCondition>) {
         let mut conditions = self.graph_guard_conditions.lock().unwrap();
-        let gc_usize = guard_condition as usize;
-        conditions.retain(|&gc| gc != gc_usize);
+        conditions.retain(|gc| !Arc::ptr_eq(gc, guard_condition));
     }
 
     pub fn trigger_event(&self, entity_gid: &GidArray, event_type: ZenohEventType, change: i32) {
@@ -309,15 +334,16 @@ impl GraphEventManager {
         let change = if appeared { 1 } else { -1 };
 
         // Trigger graph guard conditions for ALL graph changes (local and remote).
-        // Snapshot the trigger and the pointer list, then release both locks before
-        // calling out — the trigger is rmw-side code and may re-enter.
-        let trigger = self.trigger_guard_condition.lock().unwrap().clone();
-        if let Some(trigger) = trigger {
-            let guard_conditions = self.graph_guard_conditions.lock().unwrap().clone();
-            for gc_usize in guard_conditions {
-                let gc = gc_usize as *mut std::ffi::c_void;
-                trigger(gc);
-            }
+        //
+        // Snapshot, release the lock, then call — the trigger is rmw-side code
+        // and may re-enter this manager, so it must not run under the guard.
+        // The snapshot clones `Arc`s rather than raw pointers, which is what
+        // makes releasing the lock safe: a concurrent `rmw_destroy_node` can
+        // unregister and free its C handle here, and each in-flight trigger
+        // still holds the target alive until it returns.
+        let guard_conditions = self.graph_guard_conditions.lock().unwrap().clone();
+        for gc in guard_conditions {
+            gc.trigger();
         }
 
         // Determine which event type based on entity kind
@@ -695,5 +721,56 @@ mod tests {
             .unwrap()
             .update_event_status(ZenohEventType::LivelinessChanged, 3);
         assert_eq!(*fired.lock().unwrap(), 3);
+    }
+
+    /// The graph-guard-condition registry must **own** what it registers.
+    ///
+    /// This is the invariant that makes triggering outside the lock safe.
+    /// `trigger_graph_change` snapshots the registrations, releases the lock,
+    /// and only then calls them; meanwhile `rmw_destroy_node` may unregister
+    /// and free its C handle. When the registry held raw pointers, that window
+    /// was a use-after-free. Holding an `Arc` closes it — an in-flight trigger
+    /// keeps the target alive regardless of what the registrant does.
+    ///
+    /// The test pins the ownership half of that contract, which is the part
+    /// that is deterministic: the registry keeps the value alive after the
+    /// registrant drops its handle, and releases it on unregister. It does not
+    /// attempt to schedule the destroy-during-trigger race itself — that would
+    /// be a timing test, and the ownership property is what makes the race
+    /// harmless in the first place.
+    #[test]
+    fn graph_guard_condition_registration_is_owned_by_the_manager() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingGc(Arc<AtomicUsize>);
+        impl GraphGuardCondition for CountingGc {
+            fn trigger(&self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let mgr = GraphEventManager::new();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let gc: Arc<dyn GraphGuardCondition> = Arc::new(CountingGc(hits.clone()));
+        let weak = Arc::downgrade(&gc);
+
+        mgr.register_graph_guard_condition(gc.clone());
+        drop(gc);
+        let held = weak.upgrade().expect(
+            "the manager must keep the registration alive after the registrant drops its handle; \
+             otherwise a trigger issued outside the lock dereferences freed memory",
+        );
+
+        // Still reachable and callable through the registry's own reference.
+        held.trigger();
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+        mgr.unregister_graph_guard_condition(&held);
+        drop(held);
+        assert!(
+            weak.upgrade().is_none(),
+            "unregister must release the registry's reference, or registrations leak for the \
+             life of the process",
+        );
     }
 }

--- a/crates/hiroz/src/event.rs
+++ b/crates/hiroz/src/event.rs
@@ -47,7 +47,19 @@ pub struct ZenohEventStatus {
 // makes any such re-entry a self-deadlock on a non-reentrant `Mutex`.
 pub type EventCallback = Arc<dyn Fn(i32) + Send + Sync>;
 
-// EventsManager - manages event state for a single publisher/subscription
+/// Event state for a single publisher/subscription.
+///
+/// # The `&mut self` rule
+///
+/// This type is shared as `Arc<Mutex<EventsManager>>`, so **`&mut self` proves
+/// the caller holds that outer mutex**. Any `&mut self` method that invoked a
+/// callback would therefore run user code under a lock the same thread already
+/// holds — and these callbacks re-enter (`rmw_take_event` →
+/// [`RmEventHandle::take_event`], or `set_callback` to re-arm). Non-reentrant
+/// mutex, one thread, no race: a guaranteed deadlock.
+///
+/// So the `&mut self` methods here *return* the callback instead, and
+/// [`update_shared_event_status`] is the entry point holders actually use.
 pub struct EventsManager {
     event_statuses: Vec<ZenohEventStatus>,
     event_callbacks: Vec<Option<EventCallback>>,
@@ -71,17 +83,11 @@ impl EventsManager {
 
     /// Install a callback, delivering any backlog immediately.
     ///
-    /// **Only for a caller that owns this manager outright.** `&mut self` means
-    /// the caller holds whatever `Mutex<EventsManager>` wraps it, and the
-    /// backlog callback below runs while that outer guard is still live — so a
-    /// callback that re-enters (`RmEventHandle::take_event`, say) deadlocks on
-    /// it. The "outside the lock" this releases is only the *inner*
-    /// `event_mutex`.
-    ///
-    /// Anyone holding an `Arc<Mutex<EventsManager>>` must instead collect the
-    /// backlog under the guard, drop it, and only then call — as
-    /// `RmEventHandle::set_callback` does, and as
-    /// [`update_shared_event_status`] does for status updates.
+    /// **Only for a caller that owns this manager outright.** It fires the
+    /// backlog while the caller's outer guard is still live — the lock this
+    /// releases is only the *inner* `event_mutex` — so a re-entering callback
+    /// deadlocks. See the `&mut self` note on [`EventsManager`]; holders of an
+    /// `Arc<Mutex<..>>` want [`RmEventHandle::set_callback`] instead.
     pub fn set_callback<F>(&mut self, event_type: ZenohEventType, callback: F)
     where
         F: Fn(i32) + Send + Sync + 'static,
@@ -138,12 +144,8 @@ impl EventsManager {
     /// Record a status change and hand back the callback that owes a
     /// notification, *without* invoking it.
     ///
-    /// Deliberately does not invoke, for the same reason as
-    /// [`EventsManager::install_callback`]: `&mut self` means the caller holds
-    /// the outer `Mutex<EventsManager>`, and the callback is user code that
-    /// routinely re-enters this manager (`rmw_take_event` on the handle that
-    /// just fired). Firing it here would self-deadlock on that outer,
-    /// non-reentrant mutex.
+    /// Not invoking is the point: see the `&mut self` note on
+    /// [`EventsManager`]. The caller invokes once every guard is dropped.
     #[must_use = "the returned callback must be invoked after every guard is dropped"]
     pub fn record_event_status_with_policy(
         &mut self,
@@ -192,19 +194,15 @@ impl EventsManager {
 /// A graph guard condition this manager may trigger on a graph change.
 ///
 /// Registrations are **owned**, not raw pointers, and that is the whole point.
-/// Triggering happens after the registry lock is released — it has to, because
-/// the trigger is rmw-side code that re-enters hiroz. But a raw pointer cloned
-/// out of the lock is only valid while something guarantees the target outlives
-/// the call, and nothing did: `rmw_destroy_node` unregisters and then
-/// immediately frees the guard condition, so a destroy landing between the
-/// snapshot and the call left the trigger dereferencing freed memory.
+/// Triggering happens with the registry lock released — it must, since the
+/// trigger re-enters hiroz — and a raw pointer cloned out of the lock is only
+/// valid if something keeps the target alive across the call. Nothing did:
+/// `rmw_destroy_node` unregisters and immediately frees, so a destroy landing
+/// mid-call dereferenced freed memory.
 ///
-/// Holding an `Arc` for the duration of the call closes that window without
-/// reintroducing the lock: the implementation's state stays alive as long as
-/// this manager holds a reference, even if the C-side handle is destroyed
-/// concurrently. Implementors must therefore keep [`trigger`] valid after the
-/// owning C object is gone — the natural shape is state behind its own `Arc`,
-/// with the C handle holding one reference and this registry another.
+/// **Implementors must keep [`trigger`] valid after the owning C object is
+/// gone.** The natural shape is state behind its own `Arc`, one reference held
+/// by the C handle and one by this registry.
 ///
 /// [`trigger`]: GraphGuardCondition::trigger
 pub trait GraphGuardCondition: Send + Sync {
@@ -449,25 +447,17 @@ pub fn update_shared_event_status(
 
 /// [`update_shared_event_status`] with a QoS policy kind.
 ///
-/// # Known hazard: the callback can outlive `rmw_event_set_callback(.., null)`
+/// # Known hazard
 ///
-/// Releasing the guard before invoking also releases the mutual exclusion that
-/// used to serialise this against `RmEventHandle::set_callback`. A concurrent
-/// detach can therefore return — and rclcpp can free the object `user_data`
-/// points at — between the clone below and the call. The `Arc` keeps the
-/// *closure* alive; nothing owns the raw C pointer it captured.
+/// Releasing the guard also releases the mutual exclusion that used to
+/// serialise this against `RmEventHandle::set_callback`, so a concurrent detach
+/// can return — and rclcpp can free `user_data` — between the clone below and
+/// the call. The `Arc` keeps the *closure* alive; nothing owns the raw C
+/// pointer it captured.
 ///
-/// Not fixable by re-locking: that is the deadlock this exists to remove, and
-/// callbacks legitimately call `set_callback` on their own thread. Nor by a
-/// flag checked in the closure — that only narrows the window, since the free
-/// can still land between the check and the call.
-///
-/// Closing it requires detach to *block* until any in-flight invocation
-/// returns, with a bypass when detach is called from the invoking thread
-/// itself. That is exactly `std::stop_callback`'s destructor contract, and the
-/// same shape as NT rundown protection. Note DDS does not provide this
-/// guarantee either, so it is hardening beyond the RMW contract rather than
-/// conformance to it. Tracked separately; see the PR description.
+/// Do not "fix" this by re-locking (that is the deadlock this removes) or by a
+/// flag checked in the closure (the free can land between check and call).
+/// Tracked with the design in hiroz#287.
 pub fn update_shared_event_status_with_policy(
     events_mgr: &Mutex<EventsManager>,
     event_type: ZenohEventType,
@@ -755,21 +745,13 @@ mod tests {
         assert_eq!(*fired.lock().unwrap(), 3);
     }
 
-    /// The graph-guard-condition registry must **own** what it registers.
+    /// The registry must **own** what it registers — the invariant that makes
+    /// triggering outside the lock safe. See [`GraphGuardCondition`].
     ///
-    /// This is the invariant that makes triggering outside the lock safe.
-    /// `trigger_graph_change` snapshots the registrations, releases the lock,
-    /// and only then calls them; meanwhile `rmw_destroy_node` may unregister
-    /// and free its C handle. When the registry held raw pointers, that window
-    /// was a use-after-free. Holding an `Arc` closes it — an in-flight trigger
-    /// keeps the target alive regardless of what the registrant does.
-    ///
-    /// The test pins the ownership half of that contract, which is the part
-    /// that is deterministic: the registry keeps the value alive after the
-    /// registrant drops its handle, and releases it on unregister. It does not
-    /// attempt to schedule the destroy-during-trigger race itself — that would
-    /// be a timing test, and the ownership property is what makes the race
-    /// harmless in the first place.
+    /// Pins the deterministic half: the registry keeps the value alive after
+    /// the registrant drops its handle, and releases it on unregister. It does
+    /// not try to schedule the destroy-during-trigger race, which would be a
+    /// timing test — ownership is what makes that race harmless.
     #[test]
     fn graph_guard_condition_registration_is_owned_by_the_manager() {
         use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/hiroz/src/event.rs
+++ b/crates/hiroz/src/event.rs
@@ -69,14 +69,25 @@ impl EventsManager {
         }
     }
 
+    /// Install a callback, delivering any backlog immediately.
+    ///
+    /// **Only for a caller that owns this manager outright.** `&mut self` means
+    /// the caller holds whatever `Mutex<EventsManager>` wraps it, and the
+    /// backlog callback below runs while that outer guard is still live — so a
+    /// callback that re-enters (`RmEventHandle::take_event`, say) deadlocks on
+    /// it. The "outside the lock" this releases is only the *inner*
+    /// `event_mutex`.
+    ///
+    /// Anyone holding an `Arc<Mutex<EventsManager>>` must use
+    /// [`set_shared_callback`] instead, which is to registration what
+    /// [`update_shared_event_status`] is to status updates.
     pub fn set_callback<F>(&mut self, event_type: ZenohEventType, callback: F)
     where
         F: Fn(i32) + Send + Sync + 'static,
     {
         let callback: EventCallback = Arc::new(callback);
         let unread_count = self.install_callback(event_type, callback.clone());
-        // If there were unread events, notify the freshly-registered callback —
-        // outside the lock.
+        // Outside the inner `event_mutex` only — see the note above.
         if unread_count != 0 {
             callback(unread_count);
         }
@@ -427,6 +438,40 @@ impl EventWaitData {
 /// outer guard alive across the callback, and the callback is user code handed
 /// to an rclcpp executor which routinely calls straight back into the same
 /// manager (`rmw_take_event` → [`RmEventHandle::take_event`]).
+/// Install a callback on a shared manager, delivering any backlog **after**
+/// the outer guard is released.
+///
+/// The registration counterpart of [`update_shared_event_status`], and the
+/// entry point every holder of an `Arc<Mutex<EventsManager>>` must use.
+/// [`EventsManager::set_callback`] takes `&mut self`, so it can only be called
+/// with the outer mutex already held, and it fires the backlog underneath it —
+/// a callback that re-enters (`RmEventHandle::take_event`) then self-deadlocks
+/// on a non-reentrant `Mutex`. This collects the backlog under the guard, drops
+/// it, and only then calls.
+pub fn set_shared_callback<F>(
+    events_mgr: &Mutex<EventsManager>,
+    event_type: ZenohEventType,
+    callback: F,
+) where
+    F: Fn(i32) + Send + Sync + 'static,
+{
+    let callback: EventCallback = Arc::new(callback);
+
+    // Bound to its own `let` inside a block, for the same reason as
+    // `update_shared_event_status_with_policy`: as a `match`/`if let` scrutinee
+    // the guard would outlive the invocation below and reinstate the deadlock.
+    let unread_count = {
+        let Ok(mut mgr) = events_mgr.lock() else {
+            return;
+        };
+        mgr.install_callback(event_type, callback.clone())
+    };
+
+    if unread_count != 0 {
+        callback(unread_count);
+    }
+}
+
 pub fn update_shared_event_status(
     events_mgr: &Mutex<EventsManager>,
     event_type: ZenohEventType,

--- a/crates/hiroz/src/event.rs
+++ b/crates/hiroz/src/event.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+
+use crate::reentrancy::TrackedMutex;
 use zenoh::Result;
 
 use crate::GidArray;
@@ -35,8 +37,15 @@ pub struct ZenohEventStatus {
     pub last_policy_kind: u32, // RMW QoS policy kind that caused incompatibility
 }
 
-// Event callback type
-pub type EventCallback = Box<dyn Fn(i32) + Send + Sync>;
+// Event callback type.
+//
+// `Arc` rather than `Box` so that a callback can be *collected* while the
+// registry lock is held and *invoked* after it has been released. Event
+// callbacks are user code (the rmw layer hands them straight to an rclcpp
+// executor), and they routinely re-enter hiroz — querying the graph,
+// publishing, unregistering an entity. Invoking them under the registry guard
+// makes any such re-entry a self-deadlock on a non-reentrant `Mutex`.
+pub type EventCallback = Arc<dyn Fn(i32) + Send + Sync>;
 
 // EventsManager - manages event state for a single publisher/subscription
 pub struct EventsManager {
@@ -64,29 +73,72 @@ impl EventsManager {
     where
         F: Fn(i32) + Send + Sync + 'static,
     {
+        let callback: EventCallback = Arc::new(callback);
+        let unread_count = self.install_callback(event_type, callback.clone());
+        // If there were unread events, notify the freshly-registered callback —
+        // outside the lock.
+        if unread_count != 0 {
+            callback(unread_count);
+        }
+    }
+
+    /// Install `callback` and take (clearing) the unread-event backlog.
+    ///
+    /// Deliberately does *not* invoke the callback: the caller fires it after
+    /// releasing every lock it holds, including the outer `Mutex<EventsManager>`
+    /// that [`RmEventHandle`] uses. Returns the backlog count, or 0 if none.
+    pub fn install_callback(&mut self, event_type: ZenohEventType, callback: EventCallback) -> i32 {
         let event_id = event_type as usize;
         let _lock = self.event_mutex.lock().unwrap();
 
-        // If there are unread events, trigger the callback immediately
         let unread_count = self.event_statuses[event_id].total_count_change;
         if unread_count != 0 {
-            callback(unread_count);
             self.event_statuses[event_id].total_count_change = 0;
         }
+        self.event_callbacks[event_id] = Some(callback);
 
-        self.event_callbacks[event_id] = Some(Box::new(callback));
+        unread_count
     }
 
+    /// Record a status change and invoke the registered callback, if any.
+    ///
+    /// Only safe when the caller does not hold the outer `Mutex<EventsManager>`
+    /// — see [`update_shared_event_status`], which is what every holder of an
+    /// `Arc<Mutex<EventsManager>>` must use instead.
     pub fn update_event_status(&mut self, event_type: ZenohEventType, change: i32) {
         self.update_event_status_with_policy(event_type, change, 0);
     }
 
+    /// See [`EventsManager::update_event_status`] for the locking caveat.
     pub fn update_event_status_with_policy(
         &mut self,
         event_type: ZenohEventType,
         change: i32,
         policy_kind: u32,
     ) {
+        if let Some(callback) =
+            self.record_event_status_with_policy(event_type, change, policy_kind)
+        {
+            callback(change);
+        }
+    }
+
+    /// Record a status change and hand back the callback that owes a
+    /// notification, *without* invoking it.
+    ///
+    /// Deliberately does not invoke, for the same reason as
+    /// [`EventsManager::install_callback`]: `&mut self` means the caller holds
+    /// the outer `Mutex<EventsManager>`, and the callback is user code that
+    /// routinely re-enters this manager (`rmw_take_event` on the handle that
+    /// just fired). Firing it here would self-deadlock on that outer,
+    /// non-reentrant mutex.
+    #[must_use = "the returned callback must be invoked after every guard is dropped"]
+    pub fn record_event_status_with_policy(
+        &mut self,
+        event_type: ZenohEventType,
+        change: i32,
+        policy_kind: u32,
+    ) -> Option<EventCallback> {
         let event_id = event_type as usize;
 
         {
@@ -104,10 +156,7 @@ impl EventsManager {
             }
         }
 
-        // Trigger callback if registered
-        if let Some(ref callback) = self.event_callbacks[event_id] {
-            callback(change);
-        }
+        self.event_callbacks[event_id].clone()
     }
 
     pub fn take_event_status(&mut self, event_type: ZenohEventType) -> ZenohEventStatus {
@@ -128,15 +177,19 @@ impl EventsManager {
     }
 }
 
-// Callback type for triggering graph guard conditions
-pub type GraphGuardConditionTrigger = Box<dyn Fn(*mut std::ffi::c_void) + Send + Sync>;
+// Callback type for triggering graph guard conditions.
+//
+// `Arc` for the same reason as [`EventCallback`]: it is cloned out of its
+// `Mutex` before being called, so guard-condition triggers never run with the
+// graph-event registry locked.
+pub type GraphGuardConditionTrigger = Arc<dyn Fn(*mut std::ffi::c_void) + Send + Sync>;
 
 // GraphCache event integration
 pub struct GraphEventManager {
-    event_callbacks: Mutex<HashMap<GidArray, HashMap<ZenohEventType, EventCallback>>>,
-    entity_topics: Mutex<HashMap<GidArray, String>>, // Topic name per registered entity
-    graph_guard_conditions: Mutex<Vec<usize>>,       // Pointers as usize for Send
-    trigger_guard_condition: Mutex<Option<GraphGuardConditionTrigger>>,
+    event_callbacks: TrackedMutex<HashMap<GidArray, HashMap<ZenohEventType, EventCallback>>>,
+    entity_topics: TrackedMutex<HashMap<GidArray, String>>, // Topic name per registered entity
+    graph_guard_conditions: TrackedMutex<Vec<usize>>,       // Pointers as usize for Send
+    trigger_guard_condition: TrackedMutex<Option<GraphGuardConditionTrigger>>,
 }
 
 impl Default for GraphEventManager {
@@ -148,10 +201,10 @@ impl Default for GraphEventManager {
 impl GraphEventManager {
     pub fn new() -> Self {
         Self {
-            event_callbacks: Mutex::new(HashMap::new()),
-            entity_topics: Mutex::new(HashMap::new()),
-            graph_guard_conditions: Mutex::new(Vec::new()),
-            trigger_guard_condition: Mutex::new(None),
+            event_callbacks: TrackedMutex::new(HashMap::new()),
+            entity_topics: TrackedMutex::new(HashMap::new()),
+            graph_guard_conditions: TrackedMutex::new(Vec::new()),
+            trigger_guard_condition: TrackedMutex::new(None),
         }
     }
 
@@ -169,9 +222,11 @@ impl GraphEventManager {
     where
         F: Fn(i32) + Send + Sync + 'static,
     {
-        let mut callbacks = self.event_callbacks.lock().unwrap();
-        let entity_callbacks = callbacks.entry(entity_gid).or_default();
-        entity_callbacks.insert(event_type, Box::new(callback));
+        {
+            let mut callbacks = self.event_callbacks.lock().unwrap();
+            let entity_callbacks = callbacks.entry(entity_gid).or_default();
+            entity_callbacks.insert(event_type, Arc::new(callback));
+        }
 
         let mut topics = self.entity_topics.lock().unwrap();
         topics.insert(entity_gid, topic);
@@ -180,8 +235,11 @@ impl GraphEventManager {
     }
 
     pub fn unregister_entity(&self, entity_gid: &GidArray) {
-        let mut callbacks = self.event_callbacks.lock().unwrap();
-        callbacks.remove(entity_gid);
+        // Scoped so the two registries are never held at the same time.
+        {
+            let mut callbacks = self.event_callbacks.lock().unwrap();
+            callbacks.remove(entity_gid);
+        }
         let mut topics = self.entity_topics.lock().unwrap();
         topics.remove(entity_gid);
     }
@@ -223,11 +281,20 @@ impl GraphEventManager {
             change
         };
 
-        let callbacks = self.event_callbacks.lock().unwrap();
-        if let Some(entity_callbacks) = callbacks.get(entity_gid)
-            && let Some(callback) = entity_callbacks.get(&event_type)
-        {
-            callback(encoded_change);
+        // Collect under the lock, invoke after it is released — see [`EventCallback`].
+        let callback = {
+            let callbacks = self.event_callbacks.lock().unwrap();
+            callbacks
+                .get(entity_gid)
+                .and_then(|entity_callbacks| entity_callbacks.get(&event_type))
+                .cloned()
+        };
+
+        if let Some(callback) = callback {
+            crate::invoke_user_callback!(
+                "GraphEventManager::trigger_event_with_policy",
+                callback(encoded_change)
+            );
         }
     }
 
@@ -241,10 +308,13 @@ impl GraphEventManager {
 
         let change = if appeared { 1 } else { -1 };
 
-        // Trigger graph guard conditions for ALL graph changes (local and remote)
-        if let Some(ref trigger) = *self.trigger_guard_condition.lock().unwrap() {
-            let guard_conditions = self.graph_guard_conditions.lock().unwrap();
-            for &gc_usize in guard_conditions.iter() {
+        // Trigger graph guard conditions for ALL graph changes (local and remote).
+        // Snapshot the trigger and the pointer list, then release both locks before
+        // calling out — the trigger is rmw-side code and may re-enter.
+        let trigger = self.trigger_guard_condition.lock().unwrap().clone();
+        if let Some(trigger) = trigger {
+            let guard_conditions = self.graph_guard_conditions.lock().unwrap().clone();
+            for gc_usize in guard_conditions {
                 let gc = gc_usize as *mut std::ffi::c_void;
                 trigger(gc);
             }
@@ -268,16 +338,29 @@ impl GraphEventManager {
             _ => return,
         };
 
-        let entity_topics = self.entity_topics.lock().unwrap();
-        let callbacks = self.event_callbacks.lock().unwrap();
-        for (entity_gid, entity_callbacks) in callbacks.iter() {
-            // Only notify entities on the same topic
-            if let Some(registered_topic) = entity_topics.get(entity_gid)
-                && registered_topic == changed_topic
-                && let Some(callback) = entity_callbacks.get(&event_type)
-            {
-                callback(change);
-            }
+        // Collect the callbacks to notify, then drop both registry guards before
+        // invoking any of them — see [`EventCallback`]. Locks are taken in the
+        // same order as `register_event_callback` (callbacks, then topics).
+        let to_notify: Vec<EventCallback> = {
+            let callbacks = self.event_callbacks.lock().unwrap();
+            let entity_topics = self.entity_topics.lock().unwrap();
+            callbacks
+                .iter()
+                .filter(|(entity_gid, _)| {
+                    // Only notify entities on the same topic
+                    entity_topics
+                        .get(*entity_gid)
+                        .is_some_and(|registered_topic| registered_topic == changed_topic)
+                })
+                .filter_map(|(_, entity_callbacks)| entity_callbacks.get(&event_type).cloned())
+                .collect()
+        };
+
+        for callback in to_notify {
+            crate::invoke_user_callback!(
+                "GraphEventManager::trigger_graph_change",
+                callback(change)
+            );
         }
     }
 }
@@ -307,6 +390,44 @@ impl EventWaitData {
 
     pub fn set_triggered(&self, triggered: bool) {
         self.triggered.store(triggered, Ordering::Release);
+    }
+}
+
+/// Record an event-status change on a *shared* [`EventsManager`] and fire its
+/// callback with the manager lock released.
+///
+/// Holders of an `Arc<Mutex<EventsManager>>` must use this rather than locking
+/// and calling [`EventsManager::update_event_status`] directly: that keeps the
+/// outer guard alive across the callback, and the callback is user code handed
+/// to an rclcpp executor which routinely calls straight back into the same
+/// manager (`rmw_take_event` → [`RmEventHandle::take_event`]).
+pub fn update_shared_event_status(
+    events_mgr: &Mutex<EventsManager>,
+    event_type: ZenohEventType,
+    change: i32,
+) {
+    update_shared_event_status_with_policy(events_mgr, event_type, change, 0)
+}
+
+/// [`update_shared_event_status`] with a QoS policy kind.
+pub fn update_shared_event_status_with_policy(
+    events_mgr: &Mutex<EventsManager>,
+    event_type: ZenohEventType,
+    change: i32,
+    policy_kind: u32,
+) {
+    // The guard is bound to its own `let` inside a block on purpose. Written as
+    // a `match`/`if let` scrutinee it would stay alive across the invocation
+    // below and silently reinstate the deadlock this function exists to remove.
+    let callback = {
+        let Ok(mut mgr) = events_mgr.lock() else {
+            return;
+        };
+        mgr.record_event_status_with_policy(event_type, change, policy_kind)
+    };
+
+    if let Some(callback) = callback {
+        callback(change);
     }
 }
 
@@ -349,8 +470,16 @@ impl RmEventHandle {
     where
         F: Fn(i32) + Send + Sync + 'static,
     {
-        let mut mgr = self.events_mgr.lock().unwrap();
-        mgr.set_callback(self.event_type, callback);
+        let callback: EventCallback = Arc::new(callback);
+        // Install under the manager lock; fire the backlog notification after it
+        // is released so the callback may re-enter this handle.
+        let unread_count = {
+            let mut mgr = self.events_mgr.lock().unwrap();
+            mgr.install_callback(self.event_type, callback.clone())
+        };
+        if unread_count != 0 {
+            callback(unread_count);
+        }
     }
 }
 

--- a/crates/hiroz/src/graph.rs
+++ b/crates/hiroz/src/graph.rs
@@ -600,7 +600,6 @@ impl Graph {
             .declare_subscriber(&liveliness_pattern)
             .history(true)
             .callback(move |sample| {
-                let mut graph_data_guard = c_graph_data.lock();
                 let key_expr = sample.key_expr().to_owned();
                 let ke = LivelinessKE(key_expr.clone());
                 tracing::debug!(
@@ -609,6 +608,11 @@ impl Graph {
                     sample.kind()
                 );
 
+                // `trigger_graph_change` runs user/rmw event callbacks, which routinely
+                // re-enter the graph (counting publishers, publishing, registering
+                // entities). `data` is a non-reentrant mutex, so it must never be held
+                // across that call — hence the tight scopes below. `add_local_entity`
+                // already follows this rule.
                 match sample.kind() {
                     SampleKind::Put => {
                         debug!("[GRF] Entity appeared: {}", ke.0);
@@ -625,26 +629,35 @@ impl Graph {
                             }
                         };
 
-                        // Only insert if not already parsed (avoid duplicates from liveliness query)
-                        let already_parsed = graph_data_guard.parsed.contains_key(&ke);
-                        let already_cached = graph_data_guard.cached.contains(&ke);
-                        tracing::debug!(
-                            "  Check: parsed={}, cached={}, parsed.len()={}, cached.len()={}",
-                            already_parsed,
-                            already_cached,
-                            graph_data_guard.parsed.len(),
-                            graph_data_guard.cached.len()
-                        );
-                        if already_parsed {
-                            tracing::debug!("  Skipping - already in parsed");
-                        } else if already_cached {
-                            tracing::debug!("  Skipping - already in cached");
-                        } else {
-                            tracing::debug!("  Adding to cached");
-                            graph_data_guard.insert(ke.clone());
-                        }
+                        let already_parsed = {
+                            let mut graph_data_guard = c_graph_data.lock();
+
+                            // Only insert if not already parsed (avoid duplicates from
+                            // liveliness query)
+                            let already_parsed = graph_data_guard.parsed.contains_key(&ke);
+                            let already_cached = graph_data_guard.cached.contains(&ke);
+                            tracing::debug!(
+                                "  Check: parsed={}, cached={}, parsed.len()={}, cached.len()={}",
+                                already_parsed,
+                                already_cached,
+                                graph_data_guard.parsed.len(),
+                                graph_data_guard.cached.len()
+                            );
+                            if already_parsed {
+                                tracing::debug!("  Skipping - already in parsed");
+                            } else if already_cached {
+                                tracing::debug!("  Skipping - already in cached");
+                            } else {
+                                tracing::debug!("  Adding to cached");
+                                graph_data_guard.insert(ke.clone());
+                            }
+                            already_parsed
+                        };
+
                         // Only fire the event for genuinely new entities; if add_local_entity
                         // already inserted and fired for this key, don't fire a second time.
+                        // Fires after the insert, as before — a callback that queries the
+                        // graph sees the new entity.
                         if !already_parsed && let Some(entity) = parsed_entity {
                             tracing::debug!("Successfully parsed entity: {:?}", entity);
                             c_event_manager.trigger_graph_change(&entity, true, c_zid);
@@ -655,20 +668,20 @@ impl Graph {
                     SampleKind::Delete => {
                         debug!("[GRF] Entity disappeared: {}", ke.0);
                         tracing::debug!("Graph subscriber: DELETE {}", key_expr.as_str());
-                        // Trigger graph change events before removal using backend-specific parser
+                        // Trigger graph change events before removal using backend-specific
+                        // parser — a callback still observes the disappearing entity, as
+                        // before.
                         if let Ok(entity) = callback_parser(&key_expr) {
                             c_event_manager.trigger_graph_change(&entity, false, c_zid);
                         }
-                        graph_data_guard.remove(&ke);
+                        c_graph_data.lock().remove(&ke);
                         c_change_notify.notify_waiters();
                     }
                 }
 
-                // Release graph.data before signaling sync waiters.
-                // Lock ordering: sync waiters acquire change_signal.0 then (briefly) data;
-                // the callback holds data then acquires change_signal.0 — so we must drop
-                // data first to ensure the two locks are never held simultaneously.
-                drop(graph_data_guard);
+                // graph.data is released above before signaling sync waiters.
+                // Lock ordering: sync waiters acquire change_signal.0 then (briefly) data,
+                // so the callback must never hold data while acquiring change_signal.0.
                 c_change_signal.1.notify_all();
             })
             .wait()?;

--- a/crates/rmw-zenoh-rs/src/context.rs
+++ b/crates/rmw-zenoh-rs/src/context.rs
@@ -95,18 +95,6 @@ impl ContextImpl {
             .build()
             .map_err(|e| format!("Failed to create ZContext: {}", e))?;
 
-        // Set up the guard condition trigger function for graph events
-        // This allows graph changes to trigger RMW guard conditions
-        let trigger_fn: hiroz::event::GraphGuardConditionTrigger = Arc::new(|gc_ptr| {
-            crate::guard_condition::rmw_trigger_guard_condition(
-                gc_ptr as *const crate::ros::rmw_guard_condition_t,
-            );
-        });
-        zcontext
-            .graph()
-            .event_manager
-            .set_guard_condition_trigger(trigger_fn);
-
         Ok(Self {
             zcontext: Arc::new(zcontext),
             enclave,

--- a/crates/rmw-zenoh-rs/src/context.rs
+++ b/crates/rmw-zenoh-rs/src/context.rs
@@ -97,7 +97,7 @@ impl ContextImpl {
 
         // Set up the guard condition trigger function for graph events
         // This allows graph changes to trigger RMW guard conditions
-        let trigger_fn: hiroz::event::GraphGuardConditionTrigger = Box::new(|gc_ptr| {
+        let trigger_fn: hiroz::event::GraphGuardConditionTrigger = Arc::new(|gc_ptr| {
             crate::guard_condition::rmw_trigger_guard_condition(
                 gc_ptr as *const crate::ros::rmw_guard_condition_t,
             );

--- a/crates/rmw-zenoh-rs/src/guard_condition.rs
+++ b/crates/rmw-zenoh-rs/src/guard_condition.rs
@@ -3,30 +3,76 @@ use crate::ros::*;
 use crate::traits::*;
 use crate::utils::Notifier;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-/// Guard condition implementation for RMW
+/// The triggerable state of a guard condition, separated from the C handle.
+///
+/// This lives behind an `Arc` so it can outlive `rmw_destroy_guard_condition`.
+/// hiroz's graph-event manager registers a clone (as
+/// `Arc<dyn GraphGuardCondition>`) and triggers it **after** dropping its
+/// registry lock; without shared ownership, a `rmw_destroy_node` racing that
+/// window would free the target and the trigger would write through dangling
+/// memory. The C handle holds one reference and the registry another, so
+/// whichever outlives the other, the state is valid for the whole call.
+///
+/// `triggered` is atomic because triggering no longer happens under any lock:
+/// a graph-event thread can set it while `rmw_wait` reads it.
 #[derive(Debug, Default)]
-pub struct GuardConditionImpl {
+pub struct GuardConditionState {
     pub(crate) notifier: Option<Arc<Notifier>>,
-    pub(crate) triggered: bool,
+    pub(crate) triggered: AtomicBool,
 }
 
-impl GuardConditionImpl {
-    pub(crate) fn trigger(&mut self) -> Result<(), ()> {
+impl GuardConditionState {
+    pub(crate) fn fire(&self) -> Result<(), ()> {
         let notifier = self.notifier.as_ref().ok_or(())?;
-        self.triggered = true;
+        self.triggered.store(true, Ordering::SeqCst);
         notifier.notify_all();
         Ok(())
     }
 
+    pub(crate) fn reset(&self) {
+        self.triggered.store(false, Ordering::SeqCst);
+    }
+
+    pub(crate) fn is_triggered(&self) -> bool {
+        self.triggered.load(Ordering::SeqCst)
+    }
+}
+
+impl hiroz::event::GraphGuardCondition for GuardConditionState {
+    fn trigger(&self) {
+        // A guard condition with no notifier cannot wake anyone; that is not an
+        // error worth propagating across the registry.
+        let _ = self.fire();
+    }
+}
+
+/// Guard condition implementation for RMW
+#[derive(Debug, Default)]
+pub struct GuardConditionImpl {
+    pub(crate) state: Arc<GuardConditionState>,
+}
+
+impl GuardConditionImpl {
+    pub(crate) fn trigger(&mut self) -> Result<(), ()> {
+        self.state.fire()
+    }
+
     pub fn reset(&mut self) {
-        self.triggered = false;
+        self.state.reset();
+    }
+
+    /// A shared handle to this guard condition's state, for registration with
+    /// hiroz's graph-event manager.
+    pub(crate) fn share_state(&self) -> Arc<GuardConditionState> {
+        self.state.clone()
     }
 }
 
 impl crate::traits::Waitable for GuardConditionImpl {
     fn is_ready(&self) -> bool {
-        self.triggered
+        self.state.is_triggered()
     }
 }
 
@@ -52,8 +98,10 @@ pub extern "C" fn rmw_create_guard_condition(
 
     let notifier = Some(context_impl.share_notifier());
     let gc_impl = GuardConditionImpl {
-        notifier,
-        triggered: false,
+        state: Arc::new(GuardConditionState {
+            notifier,
+            triggered: AtomicBool::new(false),
+        }),
     };
     let gc = Box::new(rmw_guard_condition_t {
         implementation_identifier: crate::RMW_ZENOH_IDENTIFIER.as_ptr() as *const _,

--- a/crates/rmw-zenoh-rs/src/guard_condition.rs
+++ b/crates/rmw-zenoh-rs/src/guard_condition.rs
@@ -7,16 +7,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 /// The triggerable state of a guard condition, separated from the C handle.
 ///
-/// This lives behind an `Arc` so it can outlive `rmw_destroy_guard_condition`.
-/// hiroz's graph-event manager registers a clone (as
-/// `Arc<dyn GraphGuardCondition>`) and triggers it **after** dropping its
-/// registry lock; without shared ownership, a `rmw_destroy_node` racing that
-/// window would free the target and the trigger would write through dangling
-/// memory. The C handle holds one reference and the registry another, so
-/// whichever outlives the other, the state is valid for the whole call.
+/// Behind an `Arc` so it can outlive `rmw_destroy_guard_condition`: hiroz's
+/// graph-event manager registers a clone and triggers it **after** dropping its
+/// registry lock, so a racing `rmw_destroy_node` would otherwise free the target
+/// mid-call. The C handle holds one reference and the registry another.
 ///
-/// `triggered` is atomic because triggering no longer happens under any lock:
-/// a graph-event thread can set it while `rmw_wait` reads it.
+/// `triggered` is atomic because triggering no longer happens under any lock.
 #[derive(Debug, Default)]
 pub struct GuardConditionState {
     pub(crate) notifier: Option<Arc<Notifier>>,
@@ -65,14 +61,11 @@ pub struct GuardConditionImpl {
 }
 
 impl GuardConditionImpl {
-    // `&self`, not `&mut self`. `rmw_wait` holds shared references to this
-    // object while scanning the wait set, and `rmw_trigger_guard_condition` can
-    // fire from a zenoh delivery thread at the same time. Handing out a `&mut`
-    // to an object another thread holds a `&` to is undefined behaviour in Rust
-    // whatever the field types are -- moving `triggered` behind an atomic
-    // defines the *data race* but says nothing about the aliasing. All mutation
-    // now goes through the atomics in `GuardConditionState`, so shared access is
-    // sufficient and every borrow can be immutable.
+    // `&self`, not `&mut self`: `rmw_wait` holds shared references while
+    // scanning the wait set, and a zenoh thread can trigger concurrently.
+    // Handing out `&mut` to an object another thread holds a `&` to is UB
+    // regardless of field types — the atomic defines the *data race* but says
+    // nothing about the aliasing. All mutation goes through the atomics.
     pub(crate) fn trigger(&self) -> Result<(), ()> {
         self.state.fire()
     }

--- a/crates/rmw-zenoh-rs/src/guard_condition.rs
+++ b/crates/rmw-zenoh-rs/src/guard_condition.rs
@@ -55,11 +55,19 @@ pub struct GuardConditionImpl {
 }
 
 impl GuardConditionImpl {
-    pub(crate) fn trigger(&mut self) -> Result<(), ()> {
+    // `&self`, not `&mut self`. `rmw_wait` holds shared references to this
+    // object while scanning the wait set, and `rmw_trigger_guard_condition` can
+    // fire from a zenoh delivery thread at the same time. Handing out a `&mut`
+    // to an object another thread holds a `&` to is undefined behaviour in Rust
+    // whatever the field types are -- moving `triggered` behind an atomic
+    // defines the *data race* but says nothing about the aliasing. All mutation
+    // now goes through the atomics in `GuardConditionState`, so shared access is
+    // sufficient and every borrow can be immutable.
+    pub(crate) fn trigger(&self) -> Result<(), ()> {
         self.state.fire()
     }
 
-    pub fn reset(&mut self) {
+    pub fn reset(&self) {
         self.state.reset();
     }
 
@@ -138,7 +146,8 @@ pub extern "C" fn rmw_trigger_guard_condition(
         return RMW_RET_INVALID_ARGUMENT as _;
     }
 
-    if let Ok(gc_impl) = (guard_condition as *mut rmw_guard_condition_t).borrow_mut_data() {
+    // Immutable borrow: see the note on `GuardConditionImpl::trigger`.
+    if let Ok(gc_impl) = (guard_condition as *mut rmw_guard_condition_t).borrow_data() {
         let _ = gc_impl.trigger();
     }
 

--- a/crates/rmw-zenoh-rs/src/guard_condition.rs
+++ b/crates/rmw-zenoh-rs/src/guard_condition.rs
@@ -35,6 +35,16 @@ impl GuardConditionState {
         self.triggered.store(false, Ordering::SeqCst);
     }
 
+    /// Consume the triggered flag, returning what it was.
+    ///
+    /// One atomic op, so a `trigger()` racing this either wins or is preserved.
+    /// `is_triggered()` then `reset()` is two ops and silently drops a trigger
+    /// landing between them: the waiter reports this wake, and the next
+    /// `rmw_wait` blocks until timeout.
+    pub(crate) fn take_triggered(&self) -> bool {
+        self.triggered.swap(false, Ordering::SeqCst)
+    }
+
     pub(crate) fn is_triggered(&self) -> bool {
         self.triggered.load(Ordering::SeqCst)
     }
@@ -69,6 +79,11 @@ impl GuardConditionImpl {
 
     pub fn reset(&self) {
         self.state.reset();
+    }
+
+    /// Consume the triggered flag. See [`GuardConditionState::take_triggered`].
+    pub(crate) fn take_triggered(&self) -> bool {
+        self.state.take_triggered()
     }
 
     /// A shared handle to this guard condition's state, for registration with

--- a/crates/rmw-zenoh-rs/src/node.rs
+++ b/crates/rmw-zenoh-rs/src/node.rs
@@ -12,6 +12,14 @@ pub struct NodeImpl {
     pub namespace: CString,
     pub fq_name: CString,
     pub graph_guard_condition: *mut rmw_guard_condition_t,
+    /// The shared state registered with hiroz's graph-event manager.
+    ///
+    /// Kept so teardown can unregister the exact allocation it registered
+    /// (identity is `Arc::ptr_eq`). Holding it here also means the state
+    /// survives `rmw_destroy_guard_condition` below, which is what makes it safe
+    /// to free the C handle while a graph-change trigger may still be in flight.
+    pub graph_guard_condition_state:
+        Option<std::sync::Arc<dyn hiroz::event::GraphGuardCondition>>,
 }
 
 impl NodeImpl {
@@ -44,6 +52,7 @@ impl NodeImpl {
             namespace: namespace_cstr,
             fq_name: fq_name_cstr,
             graph_guard_condition: std::ptr::null_mut(),
+            graph_guard_condition_state: None,
         })
     }
 }
@@ -122,12 +131,23 @@ pub extern "C" fn rmw_create_node(
     }
     node_impl.graph_guard_condition = graph_guard_condition;
 
-    // Register the graph guard condition with the graph event manager
+    // Register the graph guard condition with the graph event manager.
+    //
+    // Register the *shared state*, not the C pointer: the manager triggers with
+    // its registry lock released, so a raw pointer could be freed by a
+    // concurrent `rmw_destroy_node` between snapshot and call. Handing over an
+    // `Arc` keeps the target alive for the duration of any in-flight trigger.
+    let gc_state: std::sync::Arc<dyn hiroz::event::GraphGuardCondition> =
+        match graph_guard_condition.borrow_data() {
+            Ok(gc_impl) => gc_impl.share_state(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+    node_impl.graph_guard_condition_state = Some(gc_state.clone());
     node_impl
         .inner
         .graph()
         .event_manager
-        .register_graph_guard_condition(graph_guard_condition as *mut std::ffi::c_void);
+        .register_graph_guard_condition(gc_state);
 
     // Add node to local graph for immediate discovery
     if let Err(e) = node_impl
@@ -175,7 +195,7 @@ pub extern "C" fn rmw_destroy_node(node: *mut rmw_node_t) -> rmw_ret_t {
     }
 
     // Remove node from local graph and destroy the graph guard condition
-    if let Ok(node_impl) = node.borrow_data() {
+    if let Ok(node_impl) = node.borrow_mut_data() {
         // Remove node from local graph
         if let Err(e) = node_impl
             .inner
@@ -188,14 +208,17 @@ pub extern "C" fn rmw_destroy_node(node: *mut rmw_node_t) -> rmw_ret_t {
         }
 
         if !node_impl.graph_guard_condition.is_null() {
-            // Unregister from graph event manager
-            node_impl
-                .inner
-                .graph()
-                .event_manager
-                .unregister_graph_guard_condition(
-                    node_impl.graph_guard_condition as *mut std::ffi::c_void,
-                );
+            // Unregister from graph event manager, by the same allocation we
+            // registered. Destroying the C handle immediately afterwards is
+            // safe even if a graph-change trigger is in flight: that trigger
+            // holds its own `Arc` to the state, which outlives this handle.
+            if let Some(gc_state) = node_impl.graph_guard_condition_state.take() {
+                node_impl
+                    .inner
+                    .graph()
+                    .event_manager
+                    .unregister_graph_guard_condition(&gc_state);
+            }
             crate::guard_condition::rmw_destroy_guard_condition(node_impl.graph_guard_condition);
         }
     }

--- a/crates/rmw-zenoh-rs/src/node.rs
+++ b/crates/rmw-zenoh-rs/src/node.rs
@@ -18,8 +18,7 @@ pub struct NodeImpl {
     /// (identity is `Arc::ptr_eq`). Holding it here also means the state
     /// survives `rmw_destroy_guard_condition` below, which is what makes it safe
     /// to free the C handle while a graph-change trigger may still be in flight.
-    pub graph_guard_condition_state:
-        Option<std::sync::Arc<dyn hiroz::event::GraphGuardCondition>>,
+    pub graph_guard_condition_state: Option<std::sync::Arc<dyn hiroz::event::GraphGuardCondition>>,
 }
 
 impl NodeImpl {

--- a/crates/rmw-zenoh-rs/src/rmw.rs
+++ b/crates/rmw-zenoh-rs/src/rmw.rs
@@ -2406,32 +2406,24 @@ pub extern "C" fn rmw_subscription_event_init(
 
 /// The `user_data` pointer rmw handed us, carried into the event callback.
 ///
-/// The callback is stored as `Fn(i32) + Send + Sync`, and a raw pointer is
-/// neither — so capturing `user_data` directly does not compile. Casting it to
-/// `usize` makes it compile, which is why the surrounding code used to do that.
-/// It is the wrong remedy twice over: it silences the auto-trait check that was
-/// correctly flagging a pointer crossing threads, and it destroys the pointer's
-/// provenance, so Miri and provenance-aware tooling stop seeing the access too.
-///
-/// This newtype makes the same assertion explicitly, in one place, with the
-/// obligation written down.
-///
-/// # Safety
+/// The callback is `Fn(i32) + Send + Sync` and a raw pointer is neither, so
+/// capturing `user_data` directly does not compile. The previous `as usize`
+/// round-trip made it compile by silencing exactly the check that was flagging
+/// the hazard, and destroyed the pointer's provenance with it. This asserts the
+/// same thing explicitly, once.
 ///
 /// The `unsafe impl`s below assert only that the pointer may be *moved* between
-/// threads — which is true, since rmw's contract is that `user_data` is opaque
-/// to us and the callback may run on any thread. They assert nothing about how
-/// long the pointee lives; see the known hazard below.
+/// threads. They say nothing about how long the pointee lives — see the known
+/// hazard on `update_shared_event_status_with_policy`.
 struct EventUserData(*mut c_void);
 
 impl EventUserData {
     /// Hand the pointer back in the form the C callback expects.
     ///
-    /// Deliberately a method rather than a field read. Closures capture the
-    /// most precise path they use (RFC 2229), so `move |..| { ud.0 }` captures
-    /// the bare `*mut c_void` and the newtype's `Send`/`Sync` never apply —
-    /// the closure simply fails to satisfy its bound. Taking `&self` forces
-    /// the whole struct to be captured.
+    /// A method, not a field read: closures capture the most precise path they
+    /// use (RFC 2229), so `move |..| { ud.0 }` captures the bare pointer and
+    /// the newtype's `Send`/`Sync` never apply. `&self` forces whole-struct
+    /// capture.
     fn as_ptr(&self) -> *const ::std::os::raw::c_void {
         self.0 as *const ::std::os::raw::c_void
     }
@@ -2463,14 +2455,9 @@ pub extern "C" fn rmw_event_set_callback(
     let user_data = EventUserData(user_data);
     rm_event_handle.set_callback(move |change: i32| {
         if let Some(cb) = callback {
-            // SAFETY: `cb` and `user_data.0` were supplied together by rmw, and
-            // this is the pair's only use. Validity of the pointee is the
-            // caller's obligation and is NOT guaranteed here — a concurrent
-            // `rmw_event_set_callback(.., null)` can return, and rclcpp can
-            // free, between the registry lock being released and this call.
-            // Tracked as a known residual; see `hiroz::event` for why closing
-            // it needs detach to block on in-flight invocations rather than a
-            // check here.
+            // SAFETY: `cb` and the pointer were supplied together by rmw and
+            // this is the pair's only use. Pointee validity is NOT established
+            // here — a concurrent detach can free it first. See hiroz#287.
             unsafe { cb(user_data.as_ptr(), change as usize) };
         }
     });

--- a/crates/rmw-zenoh-rs/src/rmw.rs
+++ b/crates/rmw-zenoh-rs/src/rmw.rs
@@ -2404,6 +2404,47 @@ pub extern "C" fn rmw_subscription_event_init(
     RMW_RET_OK as _
 }
 
+/// The `user_data` pointer rmw handed us, carried into the event callback.
+///
+/// The callback is stored as `Fn(i32) + Send + Sync`, and a raw pointer is
+/// neither — so capturing `user_data` directly does not compile. Casting it to
+/// `usize` makes it compile, which is why the surrounding code used to do that.
+/// It is the wrong remedy twice over: it silences the auto-trait check that was
+/// correctly flagging a pointer crossing threads, and it destroys the pointer's
+/// provenance, so Miri and provenance-aware tooling stop seeing the access too.
+///
+/// This newtype makes the same assertion explicitly, in one place, with the
+/// obligation written down.
+///
+/// # Safety
+///
+/// The `unsafe impl`s below assert only that the pointer may be *moved* between
+/// threads — which is true, since rmw's contract is that `user_data` is opaque
+/// to us and the callback may run on any thread. They assert nothing about how
+/// long the pointee lives; see the known hazard below.
+struct EventUserData(*mut c_void);
+
+impl EventUserData {
+    /// Hand the pointer back in the form the C callback expects.
+    ///
+    /// Deliberately a method rather than a field read. Closures capture the
+    /// most precise path they use (RFC 2229), so `move |..| { ud.0 }` captures
+    /// the bare `*mut c_void` and the newtype's `Send`/`Sync` never apply —
+    /// the closure simply fails to satisfy its bound. Taking `&self` forces
+    /// the whole struct to be captured.
+    fn as_ptr(&self) -> *const ::std::os::raw::c_void {
+        self.0 as *const ::std::os::raw::c_void
+    }
+}
+
+// SAFETY: the pointer is opaque to hiroz — it is never dereferenced here, only
+// handed back to the C callback that supplied it. rmw's contract is that the
+// callback may be invoked from any thread, so the caller has already accepted
+// that `user_data` is reachable from other threads.
+unsafe impl Send for EventUserData {}
+// SAFETY: as above. `&EventUserData` exposes no operation on the pointee.
+unsafe impl Sync for EventUserData {}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn rmw_event_set_callback(
     event: *mut rmw_event_t,
@@ -2419,11 +2460,18 @@ pub extern "C" fn rmw_event_set_callback(
     }
 
     let rm_event_handle = unsafe { &mut *((*event).data as *mut RmEventHandle) };
-    let user_data_ptr = user_data as usize;
+    let user_data = EventUserData(user_data);
     rm_event_handle.set_callback(move |change: i32| {
         if let Some(cb) = callback {
-            let ud = user_data_ptr as *mut ::std::os::raw::c_void;
-            unsafe { cb(ud as *const ::std::os::raw::c_void, change as usize) };
+            // SAFETY: `cb` and `user_data.0` were supplied together by rmw, and
+            // this is the pair's only use. Validity of the pointee is the
+            // caller's obligation and is NOT guaranteed here — a concurrent
+            // `rmw_event_set_callback(.., null)` can return, and rclcpp can
+            // free, between the registry lock being released and this call.
+            // Tracked as a known residual; see `hiroz::event` for why closing
+            // it needs detach to block on in-flight invocations rather than a
+            // check here.
+            unsafe { cb(user_data.as_ptr(), change as usize) };
         }
     });
 

--- a/crates/rmw-zenoh-rs/src/rmw.rs
+++ b/crates/rmw-zenoh-rs/src/rmw.rs
@@ -208,9 +208,11 @@ pub extern "C" fn rmw_create_publisher(
         qualified_topic.clone(),
         hiroz::event::ZenohEventType::PublicationMatched,
         move |change| {
-            if let Ok(mut mgr) = events_mgr.lock() {
-                mgr.update_event_status(hiroz::event::ZenohEventType::PublicationMatched, change);
-            }
+            hiroz::event::update_shared_event_status(
+                &events_mgr,
+                hiroz::event::ZenohEventType::PublicationMatched,
+                change,
+            );
             // Wake up wait sets
             notifier_clone_for_matched.notify_all();
         },
@@ -230,13 +232,12 @@ pub extern "C" fn rmw_create_publisher(
             // Decode policy_kind from upper 16 bits and change from lower 16 bits
             let policy_kind = ((encoded_change >> 16) & 0xFFFF) as u32;
             let change = encoded_change & 0xFFFF;
-            if let Ok(mut mgr) = events_mgr_clone.lock() {
-                mgr.update_event_status_with_policy(
-                    hiroz::event::ZenohEventType::OfferedQosIncompatible,
-                    change,
-                    policy_kind,
-                );
-            }
+            hiroz::event::update_shared_event_status_with_policy(
+                &events_mgr_clone,
+                hiroz::event::ZenohEventType::OfferedQosIncompatible,
+                change,
+                policy_kind,
+            );
             // Wake up wait sets
             notifier_clone_for_incompatible.notify_all();
         },
@@ -250,12 +251,11 @@ pub extern "C" fn rmw_create_publisher(
     // Check if there are already existing subscriptions for this topic and trigger the event
     let matching_sub_count = graph.count(hiroz::entity::EndpointKind::Subscription, &entity.topic);
     if matching_sub_count > 0 {
-        if let Ok(mut mgr) = zpub.events_mgr().lock() {
-            mgr.update_event_status(
-                hiroz::event::ZenohEventType::PublicationMatched,
-                matching_sub_count as i32,
-            );
-        }
+        hiroz::event::update_shared_event_status(
+            zpub.events_mgr(),
+            hiroz::event::ZenohEventType::PublicationMatched,
+            matching_sub_count as i32,
+        );
         notifier_clone_for_init.notify_all();
     }
 
@@ -307,13 +307,12 @@ pub extern "C" fn rmw_create_publisher(
         }
     }
     if incompatible_count > 0 {
-        if let Ok(mut mgr) = zpub.events_mgr().lock() {
-            mgr.update_event_status_with_policy(
-                hiroz::event::ZenohEventType::OfferedQosIncompatible,
-                incompatible_count,
-                last_policy_kind,
-            );
-        }
+        hiroz::event::update_shared_event_status_with_policy(
+            zpub.events_mgr(),
+            hiroz::event::ZenohEventType::OfferedQosIncompatible,
+            incompatible_count,
+            last_policy_kind,
+        );
         notifier_clone_for_init.notify_all();
     }
 
@@ -595,9 +594,11 @@ pub extern "C" fn rmw_create_subscription(
         sub_topic.clone(),
         hiroz::event::ZenohEventType::SubscriptionMatched,
         move |change| {
-            if let Ok(mut mgr) = events_mgr.lock() {
-                mgr.update_event_status(hiroz::event::ZenohEventType::SubscriptionMatched, change);
-            }
+            hiroz::event::update_shared_event_status(
+                &events_mgr,
+                hiroz::event::ZenohEventType::SubscriptionMatched,
+                change,
+            );
             // Wake up wait sets
             notifier_clone_for_matched.notify_all();
         },
@@ -617,13 +618,12 @@ pub extern "C" fn rmw_create_subscription(
             // Decode policy_kind from upper 16 bits and change from lower 16 bits
             let policy_kind = ((encoded_change >> 16) & 0xFFFF) as u32;
             let change = encoded_change & 0xFFFF;
-            if let Ok(mut mgr) = events_mgr_clone.lock() {
-                mgr.update_event_status_with_policy(
-                    hiroz::event::ZenohEventType::RequestedQosIncompatible,
-                    change,
-                    policy_kind,
-                );
-            }
+            hiroz::event::update_shared_event_status_with_policy(
+                &events_mgr_clone,
+                hiroz::event::ZenohEventType::RequestedQosIncompatible,
+                change,
+                policy_kind,
+            );
             // Wake up wait sets
             notifier_clone_for_incompatible.notify_all();
         },
@@ -637,12 +637,11 @@ pub extern "C" fn rmw_create_subscription(
     // Check if there are already existing publishers for this topic and trigger the event
     let matching_pub_count = graph.count(hiroz::entity::EndpointKind::Publisher, &entity.topic);
     if matching_pub_count > 0 {
-        if let Ok(mut mgr) = zsub.events_mgr().lock() {
-            mgr.update_event_status(
-                hiroz::event::ZenohEventType::SubscriptionMatched,
-                matching_pub_count as i32,
-            );
-        }
+        hiroz::event::update_shared_event_status(
+            zsub.events_mgr(),
+            hiroz::event::ZenohEventType::SubscriptionMatched,
+            matching_pub_count as i32,
+        );
         notifier_clone_for_init.notify_all();
     }
 
@@ -694,13 +693,12 @@ pub extern "C" fn rmw_create_subscription(
         }
     }
     if incompatible_count > 0 {
-        if let Ok(mut mgr) = zsub.events_mgr().lock() {
-            mgr.update_event_status_with_policy(
-                hiroz::event::ZenohEventType::RequestedQosIncompatible,
-                incompatible_count,
-                last_policy_kind,
-            );
-        }
+        hiroz::event::update_shared_event_status_with_policy(
+            zsub.events_mgr(),
+            hiroz::event::ZenohEventType::RequestedQosIncompatible,
+            incompatible_count,
+            last_policy_kind,
+        );
         notifier_clone_for_init.notify_all();
     }
 

--- a/crates/rmw-zenoh-rs/src/wait_set.rs
+++ b/crates/rmw-zenoh-rs/src/wait_set.rs
@@ -388,8 +388,10 @@ pub extern "C" fn rmw_wait(
                     unsafe { *gc_array.guard_conditions.add(i) as *mut rmw_guard_condition_impl_t };
                 if !gc_impl_ptr.is_null() {
                     unsafe {
+                        // Shared, not exclusive: a delivery thread may be
+                        // inside `trigger` on this same object right now.
                         let gc_impl =
-                            &mut *(gc_impl_ptr as *mut crate::guard_condition::GuardConditionImpl);
+                            &*(gc_impl_ptr as *const crate::guard_condition::GuardConditionImpl);
                         if !gc_impl.is_ready() {
                             // Not ready - set to NULL in place
                             *gc_array.guard_conditions.add(i) = std::ptr::null_mut();

--- a/crates/rmw-zenoh-rs/src/wait_set.rs
+++ b/crates/rmw-zenoh-rs/src/wait_set.rs
@@ -392,13 +392,11 @@ pub extern "C" fn rmw_wait(
                         // inside `trigger` on this same object right now.
                         let gc_impl =
                             &*(gc_impl_ptr as *const crate::guard_condition::GuardConditionImpl);
-                        if !gc_impl.is_ready() {
-                            // Not ready - set to NULL in place
+                        // Check and consume in one atomic op. Reading then
+                        // resetting would drop a trigger landing between the
+                        // two: this wake is reported, the next one is lost.
+                        if !gc_impl.take_triggered() {
                             *gc_array.guard_conditions.add(i) = std::ptr::null_mut();
-                        } else {
-                            // Reset the guard condition after it's been detected as ready
-                            // This prevents it from staying triggered forever
-                            gc_impl.reset();
                         }
                     }
                 }


### PR DESCRIPTION
Part of #282 — the defect class, the shared fix shape and the merge order are stated there.

## Role in #282

Instance fix plus coverage, and the widest one. It converts the graph and event registry locks. It is also why the debug-time monitor **counts** guards rather than setting a flag: the liveliness path runs with three tracked-or-untracked locks held, and a single bit cannot be cleared soundly on release.

Consumes the types added by #255 (`TrackedMutex`, `invoke_user_callback!`), which is merged. Targets `main`; the merge base is `af00f1ed`, the current tip of `main`.

## Issue

Fixes #259 — three failures spanning two defect classes.

| # | Failure | Class | Evidence |
|---|---|---|---|
| 1 | `GraphEventManager` invoked registered callbacks while holding the registries they live in. The hot path is the liveliness subscriber in `Graph::new_with_pattern`, which also held the `GraphData` mutex — so three locks (`GraphData`, `event_callbacks`, `entity_topics`) on every liveliness token, around user code the rmw layer hands to an rclcpp executor | re-entrancy | deterministic hang, reproduced by test |
| 2 | Lock-order hazard. The liveliness callback held `GraphData` across the acquisition of `event_callbacks`, so that order constrained every other path; `add_local_entity` and the rmw callers reach `event_callbacks` without `GraphData`. #259 classifies this as an ABBA inversion | lock ordering | established by reading, not by executing — no test reproduces it |
| 3 | `EventsManager` is shared as `Arc<Mutex<..>>`, so `&mut self` proves the caller holds it — and `update_event_status` fired the callback from there. All eight call sites in `crates/rmw-zenoh-rs/src/rmw.rs` had this shape | re-entrancy | deterministic hang, reproduced by test |

Failure 2 is **not** covered by the "no callout under a lock" property. A guard count cannot see lock order.

## What this PR does

| # | Change | Why |
|---|---|---|
| 1 | `trigger_event_with_policy`, `trigger_graph_change` and the guard-condition sweep collect under the lock, drop every guard, then notify | the class fix |
| 2 | `Graph::new_with_pattern` stops holding `GraphData` across `trigger_graph_change` | the third lock of failure 1, and the `GraphData`-then-`event_callbacks` leg of failure 2 |
| 3 | `record_event_status_with_policy` returns the callback (`#[must_use]`); `update_shared_event_status[_with_policy]` becomes the entry point holders of the shared manager use | failure 3 |
| 4 | `event_callbacks`, `entity_topics` and `graph_guard_conditions` become `TrackedMutex`; the two `GraphEventManager` callouts route through `invoke_user_callback!` | a reintroduction panics naming the site instead of hanging |
| 5 | `GuardConditionState::take_triggered` (one `swap`) replaces read-then-reset in `rmw_wait` | **independent bug**: a `trigger()` landing between the two atomic ops was swallowed — that wake was reported and the next `rmw_wait` blocked until timeout |
| 6 | `GraphGuardConditionTrigger` removed; registrations become `Arc<dyn GraphGuardCondition>`, and `NodeImpl` keeps the same allocation so teardown can unregister it | triggering outside the lock made raw-pointer registrations a use-after-free — `rmw_destroy_node` unregisters and frees while a trigger is in flight |
| 7 | The event `user_data` pointer stops being laundered through `usize`; it moves in a newtype with explicit `unsafe impl Send`/`Sync` | the `as usize` round-trip silenced the `Send`/`Sync` check that was flagging a pointer crossing threads, and destroyed the pointer's provenance |

Change 5 is not a re-entrancy defect — it was found while reading the same file. Its symptom is a latency spike rather than a hang, which is how it survived.

**Kept whole deliberately.** Splitting on the crate boundary was considered and rejected: the `rmw-zenoh-rs` half *implements* a trait the hiroz half defines, so an rmw-only PR would not compile until the hiroz-only PR merged — another stacked PR, which is what this series exists to remove.

## Evidence

Six tests are added: five deadlock scenarios (three in `reentrant_graph_event.rs`, two in `reentrant_event_status.rs`) and one unit test in `event.rs` pinning that the guard-condition registry owns its registrations.

| measurement | result | revision |
|---|---|---|
| the six new tests, plus fmt, clippy and doc build | all pass, all clean | `e285962c` (current tip) |
| revert `event.rs` and `graph.rs`, keep the three `reentrant_graph_event` tests | **3 fail** — two on the 30 s deadline, one because the re-entrant graph query returned 0 publishers | `cbabd82c` (earlier revision of this branch, before the rebase onto `af00f1ed`) |
| revert wholesale, keep the two `reentrant_event_status` tests | **does not compile** — both call an entry point this PR introduces | as above |
| reinstate the callout inside `update_shared_event_status_with_policy` and re-run | **2 fail** on the 30 s deadline | temporary revert commit on the same revision |

The third row is why the event-status pair is necessary rather than a passenger: it does not detect the *history* (a wholesale revert stops the file compiling) but it does detect the *property*. Reinstate the callout and both tests hang. That is the regression still reachable, since the old entry point is gone.

The reinstated-callout run fails on the harness's **timeout** arm, not its panic arm, so it is classified as a deadlock rather than an assertion failure.

⚠️ The two revert directions were measured on the pre-rebase revision of this branch and have not been re-run at `e285962c`. The fix-present row was measured at the current tip.

## Breaking changes

**Three public items in `hiroz`, all source-breaking.** `rmw-zenoh-rs` is consumed over the C ABI, so its changes are not part of this list.

| # | Item | Before → After | Action | Effort |
|---|---|---|---|---|
| 1 | `pub type EventCallback` | `Box<dyn Fn(i32) + Send + Sync>` → `Arc<…>` | `Box::new` → `Arc::new` | mechanical |
| 2 | `pub type GraphGuardConditionTrigger` | **removed**; `register_graph_guard_condition` / `unregister_graph_guard_condition` now take `Arc<dyn GraphGuardCondition>` | define a type and `impl GraphGuardCondition` | **not mechanical** — a closure cannot be substituted |
| 3 | `GraphEventManager::set_guard_condition_trigger` | **removed** | register the guard condition itself; there is no separate trigger hook | small, but no drop-in |

Neither of the first two is a rename:

- `Box` cannot be cloned, so it cannot be lifted out of a guard — and lifting the callback out *is* the fix.
- The closure form cannot express the ownership a guard condition needs: the registry must keep the target alive across a trigger performed with no lock held.

Additive, not breaking: `EventsManager::install_callback` and `EventsManager::record_event_status_with_policy` are new; `update_shared_event_status[_with_policy]` are new free functions.

## Coverage this does not have

| gap | detail |
|---|---|
| `GraphData` is untracked | it is a `parking_lot::Mutex`. Reintroduce the deleted guard at the top of the liveliness callback and `assert_no_guards_held` still reports 0. That hot path is caught by exactly one test — `graph_change_callback_querying_the_graph_does_not_deadlock` — which needs a router, is `#[serial]`, and polls for propagation |
| nothing covers failure 2 | lock ordering is invisible to a guard count |
| five callouts in `event.rs` bypass `invoke_user_callback!` | `EventsManager::set_callback` (backlog), `EventsManager::update_event_status_with_policy`, `gc.trigger()` inside `trigger_graph_change`, `update_shared_event_status_with_policy`, `RmEventHandle::set_callback` (backlog). Only the two `GraphEventManager` registry callouts are routed |
| change 5 has no detector — measured, not suspected | reverting `take_triggered` to the racy read-then-reset leaves the suite green: 93 integration tests and 288 library unit tests all passed. The lost-wake bug is guarded only by the reading that found it |
| changes 6 and 7 are believed to have no behavioural detector | stated as a belief; not probed |

## ⚠️ Known residual this fix introduces

**An event callback can fire after `rmw_event_set_callback(event, nullptr, nullptr)` returns**, and invoke a stale `user_data`. Tracked in #287 with the design settled.

| | |
|---|---|
| **Trigger** | Thread A clones the `Arc` out and releases the manager lock. Thread B (executor teardown) calls `set_callback(nullptr)`, which returns; rclcpp frees the pointee. Thread A then calls the closure. |
| **Why it is new** | The invocation used to happen inside `Mutex<EventsManager>`, which `RmEventHandle::set_callback` also takes, so a detach could not return mid-invocation. That exclusion was accidental but load-bearing. |
| **Why the `Arc` does not help** | It owns the *closure*. The raw C pointer it captured is rclcpp's — which is why change 6's remedy cannot be reused here. |
| **Not fixable by** | re-locking (that is the deadlock this removes), or a flag checked in the closure (the free can land between check and call, and the code then *looks* defended) |
| **What does fix it** | detach blocks until any in-flight invocation returns, with a bypass when called from the invoking thread — the shape of `std::stop_callback`'s destructor contract |

This does not block merging, but it is a real trade, and it is **not** a gap shared with upstream. `rmw_zenoh_cpp` does not have this seam: `EventsManager::event_set_callback` (`rmw_zenoh_cpp/src/detail/event.cpp:105`) and `EventsManager::trigger_event_callback` (`:133`) both take `event_mutex_` (`:118`, `:143`) and invoke the user callback while holding it (`:126`, `:146`). Upstream's detach therefore cannot return mid-invocation.

So upstream takes the other horn: it keeps the lock, has no use-after-free window, and does have the deadlock this PR removes. Closing #287 is hardening beyond what any peer implementation provides, not catching up to one.

## How upstream compares

Read from `rmw_zenoh_cpp` source, not inferred. Paths below are relative to `rmw_zenoh_cpp/src/detail/`.

| path | rmw_zenoh_cpp | this PR |
|---|---|---|
| graph discovery callbacks | collect, release, call — `parse_put` unlocks `graph_mutex_` at `graph_cache.cpp:428` before invoking, with the `graph_mutex_ → discovery_mutex_` order documented at `:205` | same |
| QoS event callbacks | still under two locks: `parse_put` holds `graph_mutex_` (`graph_cache.cpp:367`) through `handle_matched_events_for_put` (`:180`) into `update_event_counters`, which locks `events_mutex_` (`:1496`) and invokes the callback at `:1528` | released |
| event set / trigger | invoked under the same mutex `event_set_callback` takes (`event.cpp:118`, `:126`, `:143`, `:146`) | released → #287 |

- **The fix shape is independently confirmed.** Upstream reached collect-release-call for discovery, with a comment giving the same reason (`graph_cache.cpp:210-213`).
- **This PR is ahead on the event path.** Upstream still holds two locks across the QoS event callout — that is failure 1, unfixed in C++.
- **The #287 tradeoff is a genuine choice, not a regression against a peer.** Upstream keeps the lock: no use-after-free, but the deadlock. This takes the other horn. Neither has both, which is the argument for the barrier rather than for either status quo.

## Checklist

- [x] Added tests and documentation
- [x] Both directions measured — see the evidence table, including which revision each row was measured on
- [x] Review findings addressed: the lost wake (change 5) and the immutable guard-condition borrow are fixed here, the teardown window is documented above, and #287, #288 and #289 are filed
- [x] Comments tightened — the `&mut self` rule is stated once on `EventsManager` and referenced, rather than restated at three call sites
- [ ] `./scripts/check-local.sh` not re-run since the rebase; CI covers it
