### PR TITLE
feat(hu-meter): restore pub and delay subcommands

### DIFF
--- a/crates/hiroz-tests/tests/hu_meter.rs
+++ b/crates/hiroz-tests/tests/hu_meter.rs
@@ -2129,12 +2129,13 @@ fn test_hu_meter_delay_basic() {
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
 
-    // `extract_delay_note` is a documented stub that reports the raw message
-    // ("(raw) {json}"); assert on what it actually emits (a message on the
-    // topic, echoed), not on measurement text no code path produces.
+    // The producer stamps each Header with the current time, so `delay` must
+    // report a real end-to-end latency ("delay: <n> ms"), prefixed with the
+    // topic. (Not asserting the sign/magnitude — only that a delay was measured
+    // from the stamped header, i.e. the header.stamp parse + clock path worked.)
     assert!(
-        stdout.contains("(raw)") && stdout.contains("delay_test"),
-        "Expected a raw echoed message from the delay subscriber, got: {}",
+        stdout.contains("delay:") && stdout.contains("ms") && stdout.contains("delay_test"),
+        "Expected a measured delay from the stamped header, got: {}",
         stdout
     );
 }

--- a/crates/hiroz-tests/tests/hu_meter.rs
+++ b/crates/hiroz-tests/tests/hu_meter.rs
@@ -2366,3 +2366,79 @@ fn test_hu_meter_pub_empty_topic_from_disk() {
         "raw subscriber did not receive the message published to the empty topic"
     );
 }
+
+/// Nested-type coverage for the disk schema loader: `geometry_msgs/msg/Twist`
+/// has same-package nested fields (`Vector3 linear`/`angular`) written
+/// unqualified. The loader must default those to the parent package and resolve
+/// them recursively; if it doesn't, `encode-yaml-to-cdr` fails and `pub` exits
+/// non-zero. Published to an empty topic (no live node), so only the disk path
+/// can supply the schema. Receipt is confirmed by a raw Zenoh subscriber.
+#[test]
+#[serial_test::serial]
+fn test_hu_meter_pub_empty_topic_nested_type() {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use zenoh::Wait;
+
+    let msg_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../hiroz-codegen/assets/jazzy");
+
+    let router = TestRouter::new();
+    let got = Arc::new(AtomicBool::new(false));
+    let got_bg = got.clone();
+
+    let endpoint = router.endpoint().to_string();
+    let _producer = spawn_producer(move |stop| async move {
+        let ctx = create_hiroz_context_with_endpoint(&endpoint).unwrap();
+        let node = ctx.create_node("nested_pub_watcher").build().unwrap();
+        // Raw subscriber over data keys (`**` excludes `@`-prefixed liveliness),
+        // announcing no ROS type — the empty topic has no discoverable schema, so
+        // a successful publish proves the nested type resolved from disk.
+        let _sub = node
+            .session()
+            .declare_subscriber("**")
+            .callback(move |_sample| got_bg.store(true, Ordering::Relaxed))
+            .wait()
+            .unwrap();
+        while !stop.load(Ordering::Relaxed) {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    });
+
+    thread::sleep(Duration::from_millis(500));
+
+    let out = run_hu_meter_env(
+        router.endpoint(),
+        &[
+            "pub",
+            "/nested_pub_topic",
+            "--msg-type",
+            "geometry_msgs/msg/Twist",
+            "--yaml",
+            "{linear: {x: 1.0, y: 2.0, z: 3.0}, angular: {x: 4.0, y: 5.0, z: 6.0}}",
+        ],
+        &[("HIROZ_MSG_PATH", msg_path)],
+    );
+    assert!(
+        out.status.success(),
+        "hu meter pub of a nested type (Twist) to an empty topic should succeed \
+         via the disk loader; stderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let mut received = false;
+    for _ in 0..40 {
+        if got.load(Ordering::Relaxed) {
+            received = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        received,
+        "raw subscriber did not receive the nested-type message on the empty topic"
+    );
+}

--- a/crates/hiroz-tests/tests/hu_meter.rs
+++ b/crates/hiroz-tests/tests/hu_meter.rs
@@ -33,15 +33,25 @@ use hiroz_msgs::{
 /// Requires HU_PLUGIN_PATH to contain the compiled hu-meter.wasm.
 /// Build it first: cargo build -p hu-meter --target wasm32-wasip2
 fn run_hu_meter(router: &str, args: &[&str]) -> Output {
-    let mut child = Command::new("hu")
-        .arg("--connect")
+    run_hu_meter_env(router, args, &[])
+}
+
+/// Like [`run_hu_meter`], but sets extra environment variables on the `hu`
+/// subprocess. Used to point the schema loader at a `.msg` directory
+/// (`HIROZ_MSG_PATH`) so a test is self-contained regardless of how it was
+/// launched.
+fn run_hu_meter_env(router: &str, args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new("hu");
+    cmd.arg("--connect")
         .arg(router)
         .arg("meter")
         .args(args)
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("failed to spawn hu meter");
+        .stderr(Stdio::piped());
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().expect("failed to spawn hu meter");
 
     // Hard wall-clock ceiling well above any individual test's own `--timeout`
     // (tests use at most 10-30s). This is a safety net, not a normal exit
@@ -2143,12 +2153,12 @@ fn test_hu_meter_delay_basic() {
 // ─── pub ──────────────────────────────────────────────────────────────────────
 
 /// Error-path coverage for `hu meter pub`: argument validation and the
-/// no-discoverable-schema case. `pub` resolves the message schema by live
-/// discovery from a node on the topic (`encode-yaml-to-cdr` takes the topic),
-/// so publishing to a topic with no publisher/subscriber must fail cleanly
-/// rather than panic or hang. The happy path (a live consumer is present, the
-/// message is published and received) is covered by
-/// `test_hu_meter_pub_publishes_to_live_topic`.
+/// unresolvable-schema case. `pub` resolves the message schema from a `.msg` on
+/// disk (`HIROZ_MSG_PATH`) first, then falls back to live discovery from a node
+/// on the topic; a type that is neither on disk nor announced must fail cleanly
+/// rather than panic or hang. The disk path (empty topic) is covered by
+/// `test_hu_meter_pub_empty_topic_from_disk`, and the live-discovery happy path
+/// by `test_hu_meter_pub_publishes_to_live_topic`.
 #[test]
 #[serial_test::serial]
 fn test_hu_meter_pub_arg_and_encode_paths() {
@@ -2168,22 +2178,26 @@ fn test_hu_meter_pub_arg_and_encode_paths() {
         String::from_utf8_lossy(&out.stdout)
     );
 
-    // (b) No publisher/subscriber on the topic → schema discovery finds nothing,
+    // (b) A type that is neither on disk (no such `.msg`) nor announced by any
+    //     node on the topic → the loader and live discovery both come up empty,
     //     so the encode boundary must surface a clean error and exit non-zero.
+    //     (A real type like std_msgs/msg/String would instead resolve from disk
+    //     via HIROZ_MSG_PATH; that empty-topic path is covered separately by
+    //     `test_hu_meter_pub_empty_topic_from_disk`.)
     let out = run_hu_meter(
         router.endpoint(),
         &[
             "pub",
             "/pub_unannounced_topic",
             "--msg-type",
-            "std_msgs/msg/String",
+            "made_up_pkg/msg/NoSuchType",
             "--yaml",
             "{data: hello}",
         ],
     );
     assert!(
         !out.status.success(),
-        "hu meter pub to a topic with no announced type should exit non-zero"
+        "hu meter pub with an unresolvable type should exit non-zero"
     );
     let combined = format!(
         "{}{}",
@@ -2263,5 +2277,92 @@ fn test_hu_meter_pub_publishes_to_live_topic() {
         got,
         "subscriber did not receive the published message; got: {:?}",
         received.lock().unwrap()
+    );
+}
+
+/// Disk-schema path for `hu meter pub`: publishing to an *empty* topic — no
+/// hiroz publisher or subscriber present, so live discovery can find nothing —
+/// still works because the host resolves the message schema from a `.msg` on
+/// `HIROZ_MSG_PATH`, exactly like `ros2 topic pub`. Receipt is confirmed by a
+/// *raw* Zenoh subscriber, which announces no ROS type into the graph (so it
+/// cannot be what made the schema resolvable); the type comes purely from disk.
+#[test]
+#[serial_test::serial]
+fn test_hu_meter_pub_empty_topic_from_disk() {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use zenoh::Wait;
+
+    // The bundled codegen assets ship the standard `.msg` set in prefix layout
+    // (<pkg>/msg/<Name>.msg); point the loader there so the test is
+    // self-contained regardless of how it was launched.
+    let msg_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../hiroz-codegen/assets/jazzy");
+
+    let router = TestRouter::new();
+    let got = Arc::new(AtomicBool::new(false));
+    let got_bg = got.clone();
+
+    let endpoint = router.endpoint().to_string();
+    let _producer = spawn_producer(move |stop| async move {
+        let ctx = create_hiroz_context_with_endpoint(&endpoint).unwrap();
+        // A bare node (no typed pub/sub) gives us a Zenoh session without
+        // announcing any endpoint type on the topic.
+        let node = ctx.create_node("empty_pub_watcher").build().unwrap();
+        // Raw Zenoh subscriber over all data keys (`**` excludes `@`-prefixed
+        // liveliness). It carries no ROS type, so hu's discovery stays empty.
+        const MARKER: &[u8] = b"hu_empty_from_disk";
+        let _sub = node
+            .session()
+            .declare_subscriber("**")
+            .callback(move |sample| {
+                let bytes = sample.payload().to_bytes();
+                if bytes.windows(MARKER.len()).any(|w| w == MARKER) {
+                    got_bg.store(true, Ordering::Relaxed);
+                }
+            })
+            .wait()
+            .unwrap();
+        while !stop.load(Ordering::Relaxed) {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    });
+
+    // Let the raw subscriber settle into the router before publishing.
+    thread::sleep(Duration::from_millis(500));
+
+    let out = run_hu_meter_env(
+        router.endpoint(),
+        &[
+            "pub",
+            "/empty_pub_from_disk",
+            "--msg-type",
+            "std_msgs/msg/String",
+            "--yaml",
+            "{data: hu_empty_from_disk}",
+        ],
+        &[("HIROZ_MSG_PATH", msg_path)],
+    );
+    assert!(
+        out.status.success(),
+        "hu meter pub to an empty topic should succeed via the disk schema \
+         loader; stderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let mut received = false;
+    for _ in 0..40 {
+        if got.load(Ordering::Relaxed) {
+            received = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        received,
+        "raw subscriber did not receive the message published to the empty topic"
     );
 }

--- a/crates/hiroz-tests/tests/hu_meter.rs
+++ b/crates/hiroz-tests/tests/hu_meter.rs
@@ -2142,20 +2142,13 @@ fn test_hu_meter_delay_basic() {
 
 // ─── pub ──────────────────────────────────────────────────────────────────────
 
-/// Coverage for `hu meter pub` (publish subcommand).
-///
-/// NOTE on scope: `pub --yaml` encodes via the `encode-yaml-to-cdr` WIT host
-/// function, which resolves the message schema from the global `SchemaRegistry`.
-/// Nothing populates that registry at runtime yet — schemas come only from
-/// compile-time Rust types or live discovery, and `encode-yaml-to-cdr` (unlike
-/// service `call`) is not rerouted through discovery — so every msg-type fails
-/// schema lookup. This is not a bug in `pub`; the happy encode-and-receive path
-/// needs a runtime `.msg` schema loader that does not exist yet.
-///
-/// This test therefore exercises the maximal CI-safe surface: arg parsing, the
-/// one-shot dispatch, the `encode-yaml-to-cdr` host-call boundary, and the
-/// error-rendering/exit paths — catching regressions that break argument
-/// handling, panic the plugin, or hang the command.
+/// Error-path coverage for `hu meter pub`: argument validation and the
+/// no-discoverable-schema case. `pub` resolves the message schema by live
+/// discovery from a node on the topic (`encode-yaml-to-cdr` takes the topic),
+/// so publishing to a topic with no publisher/subscriber must fail cleanly
+/// rather than panic or hang. The happy path (a live consumer is present, the
+/// message is published and received) is covered by
+/// `test_hu_meter_pub_publishes_to_live_topic`.
 #[test]
 #[serial_test::serial]
 fn test_hu_meter_pub_arg_and_encode_paths() {
@@ -2175,14 +2168,13 @@ fn test_hu_meter_pub_arg_and_encode_paths() {
         String::from_utf8_lossy(&out.stdout)
     );
 
-    // (b) With --msg-type + --yaml but no schema in the registry: the
-    //     encode-yaml-to-cdr host call must surface a clean encode error and
-    //     exit non-zero — again, no panic/hang.
+    // (b) No publisher/subscriber on the topic → schema discovery finds nothing,
+    //     so the encode boundary must surface a clean error and exit non-zero.
     let out = run_hu_meter(
         router.endpoint(),
         &[
             "pub",
-            "/pub_string_topic",
+            "/pub_unannounced_topic",
             "--msg-type",
             "std_msgs/msg/String",
             "--yaml",
@@ -2191,7 +2183,7 @@ fn test_hu_meter_pub_arg_and_encode_paths() {
     );
     assert!(
         !out.status.success(),
-        "hu meter pub with an unresolvable schema should exit non-zero"
+        "hu meter pub to a topic with no announced type should exit non-zero"
     );
     let combined = format!(
         "{}{}",
@@ -2199,7 +2191,77 @@ fn test_hu_meter_pub_arg_and_encode_paths() {
         String::from_utf8_lossy(&out.stderr)
     );
     assert!(
-        combined.contains("encode error") || combined.contains("not found"),
-        "Expected a schema-not-found encode error from `pub`, got: {combined}"
+        combined.contains("encode error"),
+        "Expected an encode error from `pub` on an unannounced topic, got: {combined}"
+    );
+}
+
+/// Happy path for `hu meter pub`: with a live subscriber on the topic (so the
+/// message type is discoverable), `pub` resolves the schema, encodes the YAML,
+/// and publishes — and the subscriber receives the message.
+#[test]
+#[serial_test::serial]
+fn test_hu_meter_pub_publishes_to_live_topic() {
+    use std::sync::{Arc, Mutex};
+
+    let router = TestRouter::new();
+    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let received_bg = received.clone();
+
+    let endpoint = router.endpoint().to_string();
+    let _producer = spawn_producer(move |stop| async move {
+        let ctx = create_hiroz_context_with_endpoint(&endpoint).unwrap();
+        let node = ctx
+            .create_node("pub_target")
+            .with_type_description_service()
+            .build()
+            .unwrap();
+        // A live subscriber both announces the std_msgs/String type (so hu's
+        // discovery can resolve the schema) and lets us confirm receipt.
+        let _sub = node
+            .create_sub::<RosString>("/pub_target")
+            .build_with_callback(move |msg| {
+                received_bg.lock().unwrap().push(msg.data.clone());
+            })
+            .unwrap();
+        while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    });
+
+    // Let the subscriber settle into the graph so hu's discovery (2s budget)
+    // finds it.
+    thread::sleep(Duration::from_millis(1500));
+
+    let out = run_hu_meter(
+        router.endpoint(),
+        &[
+            "pub",
+            "/pub_target",
+            "--msg-type",
+            "std_msgs/msg/String",
+            "--yaml",
+            "{data: hu_pub_hello}",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "hu meter pub should succeed with a live subscriber; stderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let mut got = false;
+    for _ in 0..40 {
+        if received.lock().unwrap().iter().any(|d| d == "hu_pub_hello") {
+            got = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        got,
+        "subscriber did not receive the published message; got: {:?}",
+        received.lock().unwrap()
     );
 }

--- a/crates/hiroz-tests/tests/hu_meter.rs
+++ b/crates/hiroz-tests/tests/hu_meter.rs
@@ -25,7 +25,7 @@ use hiroz_msgs::action_tutorials_interfaces::{FibonacciResult, action::Fibonacci
 use hiroz_msgs::example_interfaces::{FibonacciResult, action::Fibonacci};
 use hiroz_msgs::{
     example_interfaces::{AddTwoIntsResponse, srv::AddTwoInts},
-    std_msgs::String as RosString,
+    std_msgs::{Header, String as RosString},
 };
 
 /// Run `hu meter <args>` with a specific router endpoint.
@@ -2074,5 +2074,131 @@ fn test_hu_meter_info_service() {
     assert!(
         json["servers"].as_u64().unwrap_or(0) >= 1,
         "Expected at least 1 service server: {stdout}"
+    );
+}
+
+// ─── delay ────────────────────────────────────────────────────────────────────
+
+/// Coverage for `hu meter delay <topic>`: subscribes to a topic and echoes
+/// received messages. `delay` supports `--duration` (like hz/bw) so the command
+/// self-exits deterministically instead of relying on a blind kill.
+#[test]
+fn test_hu_meter_delay_basic() {
+    let router = TestRouter::new();
+
+    let endpoint = router.endpoint().to_string();
+    let _producer = spawn_producer(move |stop| async move {
+        let ctx = create_hiroz_context_with_endpoint(&endpoint).unwrap();
+        let node = ctx
+            .create_node("delay_pub")
+            .with_type_description_service()
+            .build()
+            .unwrap();
+        let pub_ = node.create_pub::<Header>("/delay_test").build().unwrap();
+        // Deterministic: wait until hu's subscriber is in the graph before
+        // publishing, so the burst can't race ahead of discovery.
+        let _ = pub_.wait_for_subscription(1, Duration::from_secs(20)).await;
+        for _ in 0..20 {
+            if stop.load(std::sync::atomic::Ordering::Relaxed) {
+                break;
+            }
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default();
+            let _ = pub_
+                .async_publish(&Header {
+                    stamp: hiroz_msgs::builtin_interfaces::Time {
+                        sec: now.as_secs() as i32,
+                        nanosec: now.subsec_nanos(),
+                    },
+                    frame_id: "delay_test".into(),
+                })
+                .await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    });
+
+    // Self-exit via --duration; must stay >= the publisher's burst length above
+    // so hu doesn't exit before the burst (plus its own discovery) completes.
+    let out = run_hu_meter(
+        router.endpoint(),
+        &["delay", "/delay_test", "--duration", "13"],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // `extract_delay_note` is a documented stub that reports the raw message
+    // ("(raw) {json}"); assert on what it actually emits (a message on the
+    // topic, echoed), not on measurement text no code path produces.
+    assert!(
+        stdout.contains("(raw)") && stdout.contains("delay_test"),
+        "Expected a raw echoed message from the delay subscriber, got: {}",
+        stdout
+    );
+}
+
+// ─── pub ──────────────────────────────────────────────────────────────────────
+
+/// Coverage for `hu meter pub` (publish subcommand).
+///
+/// NOTE on scope: `pub --yaml` encodes via the `encode-yaml-to-cdr` WIT host
+/// function, which resolves the message schema from the global `SchemaRegistry`.
+/// Nothing populates that registry at runtime yet — schemas come only from
+/// compile-time Rust types or live discovery, and `encode-yaml-to-cdr` (unlike
+/// service `call`) is not rerouted through discovery — so every msg-type fails
+/// schema lookup. This is not a bug in `pub`; the happy encode-and-receive path
+/// needs a runtime `.msg` schema loader that does not exist yet.
+///
+/// This test therefore exercises the maximal CI-safe surface: arg parsing, the
+/// one-shot dispatch, the `encode-yaml-to-cdr` host-call boundary, and the
+/// error-rendering/exit paths — catching regressions that break argument
+/// handling, panic the plugin, or hang the command.
+#[test]
+#[serial_test::serial]
+fn test_hu_meter_pub_arg_and_encode_paths() {
+    let router = TestRouter::new();
+
+    // (a) Missing --msg-type: `pub` must reject with a clear error and a
+    //     non-zero exit, not silently no-op or crash.
+    let out = run_hu_meter(router.endpoint(), &["pub", "/pub_no_type_topic"]);
+    assert!(
+        !out.status.success(),
+        "hu meter pub without --msg-type should exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("msg-type"),
+        "Expected a --msg-type-required error, got stderr: {stderr}\nstdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    // (b) With --msg-type + --yaml but no schema in the registry: the
+    //     encode-yaml-to-cdr host call must surface a clean encode error and
+    //     exit non-zero — again, no panic/hang.
+    let out = run_hu_meter(
+        router.endpoint(),
+        &[
+            "pub",
+            "/pub_string_topic",
+            "--msg-type",
+            "std_msgs/msg/String",
+            "--yaml",
+            "{data: hello}",
+        ],
+    );
+    assert!(
+        !out.status.success(),
+        "hu meter pub with an unresolvable schema should exit non-zero"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("encode error") || combined.contains("not found"),
+        "Expected a schema-not-found encode error from `pub`, got: {combined}"
     );
 }

--- a/crates/hiroz-union/Cargo.toml
+++ b/crates/hiroz-union/Cargo.toml
@@ -11,7 +11,7 @@ name = "hu"
 path = "src/main.rs"
 
 [dependencies]
-hiroz = { path = "../hiroz" }
+hiroz = { path = "../hiroz", features = ["dynamic-schema-loader"] }
 hiroz-msgs = { path = "../hiroz-msgs" }
 hiroz-protocol = { path = "../hiroz-protocol" }
 clap = { workspace = true }

--- a/crates/hiroz-union/plugins/hu-meter/src/lib.rs
+++ b/crates/hiroz-union/plugins/hu-meter/src/lib.rs
@@ -346,15 +346,17 @@ impl HuMeter {
         let cdr = match ros::encode_yaml_to_cdr(&topic, &yaml, &msg_type) {
             Ok(b) => b,
             Err(e) => {
-                // The host resolves the schema by discovering a live node on the
-                // topic; not-found means no publisher/subscriber announced a type
-                // there, so a bare topic with no consumer can't be published to.
+                // The host resolves the schema from `.msg` files on disk first,
+                // then falls back to discovering a live node on the topic.
+                // Not-found means neither worked: the `.msg` isn't on
+                // HIROZ_MSG_PATH and no publisher/subscriber announced the type.
                 if matches!(e, hu::plugin::types::PluginError::NotFound) {
                     render::eprintln(&format!(
-                        "encode error: could not resolve a message schema for {topic}. \
-                         hu meter pub discovers the type from a live publisher or subscriber \
-                         on the topic — none was found (a topic with no announced type cannot \
-                         be published to)."
+                        "encode error: could not resolve a message schema for {msg_type} on \
+                         {topic}. hu meter pub loads the type from a `.msg` on HIROZ_MSG_PATH, \
+                         or discovers it from a live publisher/subscriber on the topic — neither \
+                         was found. Check the type name, set HIROZ_MSG_PATH, or start a node on \
+                         the topic."
                     ));
                 } else {
                     render::eprintln(&format!("encode error: {e}"));

--- a/crates/hiroz-union/plugins/hu-meter/src/lib.rs
+++ b/crates/hiroz-union/plugins/hu-meter/src/lib.rs
@@ -4,6 +4,7 @@ wit_bindgen::generate!({
 });
 
 
+use hu::plugin::session::RawPublisher;
 use hu::plugin::types::{EventKind, Permission};
 use hu::plugin::{graph, render, ros};
 
@@ -45,6 +46,20 @@ enum Mode {
         count: usize,
         printed: usize,
     },
+    /// Delay measurement (header stamp vs receive time) — requires JSON with header.stamp
+    Delay {
+        topic: String,
+        sub: Option<ros::Subscription>,
+    },
+    /// Repeated publish with rate/times support
+    Pub {
+        pub_: RawPublisher,
+        cdr: Vec<u8>,
+        topic: String,
+        interval_ticks: u32,
+        times_remaining: u32,
+        ticks_since_last: u32,
+    },
     /// Subscribe to action feedback topic
     ActionEcho {
         sub: Option<ros::Subscription>,
@@ -84,6 +99,8 @@ impl HuMeter {
             render::println("  hz <topic> [--duration <s>]");
             render::println("  bw <topic> [--duration <s>]");
             render::println("  echo <topic> [--count <n>] [--field <path>]");
+            render::println("  delay <topic> [--duration <s>]");
+            render::println("  pub <topic> --msg-type <type> --yaml <yaml> [--rate <Hz>] [--times <n>]");
             render::println("  list topics|nodes|services [--find <type>]");
             render::println("  info topic|node|service <name>");
             render::println("  service list|find|type|call <name> [--yaml <yaml>|--payload <hex>]");
@@ -98,6 +115,11 @@ impl HuMeter {
             "hz" => self.cmd_hz(&args[1..]),
             "bw" => self.cmd_bw(&args[1..]),
             "echo" => self.cmd_echo(&args[1..]),
+            "delay" => self.cmd_delay(&args[1..]),
+            "pub" => {
+                self.cmd_pub(&args[1..]);
+                // cmd_pub sets mode itself (Done for one-shot, or Pub for repeated).
+            }
             "list" => {
                 self.cmd_list(&args[1..]);
                 self.mode = Mode::Done;
@@ -254,6 +276,128 @@ impl HuMeter {
             printed: 0,
             field,
         };
+    }
+
+    fn cmd_delay(&mut self, args: &[String]) {
+        let Some(topic) = args.first().cloned() else {
+            render::println("Usage: hu meter delay <topic> [--duration <s>]");
+            render::exit(1);
+            self.mode = Mode::Done;
+            return;
+        };
+        // Optional self-exit, same as hz/bw/echo: with no --duration this stays
+        // 0 (never done), matching the always-running behavior.
+        self.duration_ticks = flag_value(args, "--duration")
+            .and_then(|v| v.parse::<f64>().ok())
+            .map(|s| s.ceil().max(1.0) as u32)
+            .unwrap_or(0);
+        let sub = match ros::subscribe(&topic) {
+            Ok(s) => s,
+            Err(e) => {
+                render::eprintln(&format!("Failed to subscribe to {topic}: {e}"));
+                render::exit(1);
+                self.mode = Mode::Done;
+                return;
+            }
+        };
+        self.mode = Mode::Delay {
+            topic,
+            sub: Some(sub),
+        };
+    }
+
+    fn cmd_pub(&mut self, args: &[String]) {
+        let Some(topic) = args.first().cloned() else {
+            render::println(
+                "Usage: hu meter pub <topic> --msg-type <type> --yaml <yaml> [--rate <Hz>] [--times <n>]",
+            );
+            render::exit(1);
+            self.mode = Mode::Done;
+            return;
+        };
+        let msg_type = flag_value(args, "--msg-type").unwrap_or_default();
+        let yaml = flag_value(args, "--yaml").unwrap_or_else(|| "{}".to_string());
+        let rate: f64 = flag_value(args, "--rate")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0.0);
+        let times: u32 = flag_value(args, "--times")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1);
+
+        if msg_type.is_empty() {
+            render::eprintln("--msg-type is required");
+            render::exit(1);
+            self.mode = Mode::Done;
+            return;
+        }
+
+        let cdr = match ros::encode_yaml_to_cdr(&yaml, &msg_type) {
+            Ok(b) => b,
+            Err(e) => {
+                render::println(&format!("encode error: {e}"));
+                render::exit(1);
+                self.mode = Mode::Done;
+                return;
+            }
+        };
+
+        let sess = match hu::plugin::session::get_session("default") {
+            Ok(s) => s,
+            Err(e) => {
+                render::eprintln(&format!("failed to get default session: {e}"));
+                render::exit(1);
+                self.mode = Mode::Done;
+                return;
+            }
+        };
+        let pub_ = match sess.raw_publisher(&topic) {
+            Ok(p) => p,
+            Err(e) => {
+                render::eprintln(&format!("failed to declare publisher on {topic}: {e}"));
+                render::exit(1);
+                self.mode = Mode::Done;
+                return;
+            }
+        };
+
+        // With --rate or --times>1, publish repeatedly via ticks; otherwise one-shot.
+        if rate > 0.0 || times > 1 {
+            // tick_ms = 1000 ms; interval_ticks = max(1, round(1.0 / rate)) when rate > 0.
+            let interval_ticks = if rate > 0.0 {
+                let t = (1.0 / rate).round() as u32;
+                if t == 0 {
+                    1
+                } else {
+                    t
+                }
+            } else {
+                0 // no rate limit: publish each tick up to times_remaining
+            };
+            self.mode = Mode::Pub {
+                pub_,
+                cdr,
+                topic,
+                interval_ticks,
+                times_remaining: times,
+                ticks_since_last: interval_ticks, // ready to publish on the first tick
+            };
+        } else {
+            let cdr_len = cdr.len();
+            if let Err(e) = pub_.publish(&cdr) {
+                render::println(&format!("publish error: {e}"));
+                render::exit(1);
+            } else {
+                if self.json {
+                    render::println(&format!(
+                        "{{\"published\":1,\"bytes\":{cdr_len},\"topic\":\"{topic}\"}}"
+                    ));
+                } else {
+                    render::println(&format!("Published to {topic}"));
+                }
+                render::exit(0);
+            }
+            self.mode = Mode::Done;
+        }
     }
 
     fn cmd_list(&self, args: &[String]) {
@@ -1161,6 +1305,51 @@ impl HuMeter {
                     self.mode = Mode::Done;
                 }
             }
+            Mode::Delay { topic, sub } => {
+                let Some(s) = sub.as_ref() else {
+                    return;
+                };
+                while let Some(json_msg) = s.try_recv() {
+                    let delay_note = extract_delay_note(&json_msg);
+                    let t = topic.clone();
+                    render::println(&format!("[{t}] {delay_note}"));
+                }
+                if done {
+                    render::exit(0);
+                    self.mode = Mode::Done;
+                }
+            }
+            Mode::Pub {
+                pub_,
+                cdr,
+                topic,
+                interval_ticks,
+                times_remaining,
+                ticks_since_last,
+            } => {
+                *ticks_since_last += 1;
+                let ready = if *interval_ticks == 0 {
+                    true // no rate limit: publish each tick
+                } else {
+                    *ticks_since_last >= *interval_ticks
+                };
+                if ready && *times_remaining > 0 {
+                    *ticks_since_last = 0;
+                    if let Err(e) = pub_.publish(cdr) {
+                        render::println(&format!("publish error: {e}"));
+                        render::exit(1);
+                        self.mode = Mode::Done;
+                        return;
+                    }
+                    let t = topic.clone();
+                    render::println(&format!("Published to {t}"));
+                    *times_remaining -= 1;
+                    if *times_remaining == 0 {
+                        render::exit(0);
+                        self.mode = Mode::Done;
+                    }
+                }
+            }
             Mode::ActionEcho {
                 sub,
                 count,
@@ -1201,6 +1390,13 @@ fn flag_value(args: &[String], flag: &str) -> Option<String> {
         }
     }
     None
+}
+
+// Best-effort note for `hu meter delay`. A full implementation would parse the
+// decoded-JSON message and compute (receive-time − header.stamp); for now it
+// surfaces the raw message so the receive path is observable.
+fn extract_delay_note(json: &str) -> String {
+    format!("(raw) {json}")
 }
 
 fn parse_topic_duration(args: &[String]) -> (Option<String>, u32) {

--- a/crates/hiroz-union/plugins/hu-meter/src/lib.rs
+++ b/crates/hiroz-union/plugins/hu-meter/src/lib.rs
@@ -343,18 +343,18 @@ impl HuMeter {
             return;
         }
 
-        let cdr = match ros::encode_yaml_to_cdr(&yaml, &msg_type) {
+        let cdr = match ros::encode_yaml_to_cdr(&topic, &yaml, &msg_type) {
             Ok(b) => b,
             Err(e) => {
-                // encode-yaml-to-cdr resolves the schema from the host's runtime
-                // SchemaRegistry, which is not populated yet, so a not-found here
-                // is expected for every type — surface that clearly rather than a
-                // bare "not found". (Known limitation; a fix needs a WIT change.)
+                // The host resolves the schema by discovering a live node on the
+                // topic; not-found means no publisher/subscriber announced a type
+                // there, so a bare topic with no consumer can't be published to.
                 if matches!(e, hu::plugin::types::PluginError::NotFound) {
                     render::eprintln(&format!(
-                        "encode error: no schema for '{msg_type}' is available to the plugin host. \
-                         hu meter pub's --yaml encoding requires the message type in the host's \
-                         runtime schema registry, which is not yet populated — a known limitation."
+                        "encode error: could not resolve a message schema for {topic}. \
+                         hu meter pub discovers the type from a live publisher or subscriber \
+                         on the topic — none was found (a topic with no announced type cannot \
+                         be published to)."
                     ));
                 } else {
                     render::eprintln(&format!("encode error: {e}"));

--- a/crates/hiroz-union/plugins/hu-meter/src/lib.rs
+++ b/crates/hiroz-union/plugins/hu-meter/src/lib.rs
@@ -4,7 +4,7 @@ wit_bindgen::generate!({
 });
 
 
-use hu::plugin::session::RawPublisher;
+use hu::plugin::raw_transport::RawPublisher;
 use hu::plugin::types::{EventKind, Permission};
 use hu::plugin::{graph, render, ros};
 
@@ -279,18 +279,16 @@ impl HuMeter {
     }
 
     fn cmd_delay(&mut self, args: &[String]) {
-        let Some(topic) = args.first().cloned() else {
+        // Same topic + optional --duration parsing as hz/bw: with no --duration
+        // this stays 0 (never self-exits), matching the always-running behavior.
+        let (topic, duration_ticks) = parse_topic_duration(args);
+        let Some(topic) = topic else {
             render::println("Usage: hu meter delay <topic> [--duration <s>]");
             render::exit(1);
             self.mode = Mode::Done;
             return;
         };
-        // Optional self-exit, same as hz/bw/echo: with no --duration this stays
-        // 0 (never done), matching the always-running behavior.
-        self.duration_ticks = flag_value(args, "--duration")
-            .and_then(|v| v.parse::<f64>().ok())
-            .map(|s| s.ceil().max(1.0) as u32)
-            .unwrap_or(0);
+        self.duration_ticks = duration_ticks;
         let sub = match ros::subscribe(&topic) {
             Ok(s) => s,
             Err(e) => {
@@ -341,6 +339,23 @@ impl HuMeter {
             }
         };
 
+        // Resolve the ROS topic name to its full RmwZenoh key expression before
+        // publishing raw CDR — raw_publisher uses the string verbatim, so a bare
+        // "/topic" would go out on a key no ROS subscriber matches (and the
+        // leading '/' is an invalid zenoh key expression). Same pattern as the
+        // `echo --raw` path.
+        let ke = match ros::resolve_topic_ke(&topic) {
+            Ok(ke) => ke,
+            Err(e) => {
+                render::eprintln(&format!(
+                    "Failed to resolve key expression for {topic}: {e}"
+                ));
+                render::exit(1);
+                self.mode = Mode::Done;
+                return;
+            }
+        };
+
         let sess = match hu::plugin::session::get_session("default") {
             Ok(s) => s,
             Err(e) => {
@@ -350,7 +365,7 @@ impl HuMeter {
                 return;
             }
         };
-        let pub_ = match sess.raw_publisher(&topic) {
+        let pub_ = match sess.raw_publisher(&ke) {
             Ok(p) => p,
             Err(e) => {
                 render::eprintln(&format!("failed to declare publisher on {topic}: {e}"));
@@ -1069,7 +1084,7 @@ impl HuMeter {
                 let send_goal_svc = format!("{name}/_action/send_goal");
                 let Some(svc) = graph::list_services()
                     .into_iter()
-                    .find(|s| &s.name == &send_goal_svc)
+                    .find(|s| s.name == send_goal_svc)
                 else {
                     render::eprintln(&format!("action not found: {name}"));
                     render::exit(1);
@@ -1342,7 +1357,14 @@ impl HuMeter {
                         return;
                     }
                     let t = topic.clone();
-                    render::println(&format!("Published to {t}"));
+                    if self.json {
+                        render::println(&format!(
+                            "{{\"published\":1,\"bytes\":{},\"topic\":\"{t}\"}}",
+                            cdr.len()
+                        ));
+                    } else {
+                        render::println(&format!("Published to {t}"));
+                    }
                     *times_remaining -= 1;
                     if *times_remaining == 0 {
                         render::exit(0);

--- a/crates/hiroz-union/plugins/hu-meter/src/lib.rs
+++ b/crates/hiroz-union/plugins/hu-meter/src/lib.rs
@@ -51,13 +51,14 @@ enum Mode {
         topic: String,
         sub: Option<ros::Subscription>,
     },
-    /// Repeated publish with rate/times support
+    /// Repeated publish with rate/times support. `times_remaining: None` = run
+    /// unbounded (until the process is stopped); `Some(n)` = n publishes left.
     Pub {
         pub_: RawPublisher,
         cdr: Vec<u8>,
         topic: String,
         interval_ticks: u32,
-        times_remaining: u32,
+        times_remaining: Option<u32>,
         ticks_since_last: u32,
     },
     /// Subscribe to action feedback topic
@@ -318,9 +319,22 @@ impl HuMeter {
         let rate: f64 = flag_value(args, "--rate")
             .and_then(|v| v.parse().ok())
             .unwrap_or(0.0);
-        let times: u32 = flag_value(args, "--times")
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(1);
+        // --times, when given, must be a positive integer. `None` means it was
+        // omitted (distinct from a value): with a rate that means "unbounded",
+        // without one it means a single publish. A literal 0 (which would enter
+        // a mode that never publishes and never exits) is rejected.
+        let times: Option<u32> = match flag_value(args, "--times") {
+            None => None,
+            Some(v) => match v.parse::<u32>() {
+                Ok(n) if n >= 1 => Some(n),
+                _ => {
+                    render::eprintln("--times must be a positive integer");
+                    render::exit(1);
+                    self.mode = Mode::Done;
+                    return;
+                }
+            },
+        };
 
         if msg_type.is_empty() {
             render::eprintln("--msg-type is required");
@@ -332,7 +346,19 @@ impl HuMeter {
         let cdr = match ros::encode_yaml_to_cdr(&yaml, &msg_type) {
             Ok(b) => b,
             Err(e) => {
-                render::println(&format!("encode error: {e}"));
+                // encode-yaml-to-cdr resolves the schema from the host's runtime
+                // SchemaRegistry, which is not populated yet, so a not-found here
+                // is expected for every type — surface that clearly rather than a
+                // bare "not found". (Known limitation; a fix needs a WIT change.)
+                if matches!(e, hu::plugin::types::PluginError::NotFound) {
+                    render::eprintln(&format!(
+                        "encode error: no schema for '{msg_type}' is available to the plugin host. \
+                         hu meter pub's --yaml encoding requires the message type in the host's \
+                         runtime schema registry, which is not yet populated — a known limitation."
+                    ));
+                } else {
+                    render::eprintln(&format!("encode error: {e}"));
+                }
                 render::exit(1);
                 self.mode = Mode::Done;
                 return;
@@ -375,9 +401,27 @@ impl HuMeter {
             }
         };
 
-        // With --rate or --times>1, publish repeatedly via ticks; otherwise one-shot.
-        if rate > 0.0 || times > 1 {
-            // tick_ms = 1000 ms; interval_ticks = max(1, round(1.0 / rate)) when rate > 0.
+        // Effective publish count: an explicit --times wins; otherwise --rate
+        // alone means "publish continuously until stopped" (unbounded, `None`),
+        // and a plain `pub` with neither flag is a single one-shot publish.
+        let count: Option<u32> = match times {
+            Some(n) => Some(n),
+            None if rate > 0.0 => None, // --rate alone → unbounded
+            None => Some(1),            // plain pub → one-shot
+        };
+
+        // One-shot only when exactly one publish is requested and no rate is
+        // set; anything else (a rate, a count > 1, or unbounded) is tick-driven.
+        let one_shot = rate <= 0.0 && matches!(count, Some(1));
+        if !one_shot {
+            // The plugin tick is 1000 ms, so the scheduler cannot publish faster
+            // than 1 Hz — warn rather than silently capping a higher --rate.
+            if rate > 1.0 {
+                render::eprintln(&format!(
+                    "note: --rate {rate} Hz exceeds the 1 Hz plugin tick resolution; publishing at 1 Hz"
+                ));
+            }
+            // interval_ticks = round(1/rate) clamped to >= 1 (0 = every tick).
             let interval_ticks = if rate > 0.0 {
                 let t = (1.0 / rate).round() as u32;
                 if t == 0 {
@@ -386,14 +430,14 @@ impl HuMeter {
                     t
                 }
             } else {
-                0 // no rate limit: publish each tick up to times_remaining
+                0 // no rate limit: publish each tick up to the count
             };
             self.mode = Mode::Pub {
                 pub_,
                 cdr,
                 topic,
                 interval_ticks,
-                times_remaining: times,
+                times_remaining: count, // None = unbounded
                 ticks_since_last: interval_ticks, // ready to publish on the first tick
             };
         } else {
@@ -1348,7 +1392,9 @@ impl HuMeter {
                 } else {
                     *ticks_since_last >= *interval_ticks
                 };
-                if ready && *times_remaining > 0 {
+                // `None` = unbounded (always has more to send); `Some(n)` = n left.
+                let has_remaining = !matches!(times_remaining, Some(0));
+                if ready && has_remaining {
                     *ticks_since_last = 0;
                     if let Err(e) = pub_.publish(cdr) {
                         render::println(&format!("publish error: {e}"));
@@ -1365,10 +1411,13 @@ impl HuMeter {
                     } else {
                         render::println(&format!("Published to {t}"));
                     }
-                    *times_remaining -= 1;
-                    if *times_remaining == 0 {
-                        render::exit(0);
-                        self.mode = Mode::Done;
+                    // Only a bounded count decrements and exits; unbounded runs on.
+                    if let Some(n) = times_remaining.as_mut() {
+                        *n -= 1;
+                        if *n == 0 {
+                            render::exit(0);
+                            self.mode = Mode::Done;
+                        }
                     }
                 }
             }
@@ -1414,11 +1463,36 @@ fn flag_value(args: &[String], flag: &str) -> Option<String> {
     None
 }
 
-// Best-effort note for `hu meter delay`. A full implementation would parse the
-// decoded-JSON message and compute (receive-time − header.stamp); for now it
-// surfaces the raw message so the receive path is observable.
+// End-to-end delay for `hu meter delay`: (receive wall-clock time − the
+// message's `header.stamp`). The host wires full WASI p2, so the plugin's
+// `SystemTime::now()` resolves against `wasi:clocks`. Assumes the publisher and
+// this receiver share a clock (as ros2 `topic delay` does); a message without a
+// stamped header cannot be measured and says so.
 fn extract_delay_note(json: &str) -> String {
-    format!("(raw) {json}")
+    let Some((stamp_sec, stamp_nanosec)) = parse_header_stamp(json) else {
+        return "no header.stamp — cannot measure delay (message has no stamped header)"
+            .to_string();
+    };
+    let Ok(now) = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) else {
+        return "delay: clock unavailable".to_string();
+    };
+    let stamp_ns = stamp_sec as i128 * 1_000_000_000 + stamp_nanosec as i128;
+    let delay_ms = (now.as_nanos() as i128 - stamp_ns) as f64 / 1_000_000.0;
+    format!("delay: {delay_ms:.3} ms")
+}
+
+// Pull `header.stamp.{sec,nanosec}` from a decoded-JSON ROS message — either a
+// nested `header` field (most stamped messages) or a top-level `stamp` (a bare
+// std_msgs/Header). Returns None if absent or malformed.
+fn parse_header_stamp(json: &str) -> Option<(i64, u64)> {
+    let v: serde_json::Value = serde_json::from_str(json).ok()?;
+    let stamp = v
+        .get("header")
+        .and_then(|h| h.get("stamp"))
+        .or_else(|| v.get("stamp"))?;
+    let sec = stamp.get("sec")?.as_i64()?;
+    let nanosec = stamp.get("nanosec")?.as_u64()?;
+    Some((sec, nanosec))
 }
 
 fn parse_topic_duration(args: &[String]) -> (Option<String>, u32) {

--- a/crates/hiroz-union/plugins/hu-meter/wit/hu-plugin.wit
+++ b/crates/hiroz-union/plugins/hu-meter/wit/hu-plugin.wit
@@ -189,10 +189,11 @@ interface ros {
     measure-hz: func(topic: string, window-ms: u32) -> result<hz-measurement, plugin-error>;
     measure-bw: func(topic: string, window-ms: u32) -> result<bw-measurement, plugin-error>;
 
-    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved by live
-    // discovery from a node already on the topic, so a publisher/subscriber must
-    // be present; `type-name` is the caller's intended type and a mismatch with
-    // the discovered wire type is an error.
+    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved from a
+    // `.msg` on HIROZ_MSG_PATH, or, failing that, by live discovery from a node
+    // already on the topic — so publishing to an empty topic works, like
+    // `ros2 topic pub`. `type-name` is the caller's intended type; if the topic
+    // already carries a different wire type, that is an error.
     encode-yaml-to-cdr: func(topic: string, yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
 }
 

--- a/crates/hiroz-union/plugins/hu-meter/wit/hu-plugin.wit
+++ b/crates/hiroz-union/plugins/hu-meter/wit/hu-plugin.wit
@@ -189,7 +189,11 @@ interface ros {
     measure-hz: func(topic: string, window-ms: u32) -> result<hz-measurement, plugin-error>;
     measure-bw: func(topic: string, window-ms: u32) -> result<bw-measurement, plugin-error>;
 
-    encode-yaml-to-cdr: func(yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
+    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved by live
+    // discovery from a node already on the topic, so a publisher/subscriber must
+    // be present; `type-name` is the caller's intended type and a mismatch with
+    // the discovered wire type is an error.
+    encode-yaml-to-cdr: func(topic: string, yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
 }
 
 interface raw-transport {

--- a/crates/hiroz-union/plugins/hu-monitor/src/lib.rs
+++ b/crates/hiroz-union/plugins/hu-monitor/src/lib.rs
@@ -217,19 +217,17 @@ impl HuMonitor {
                 *prev_services = cur_services;
             }
             Mode::Log {
-                sub,
+                sub: Some(s),
                 count,
                 printed,
             } => {
-                if let Some(s) = sub {
-                    while let Some(msg) = s.try_recv() {
-                        render::println(&msg);
-                        *printed += 1;
-                        if *count > 0 && *printed >= *count {
-                            render::exit(0);
-                            self.mode = Mode::Done;
-                            return;
-                        }
+                while let Some(msg) = s.try_recv() {
+                    render::println(&msg);
+                    *printed += 1;
+                    if *count > 0 && *printed >= *count {
+                        render::exit(0);
+                        self.mode = Mode::Done;
+                        return;
                     }
                 }
             }

--- a/crates/hiroz-union/plugins/hu-monitor/wit/hu-plugin.wit
+++ b/crates/hiroz-union/plugins/hu-monitor/wit/hu-plugin.wit
@@ -189,10 +189,11 @@ interface ros {
     measure-hz: func(topic: string, window-ms: u32) -> result<hz-measurement, plugin-error>;
     measure-bw: func(topic: string, window-ms: u32) -> result<bw-measurement, plugin-error>;
 
-    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved by live
-    // discovery from a node already on the topic, so a publisher/subscriber must
-    // be present; `type-name` is the caller's intended type and a mismatch with
-    // the discovered wire type is an error.
+    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved from a
+    // `.msg` on HIROZ_MSG_PATH, or, failing that, by live discovery from a node
+    // already on the topic — so publishing to an empty topic works, like
+    // `ros2 topic pub`. `type-name` is the caller's intended type; if the topic
+    // already carries a different wire type, that is an error.
     encode-yaml-to-cdr: func(topic: string, yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
 }
 

--- a/crates/hiroz-union/plugins/hu-monitor/wit/hu-plugin.wit
+++ b/crates/hiroz-union/plugins/hu-monitor/wit/hu-plugin.wit
@@ -189,7 +189,11 @@ interface ros {
     measure-hz: func(topic: string, window-ms: u32) -> result<hz-measurement, plugin-error>;
     measure-bw: func(topic: string, window-ms: u32) -> result<bw-measurement, plugin-error>;
 
-    encode-yaml-to-cdr: func(yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
+    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved by live
+    // discovery from a node already on the topic, so a publisher/subscriber must
+    // be present; `type-name` is the caller's intended type and a mismatch with
+    // the discovered wire type is an error.
+    encode-yaml-to-cdr: func(topic: string, yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
 }
 
 interface raw-transport {

--- a/crates/hiroz-union/plugins/hu-plugin-template/wit/hu-plugin.wit
+++ b/crates/hiroz-union/plugins/hu-plugin-template/wit/hu-plugin.wit
@@ -189,10 +189,11 @@ interface ros {
     measure-hz: func(topic: string, window-ms: u32) -> result<hz-measurement, plugin-error>;
     measure-bw: func(topic: string, window-ms: u32) -> result<bw-measurement, plugin-error>;
 
-    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved by live
-    // discovery from a node already on the topic, so a publisher/subscriber must
-    // be present; `type-name` is the caller's intended type and a mismatch with
-    // the discovered wire type is an error.
+    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved from a
+    // `.msg` on HIROZ_MSG_PATH, or, failing that, by live discovery from a node
+    // already on the topic — so publishing to an empty topic works, like
+    // `ros2 topic pub`. `type-name` is the caller's intended type; if the topic
+    // already carries a different wire type, that is an error.
     encode-yaml-to-cdr: func(topic: string, yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
 }
 

--- a/crates/hiroz-union/plugins/hu-plugin-template/wit/hu-plugin.wit
+++ b/crates/hiroz-union/plugins/hu-plugin-template/wit/hu-plugin.wit
@@ -189,7 +189,11 @@ interface ros {
     measure-hz: func(topic: string, window-ms: u32) -> result<hz-measurement, plugin-error>;
     measure-bw: func(topic: string, window-ms: u32) -> result<bw-measurement, plugin-error>;
 
-    encode-yaml-to-cdr: func(yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
+    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved by live
+    // discovery from a node already on the topic, so a publisher/subscriber must
+    // be present; `type-name` is the caller's intended type and a mismatch with
+    // the discovered wire type is an error.
+    encode-yaml-to-cdr: func(topic: string, yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
 }
 
 interface raw-transport {

--- a/crates/hiroz-union/src/plugin/wasm/host/ros.rs
+++ b/crates/hiroz-union/src/plugin/wasm/host/ros.rs
@@ -16,24 +16,35 @@ use super::super::state::{PluginState, ServiceClientData, SubscriptionData};
 use super::hu;
 use hu::plugin::types::PluginError;
 
-impl hu::plugin::ros::Host for PluginState {
-    fn resolve_topic_ke(&mut self, topic: String) -> Result<String, PluginError> {
-        use hiroz_protocol::{EndpointKind, Entity, KeyExprFormatter, RmwZenohFormatter};
-        let domain_id = self.engine.domain_id;
-        let topic_stripped = topic.trim_start_matches('/').to_string();
-
-        let type_info = [EndpointKind::Publisher, EndpointKind::Subscription]
+impl PluginState {
+    /// The message type advertised by a live publisher or subscriber on `topic`,
+    /// if any. Used both to build the concrete publish key (`resolve_topic_ke`)
+    /// and to reject a disk-resolved type that conflicts with what the topic
+    /// actually carries (`encode_yaml_to_cdr`).
+    fn live_topic_type_info(&self, topic: &str) -> Option<hiroz_protocol::TypeInfo> {
+        use hiroz_protocol::{EndpointKind, Entity};
+        [EndpointKind::Publisher, EndpointKind::Subscription]
             .into_iter()
             .find_map(|kind| {
                 self.engine
                     .graph
-                    .get_entities_by_topic(kind, &topic)
+                    .get_entities_by_topic(kind, topic)
                     .first()
                     .and_then(|ent| match ent.as_ref() {
                         Entity::Endpoint(ep) => ep.type_info.clone(),
                         _ => None,
                     })
-            });
+            })
+    }
+}
+
+impl hu::plugin::ros::Host for PluginState {
+    fn resolve_topic_ke(&mut self, topic: String) -> Result<String, PluginError> {
+        use hiroz_protocol::{KeyExprFormatter, RmwZenohFormatter};
+        let domain_id = self.engine.domain_id;
+        let topic_stripped = topic.trim_start_matches('/').to_string();
+
+        let type_info = self.live_topic_type_info(&topic);
 
         Ok(match type_info {
             Some(ti) => {
@@ -145,8 +156,9 @@ impl hu::plugin::ros::Host for PluginState {
     // (via HIROZ_MSG_PATH) so publishing works even on a topic with no live node,
     // like `ros2 topic pub`. When the type isn't on disk, fall back to live
     // discovery from a node already on the topic (same approach as
-    // HostServiceClient::call); there `type_name` is the intended type and a
-    // mismatch with the discovered wire type is reported rather than re-typed.
+    // HostServiceClient::call). Either way, if the topic already carries a
+    // different wire type, that mismatch is reported rather than published with
+    // the wrong type.
     fn encode_yaml_to_cdr(
         &mut self,
         topic: String,
@@ -156,7 +168,23 @@ impl hu::plugin::ros::Host for PluginState {
         self.require_perm(hu::plugin::types::Permission::PublishTopic)?;
 
         let schema = match hiroz::dynamic::load_schema(&type_name) {
-            Some(schema) => schema,
+            Some(schema) => {
+                // The publish key is built by `resolve_topic_ke` from a live
+                // endpoint's type. If the topic already carries a *different*
+                // type, encoding the requested type here would put incompatible
+                // bytes onto that endpoint's key — reject instead (same guard as
+                // the discovery branch below). An empty topic has no live type,
+                // so publishing to it still works, like `ros2 topic pub`.
+                if let Some(live) = self.live_topic_type_info(&topic)
+                    && live.name != type_name
+                {
+                    return Err(PluginError::Invalid(format!(
+                        "topic {topic} carries {}, not the requested {type_name}",
+                        live.name
+                    )));
+                }
+                schema
+            }
             None => {
                 let node = self.engine.node.clone();
                 // Budget discovery independently; a slow/failed round-trip

--- a/crates/hiroz-union/src/plugin/wasm/host/ros.rs
+++ b/crates/hiroz-union/src/plugin/wasm/host/ros.rs
@@ -141,13 +141,12 @@ impl hu::plugin::ros::Host for PluginState {
         Ok(Resource::new_own(rep))
     }
 
-    // Resolve the message schema by live discovery from a node already on
-    // `topic` (the SchemaRegistry is not populated on the plugin-host path), the
-    // same approach as HostServiceClient::call. `type_name` is the caller's
-    // intended type; the authoritative schema is whatever is actually on the
-    // wire, and a mismatch is reported rather than silently re-typed. Requires a
-    // live publisher/subscriber on the topic — publishing to a topic no one has
-    // announced cannot be schema-resolved this way.
+    // Resolve the message schema for `type_name`, preferring `.msg` files on disk
+    // (via HIROZ_MSG_PATH) so publishing works even on a topic with no live node,
+    // like `ros2 topic pub`. When the type isn't on disk, fall back to live
+    // discovery from a node already on the topic (same approach as
+    // HostServiceClient::call); there `type_name` is the intended type and a
+    // mismatch with the discovered wire type is reported rather than re-typed.
     fn encode_yaml_to_cdr(
         &mut self,
         topic: String,
@@ -155,25 +154,32 @@ impl hu::plugin::ros::Host for PluginState {
         type_name: String,
     ) -> Result<Vec<u8>, PluginError> {
         self.require_perm(hu::plugin::types::Permission::PublishTopic)?;
-        let node = self.engine.node.clone();
-        // Budget discovery independently; a slow/failed get_type_description
-        // round-trip shouldn't look like a generic encode failure.
-        const DISCOVERY_TIMEOUT: Duration = Duration::from_millis(2000);
-        let discovered = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(
-                node.discover_topic_schema_including_subscribers(&topic, DISCOVERY_TIMEOUT),
-            )
-        })
-        .map_err(|_| PluginError::NotFound)?;
-        if discovered.schema.type_name != type_name {
-            return Err(PluginError::Invalid(format!(
-                "topic {topic} carries {}, not the requested {type_name}",
-                discovered.schema.type_name
-            )));
-        }
+
+        let schema = match hiroz::dynamic::load_schema(&type_name) {
+            Some(schema) => schema,
+            None => {
+                let node = self.engine.node.clone();
+                // Budget discovery independently; a slow/failed round-trip
+                // shouldn't look like a generic encode failure.
+                const DISCOVERY_TIMEOUT: Duration = Duration::from_millis(2000);
+                let discovered = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(
+                        node.discover_topic_schema_including_subscribers(&topic, DISCOVERY_TIMEOUT),
+                    )
+                })
+                .map_err(|_| PluginError::NotFound)?;
+                if discovered.schema.type_name != type_name {
+                    return Err(PluginError::Invalid(format!(
+                        "topic {topic} carries {}, not the requested {type_name}",
+                        discovered.schema.type_name
+                    )));
+                }
+                discovered.schema
+            }
+        };
+
         let value = parse_yaml_or_json(&yaml).map_err(PluginError::Invalid)?;
-        let msg =
-            json_to_dynamic_message(&value, &discovered.schema).map_err(PluginError::Invalid)?;
+        let msg = json_to_dynamic_message(&value, &schema).map_err(PluginError::Invalid)?;
         serialize_cdr(&msg).map_err(|e| PluginError::Invalid(e.to_string()))
     }
 

--- a/crates/hiroz-union/src/plugin/wasm/host/ros.rs
+++ b/crates/hiroz-union/src/plugin/wasm/host/ros.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use hiroz::dynamic::{
-    DynamicMessage, DynamicValue, FieldType, MessageSchema, get_schema,
+    DynamicMessage, DynamicValue, FieldType, MessageSchema,
     serialization::{deserialize_cdr, serialize_cdr},
 };
 use wasmtime::component::Resource;
@@ -141,21 +141,38 @@ impl hu::plugin::ros::Host for PluginState {
         Ok(Resource::new_own(rep))
     }
 
-    // NOTE: reads the global (structurally never-populated) SchemaRegistry
-    // rather than live discovery like HostServiceClient::call. This is a
-    // topic-pub path (`hu meter pub --msg-type/--yaml`), but the WIT signature
-    // is `(yaml, type-name)` with no topic to key a discovery query on. Fixing
-    // it properly needs a WIT change across all plugin copies — out of scope.
-    // Known, disclosed gap (see pr-readiness.md `pub_yaml_nested_twist`).
+    // Resolve the message schema by live discovery from a node already on
+    // `topic` (the SchemaRegistry is not populated on the plugin-host path), the
+    // same approach as HostServiceClient::call. `type_name` is the caller's
+    // intended type; the authoritative schema is whatever is actually on the
+    // wire, and a mismatch is reported rather than silently re-typed. Requires a
+    // live publisher/subscriber on the topic — publishing to a topic no one has
+    // announced cannot be schema-resolved this way.
     fn encode_yaml_to_cdr(
         &mut self,
+        topic: String,
         yaml: String,
         type_name: String,
     ) -> Result<Vec<u8>, PluginError> {
         self.require_perm(hu::plugin::types::Permission::PublishTopic)?;
-        let schema = get_schema(&type_name).ok_or(PluginError::NotFound)?;
+        let node = self.engine.node.clone();
+        // Budget discovery independently; a slow/failed get_type_description
+        // round-trip shouldn't look like a generic encode failure.
+        const DISCOVERY_TIMEOUT: Duration = Duration::from_millis(2000);
+        let discovered = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current()
+                .block_on(node.discover_topic_schema(&topic, DISCOVERY_TIMEOUT))
+        })
+        .map_err(|_| PluginError::NotFound)?;
+        if discovered.schema.type_name != type_name {
+            return Err(PluginError::Invalid(format!(
+                "topic {topic} carries {}, not the requested {type_name}",
+                discovered.schema.type_name
+            )));
+        }
         let value = parse_yaml_or_json(&yaml).map_err(PluginError::Invalid)?;
-        let msg = json_to_dynamic_message(&value, &schema).map_err(PluginError::Invalid)?;
+        let msg =
+            json_to_dynamic_message(&value, &discovered.schema).map_err(PluginError::Invalid)?;
         serialize_cdr(&msg).map_err(|e| PluginError::Invalid(e.to_string()))
     }
 

--- a/crates/hiroz-union/src/plugin/wasm/host/ros.rs
+++ b/crates/hiroz-union/src/plugin/wasm/host/ros.rs
@@ -160,8 +160,9 @@ impl hu::plugin::ros::Host for PluginState {
         // round-trip shouldn't look like a generic encode failure.
         const DISCOVERY_TIMEOUT: Duration = Duration::from_millis(2000);
         let discovered = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current()
-                .block_on(node.discover_topic_schema(&topic, DISCOVERY_TIMEOUT))
+            tokio::runtime::Handle::current().block_on(
+                node.discover_topic_schema_including_subscribers(&topic, DISCOVERY_TIMEOUT),
+            )
         })
         .map_err(|_| PluginError::NotFound)?;
         if discovered.schema.type_name != type_name {

--- a/crates/hiroz-union/wit/v0.1/hu-plugin.wit
+++ b/crates/hiroz-union/wit/v0.1/hu-plugin.wit
@@ -183,7 +183,11 @@ interface ros {
     measure-hz: func(topic: string, window-ms: u32) -> result<hz-measurement, plugin-error>;
     measure-bw: func(topic: string, window-ms: u32) -> result<bw-measurement, plugin-error>;
 
-    encode-yaml-to-cdr: func(yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
+    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved by live
+    // discovery from a node already on the topic, so a publisher/subscriber must
+    // be present; `type-name` is the caller's intended type and a mismatch with
+    // the discovered wire type is an error.
+    encode-yaml-to-cdr: func(topic: string, yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
 }
 
 interface raw-transport {

--- a/crates/hiroz-union/wit/v0.1/hu-plugin.wit
+++ b/crates/hiroz-union/wit/v0.1/hu-plugin.wit
@@ -183,10 +183,11 @@ interface ros {
     measure-hz: func(topic: string, window-ms: u32) -> result<hz-measurement, plugin-error>;
     measure-bw: func(topic: string, window-ms: u32) -> result<bw-measurement, plugin-error>;
 
-    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved by live
-    // discovery from a node already on the topic, so a publisher/subscriber must
-    // be present; `type-name` is the caller's intended type and a mismatch with
-    // the discovered wire type is an error.
+    // Encode a YAML/JSON body to CDR for `topic`. The schema is resolved from a
+    // `.msg` on HIROZ_MSG_PATH, or, failing that, by live discovery from a node
+    // already on the topic — so publishing to an empty topic works, like
+    // `ros2 topic pub`. `type-name` is the caller's intended type; if the topic
+    // already carries a different wire type, that is an error.
     encode-yaml-to-cdr: func(topic: string, yaml: string, type-name: string) -> result<list<u8>, plugin-error>;
 }
 

--- a/crates/hiroz/src/dynamic/discovery.rs
+++ b/crates/hiroz/src/dynamic/discovery.rs
@@ -30,7 +30,7 @@ pub(crate) struct TopicSchemaCandidate {
     pub type_hash: String,
 }
 
-pub(crate) fn collect_topic_schema_candidates_from_publishers(
+pub(crate) fn collect_topic_schema_candidates_from_endpoints(
     publishers: &[Arc<Entity>],
     qualified_topic: &str,
 ) -> Result<Vec<TopicSchemaCandidate>, DynamicError> {
@@ -71,13 +71,13 @@ pub(crate) fn collect_topic_schema_candidates_from_publishers(
 
     if saw_missing_type_info {
         return Err(DynamicError::SchemaNotFound(format!(
-            "No publishers with type information found for topic: {}",
+            "No endpoints with type information found for topic: {}",
             qualified_topic
         )));
     }
 
     Err(DynamicError::SchemaNotFound(format!(
-        "No usable publishers found for topic: {}",
+        "No usable endpoints found for topic: {}",
         qualified_topic
     )))
 }
@@ -94,7 +94,7 @@ pub(crate) fn collect_topic_schema_candidates(
         )));
     }
 
-    collect_topic_schema_candidates_from_publishers(&publishers, qualified_topic)
+    collect_topic_schema_candidates_from_endpoints(&publishers, qualified_topic)
 }
 
 pub(crate) struct SchemaDiscovery<'a> {
@@ -128,6 +128,68 @@ impl<'a> SchemaDiscovery<'a> {
         }
 
         let candidates = collect_topic_schema_candidates(graph.as_ref(), &qualified_topic)?;
+        let (schema, type_hash) = self.try_standard(&candidates[..]).await?;
+
+        Ok(DiscoveredTopicSchema {
+            qualified_topic,
+            schema,
+            type_hash,
+        })
+    }
+
+    /// Like [`discover`], but resolves the schema from a **subscriber** when no
+    /// publisher is present. `discover` requires a live publisher (which defines
+    /// the on-wire type); this variant additionally accepts a subscriber's
+    /// advertised type, so a topic that only has a consumer — the usual target
+    /// of `hu meter pub` — is still resolvable. A publisher is still preferred
+    /// when one exists.
+    ///
+    /// [`discover`]: SchemaDiscovery::discover
+    pub(crate) async fn discover_including_subscribers(
+        &self,
+        topic: &str,
+    ) -> Result<DiscoveredTopicSchema, DynamicError> {
+        let qualified_topic = qualify_topic_name(topic, self.node.namespace(), self.node.name())
+            .map_err(|error| {
+                DynamicError::SchemaNotFound(format!("Failed to qualify topic: {error}"))
+            })?;
+
+        let graph = self.node.graph();
+        // Prefer a publisher already present (it defines the wire type); else a
+        // subscriber already present; else wait for a publisher to appear, and
+        // fall back to a subscriber one last time. This keeps the common case
+        // (a consumer is already there) fast rather than always waiting the full
+        // publisher timeout.
+        let endpoints = {
+            let pubs = graph.get_entities_by_topic(EndpointKind::Publisher, &qualified_topic);
+            if !pubs.is_empty() {
+                pubs
+            } else {
+                let subs =
+                    graph.get_entities_by_topic(EndpointKind::Subscription, &qualified_topic);
+                if !subs.is_empty() {
+                    subs
+                } else if graph
+                    .wait_for_publisher(&qualified_topic, self.timeout)
+                    .await
+                {
+                    graph.get_entities_by_topic(EndpointKind::Publisher, &qualified_topic)
+                } else {
+                    let subs =
+                        graph.get_entities_by_topic(EndpointKind::Subscription, &qualified_topic);
+                    if subs.is_empty() {
+                        return Err(DynamicError::SchemaNotFound(format!(
+                            "No publishers or subscribers found for topic: {}",
+                            qualified_topic
+                        )));
+                    }
+                    subs
+                }
+            }
+        };
+
+        let candidates =
+            collect_topic_schema_candidates_from_endpoints(&endpoints, &qualified_topic)?;
         let (schema, type_hash) = self.try_standard(&candidates[..]).await?;
 
         Ok(DiscoveredTopicSchema {

--- a/crates/hiroz/src/dynamic/mod.rs
+++ b/crates/hiroz/src/dynamic/mod.rs
@@ -74,6 +74,8 @@ mod tests;
 pub use discovery::DiscoveredTopicSchema;
 pub use error::DynamicError;
 pub use message::{DynamicMessage, DynamicMessageBuilder};
+#[cfg(feature = "dynamic-schema-loader")]
+pub use registry::load_schema;
 pub use registry::{SchemaRegistry, get_schema, has_schema, register_schema};
 pub use schema::{FieldSchema, FieldType, MessageSchema, MessageSchemaBuilder};
 pub use serdes::DynamicSerdeCdrSerdes;

--- a/crates/hiroz/src/dynamic/registry.rs
+++ b/crates/hiroz/src/dynamic/registry.rs
@@ -188,3 +188,64 @@ fn convert_base_type(
 
     Ok(FieldType::Message(schema))
 }
+
+/// Load a message schema for `type_name` (`pkg/msg/Name`) from `.msg` files on
+/// disk at runtime and register it in the global registry, resolving nested
+/// message fields recursively. Unlike live discovery, this needs no node on the
+/// topic — it is what lets `hu meter pub` publish to an empty topic, like
+/// `ros2 topic pub`. `.msg` files are located via `HIROZ_MSG_PATH` (see
+/// [`find_msg_file`]). Returns the cached schema if already registered, or
+/// `None` if the type cannot be found or parsed.
+#[cfg(feature = "dynamic-schema-loader")]
+pub fn load_schema(type_name: &str) -> Option<Arc<MessageSchema>> {
+    if let Some(schema) = get_schema(type_name) {
+        return Some(schema);
+    }
+    let (package, name) = split_msg_type(type_name)?;
+    let path = find_msg_file(&package, &name)?;
+    let parsed = hiroz_codegen::parser::msg::parse_msg_file(&path, &package).ok()?;
+    // Resolve nested message-typed fields by loading them the same way; each
+    // recursive load registers itself, so the outer conversion sees them.
+    let resolver = |field_pkg: &str, field_type: &str| -> Option<Arc<MessageSchema>> {
+        load_schema(&format!("{field_pkg}/msg/{field_type}"))
+    };
+    let schema = parsed_message_to_schema(&parsed, &resolver).ok()?;
+    Some(register_schema(schema))
+}
+
+/// Split `pkg/msg/Name` (or the shorthand `pkg/Name`) into `(package, name)`.
+#[cfg(feature = "dynamic-schema-loader")]
+fn split_msg_type(type_name: &str) -> Option<(String, String)> {
+    let parts: Vec<&str> = type_name.split('/').collect();
+    match parts.as_slice() {
+        [pkg, "msg", name] => Some((pkg.to_string(), name.to_string())),
+        [pkg, name] => Some((pkg.to_string(), name.to_string())),
+        _ => None,
+    }
+}
+
+/// Find `<pkg>/msg/<Name>.msg` under `HIROZ_MSG_PATH`. Each colon-separated
+/// entry is tried both as the package directory itself
+/// (`<entry>/msg/<Name>.msg`) and as a prefix that contains packages
+/// (`<entry>/<pkg>/msg/<Name>.msg`, e.g. an ament `.../share`).
+#[cfg(feature = "dynamic-schema-loader")]
+fn find_msg_file(package: &str, name: &str) -> Option<std::path::PathBuf> {
+    let msg_path = std::env::var("HIROZ_MSG_PATH").ok()?;
+    let file = format!("{name}.msg");
+    for entry in msg_path.split(':') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let base = std::path::Path::new(entry);
+        let as_package = base.join("msg").join(&file);
+        if as_package.is_file() {
+            return Some(as_package);
+        }
+        let as_prefix = base.join(package).join("msg").join(&file);
+        if as_prefix.is_file() {
+            return Some(as_prefix);
+        }
+    }
+    None
+}

--- a/crates/hiroz/src/dynamic/registry.rs
+++ b/crates/hiroz/src/dynamic/registry.rs
@@ -198,18 +198,55 @@ fn convert_base_type(
 /// `None` if the type cannot be found or parsed.
 #[cfg(feature = "dynamic-schema-loader")]
 pub fn load_schema(type_name: &str) -> Option<Arc<MessageSchema>> {
+    let in_progress = std::cell::RefCell::new(std::collections::HashSet::new());
+    load_schema_inner(type_name, &in_progress)
+}
+
+/// Recursive worker for [`load_schema`]. `in_progress` tracks the types whose
+/// resolution is on the current stack so a self-referential or mutually
+/// recursive `.msg` (malformed — well-formed ROS messages form a DAG) bails
+/// with a warning instead of recursing until the stack overflows: a cycle would
+/// otherwise re-enter here for a type that isn't registered yet, so the
+/// `get_schema` memo never hits.
+#[cfg(feature = "dynamic-schema-loader")]
+fn load_schema_inner(
+    type_name: &str,
+    in_progress: &std::cell::RefCell<std::collections::HashSet<String>>,
+) -> Option<Arc<MessageSchema>> {
     if let Some(schema) = get_schema(type_name) {
         return Some(schema);
     }
     let (package, name) = split_msg_type(type_name)?;
+    // File not on disk is a legitimate "try the next source" (live discovery),
+    // so return None quietly. Errors *after* a file is found are logged below,
+    // since a broken `.msg` masquerading as "not found" would be misleading.
     let path = find_msg_file(&package, &name)?;
-    let parsed = hiroz_codegen::parser::msg::parse_msg_file(&path, &package).ok()?;
+    if !in_progress.borrow_mut().insert(type_name.to_string()) {
+        tracing::warn!("cyclic .msg definition for {type_name}; skipping schema load");
+        return None;
+    }
+    let parsed = match hiroz_codegen::parser::msg::parse_msg_file(&path, &package) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            tracing::warn!("failed to parse .msg file {}: {e}", path.display());
+            in_progress.borrow_mut().remove(type_name);
+            return None;
+        }
+    };
     // Resolve nested message-typed fields by loading them the same way; each
     // recursive load registers itself, so the outer conversion sees them.
     let resolver = |field_pkg: &str, field_type: &str| -> Option<Arc<MessageSchema>> {
-        load_schema(&format!("{field_pkg}/msg/{field_type}"))
+        load_schema_inner(&format!("{field_pkg}/msg/{field_type}"), in_progress)
     };
-    let schema = parsed_message_to_schema(&parsed, &resolver).ok()?;
+    let schema = match parsed_message_to_schema(&parsed, &resolver) {
+        Ok(schema) => schema,
+        Err(e) => {
+            tracing::warn!("failed to build schema for {type_name}: {e}");
+            in_progress.borrow_mut().remove(type_name);
+            return None;
+        }
+    };
+    in_progress.borrow_mut().remove(type_name);
     Some(register_schema(schema))
 }
 
@@ -225,9 +262,12 @@ fn split_msg_type(type_name: &str) -> Option<(String, String)> {
 }
 
 /// Find `<pkg>/msg/<Name>.msg` under `HIROZ_MSG_PATH`. Each colon-separated
-/// entry is tried both as the package directory itself
-/// (`<entry>/msg/<Name>.msg`) and as a prefix that contains packages
-/// (`<entry>/<pkg>/msg/<Name>.msg`, e.g. an ament `.../share`).
+/// entry is tried as a prefix that contains packages
+/// (`<entry>/<pkg>/msg/<Name>.msg`, e.g. an ament `.../share`), and — only when
+/// the entry's own basename equals `pkg` — as the package directory itself
+/// (`<entry>/msg/<Name>.msg`). The basename guard is what keeps a request for
+/// `pkg_a/msg/Status` from silently resolving to an unrelated
+/// `pkg_b/msg/Status.msg` that happens to appear earlier in the path.
 #[cfg(feature = "dynamic-schema-loader")]
 fn find_msg_file(package: &str, name: &str) -> Option<std::path::PathBuf> {
     let msg_path = std::env::var("HIROZ_MSG_PATH").ok()?;
@@ -238,13 +278,17 @@ fn find_msg_file(package: &str, name: &str) -> Option<std::path::PathBuf> {
             continue;
         }
         let base = std::path::Path::new(entry);
-        let as_package = base.join("msg").join(&file);
-        if as_package.is_file() {
-            return Some(as_package);
-        }
+        // Prefix layout: `package` is part of the path, so it can't cross packages.
         let as_prefix = base.join(package).join("msg").join(&file);
         if as_prefix.is_file() {
             return Some(as_prefix);
+        }
+        // Package-directory layout: valid only if this entry IS the package's dir.
+        if base.file_name().and_then(|n| n.to_str()) == Some(package) {
+            let as_package = base.join("msg").join(&file);
+            if as_package.is_file() {
+                return Some(as_package);
+            }
         }
     }
     None

--- a/crates/hiroz/src/dynamic/registry.rs
+++ b/crates/hiroz/src/dynamic/registry.rs
@@ -225,7 +225,7 @@ fn load_schema_inner(
         tracing::warn!("cyclic .msg definition for {type_name}; skipping schema load");
         return None;
     }
-    let parsed = match hiroz_codegen::parser::msg::parse_msg_file(&path, &package) {
+    let mut parsed = match hiroz_codegen::parser::msg::parse_msg_file(&path, &package) {
         Ok(parsed) => parsed,
         Err(e) => {
             tracing::warn!("failed to parse .msg file {}: {e}", path.display());
@@ -233,6 +233,17 @@ fn load_schema_inner(
             return None;
         }
     };
+    // A nested field written unqualified (e.g. `Vector3` in geometry_msgs/Twist)
+    // is recorded by the parser with no package but refers to the *same* package;
+    // without this, `convert_base_type` rejects it and the whole load fails. The
+    // parser already qualifies the historical `Header` alias to std_msgs, and
+    // primitives short-circuit before the package is consulted, so defaulting
+    // every remaining unqualified field to the parent package is safe.
+    for field in &mut parsed.fields {
+        if field.field_type.package.is_none() {
+            field.field_type.package = Some(package.clone());
+        }
+    }
     // Resolve nested message-typed fields by loading them the same way; each
     // recursive load registers itself, so the outer conversion sees them.
     let resolver = |field_pkg: &str, field_type: &str| -> Option<Arc<MessageSchema>> {

--- a/crates/hiroz/src/dynamic/type_description_client.rs
+++ b/crates/hiroz/src/dynamic/type_description_client.rs
@@ -7,7 +7,7 @@ use tracing::{debug, warn};
 use crate::{Builder, node::ZNode};
 
 #[cfg(test)]
-use super::discovery::collect_topic_schema_candidates_from_publishers;
+use super::discovery::collect_topic_schema_candidates_from_endpoints;
 use super::{discovery::TopicSchemaCandidate, error::DynamicError, schema::MessageSchema};
 
 use super::type_description::type_description_msg_to_schema;
@@ -199,7 +199,7 @@ mod tests {
             publisher_entity(Some("talker"), Some("std_msgs::msg::dds_::String_")),
         ];
 
-        let candidates = collect_topic_schema_candidates_from_publishers(&publishers, "/chatter")
+        let candidates = collect_topic_schema_candidates_from_endpoints(&publishers, "/chatter")
             .expect("expected type info to be discovered");
 
         assert_eq!(candidates.len(), 1);
@@ -213,7 +213,7 @@ mod tests {
     fn test_topic_discovery_reports_missing_node_identity_only_when_all_publishers_lack_it() {
         let publishers = vec![publisher_entity(None, Some("std_msgs::msg::dds_::String_"))];
 
-        let err = collect_topic_schema_candidates_from_publishers(&publishers, "/chatter")
+        let err = collect_topic_schema_candidates_from_endpoints(&publishers, "/chatter")
             .expect_err("expected missing node identity error");
 
         assert!(matches!(

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -1106,6 +1106,20 @@ impl ZNode {
             .map_err(|e| zenoh::Error::from(e.to_string()))
     }
 
+    /// Like [`discover_topic_schema`](ZNode::discover_topic_schema), but resolves
+    /// the schema from a subscriber when no publisher is present. Used by
+    /// `hu meter pub`, whose target topic usually only has a consumer.
+    pub async fn discover_topic_schema_including_subscribers(
+        &self,
+        topic: &str,
+        discovery_timeout: Duration,
+    ) -> Result<DiscoveredTopicSchema> {
+        SchemaDiscovery::new(self, discovery_timeout)
+            .discover_including_subscribers(topic)
+            .await
+            .map_err(|e| zenoh::Error::from(e.to_string()))
+    }
+
     /// Resolve a service's request and response schemas via live discovery.
     ///
     /// Service analogue of [`discover_topic_schema`](ZNode::discover_topic_schema):

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -363,6 +363,14 @@ impl ZNode {
         T: ZMessage + WithTypeInfo,
     {
         debug!("[NOD] Creating subscriber: topic={}", topic);
+        // Register the schema with this node's type-description service (mirroring
+        // create_pub) so a typed subscriber is itself a valid schema source — a
+        // consumer that answers GetTypeDescription for its subscribed type, as
+        // ROS 2 nodes do. This is what lets `hu meter pub` resolve the schema
+        // from a topic that only has a subscriber.
+        if let Some(schema) = T::message_schema() {
+            self.register_schema_with_type_description_service(&schema);
+        }
         self.create_sub_impl(topic, Some(T::type_info()))
     }
 

--- a/docs/tools/hu-vs-ros2cli.md
+++ b/docs/tools/hu-vs-ros2cli.md
@@ -12,7 +12,7 @@
 | End-to-end delay | — | — | `hu meter delay` |
 | **Introspection** | | | |
 | Echo messages | `ros2 topic echo` | — | `hu meter echo` |
-| Publish messages | `ros2 topic pub` | — | `hu meter pub` &nbsp;⚠️ |
+| Publish messages | `ros2 topic pub` | — | `hu meter pub` |
 | List topics / nodes / services / actions | four separate commands | rqt_graph | `hu meter list` |
 | Entity info | four separate commands | rqt_graph | `hu meter info` |
 | Call a service | `ros2 service call` | — | `hu meter service call <name> --yaml <yaml> --msg-type <type>` |
@@ -31,7 +31,7 @@
 | Extensible via plugins | no | yes (rqt plugins) | yes (`.wasm` plugins) |
 | Live multi-topic rate dashboard | — | rqt_topic | `hu` (interactive TUI) |
 
-⚠️ **`hu meter pub` resolves the message schema by live discovery**, so a publisher or subscriber must already be present on the target topic (the plugin host queries a live node's type description — it does not carry a compiled type registry). When a consumer is present, `--yaml` / `--msg-type` publishing works; publishing to a topic no one has announced a type on reports a clear "no announced type" error rather than guessing.
+**`hu meter pub` resolves the message schema from `.msg` files on disk**, so — like `ros2 topic pub` — it can publish to an empty topic with no node present. The plugin host reads the type from a `.msg` under `HIROZ_MSG_PATH` (colon-separated package or prefix directories, e.g. an ament `.../share`); if the type isn't on disk it falls back to discovering it from a live publisher or subscriber on the topic. Only when neither is available does it report a clear "could not resolve a message schema" error rather than guessing.
 
 ---
 

--- a/docs/tools/hu-vs-ros2cli.md
+++ b/docs/tools/hu-vs-ros2cli.md
@@ -31,7 +31,7 @@
 | Extensible via plugins | no | yes (rqt plugins) | yes (`.wasm` plugins) |
 | Live multi-topic rate dashboard | — | rqt_topic | `hu` (interactive TUI) |
 
-⚠️ **`hu meter pub` is present but its `--yaml` encoding is not yet functional.** It encodes via the plugin host's `encode-yaml-to-cdr`, which resolves the message schema from a runtime schema registry that is not populated yet, so every `--msg-type` currently fails schema lookup. The command validates arguments and reports a clear error; a working encode path needs a runtime `.msg` schema loader (tracked separately).
+⚠️ **`hu meter pub` resolves the message schema by live discovery**, so a publisher or subscriber must already be present on the target topic (the plugin host queries a live node's type description — it does not carry a compiled type registry). When a consumer is present, `--yaml` / `--msg-type` publishing works; publishing to a topic no one has announced a type on reports a clear "no announced type" error rather than guessing.
 
 ---
 

--- a/docs/tools/hu-vs-ros2cli.md
+++ b/docs/tools/hu-vs-ros2cli.md
@@ -12,7 +12,7 @@
 | End-to-end delay | — | — | `hu meter delay` |
 | **Introspection** | | | |
 | Echo messages | `ros2 topic echo` | — | `hu meter echo` |
-| Publish messages | `ros2 topic pub` | — | `hu meter pub` |
+| Publish messages | `ros2 topic pub` | — | `hu meter pub` &nbsp;⚠️ |
 | List topics / nodes / services / actions | four separate commands | rqt_graph | `hu meter list` |
 | Entity info | four separate commands | rqt_graph | `hu meter info` |
 | Call a service | `ros2 service call` | — | `hu meter service call <name> --yaml <yaml> --msg-type <type>` |
@@ -30,6 +30,8 @@
 | Works without a ROS 2 install | no | no | yes |
 | Extensible via plugins | no | yes (rqt plugins) | yes (`.wasm` plugins) |
 | Live multi-topic rate dashboard | — | rqt_topic | `hu` (interactive TUI) |
+
+⚠️ **`hu meter pub` is present but its `--yaml` encoding is not yet functional.** It encodes via the plugin host's `encode-yaml-to-cdr`, which resolves the message schema from a runtime schema registry that is not populated yet, so every `--msg-type` currently fails schema lookup. The command validates arguments and reports a clear error; a working encode path needs a runtime `.msg` schema loader (tracked separately).
 
 ---
 

--- a/scripts/ci/hu-tests.sh
+++ b/scripts/ci/hu-tests.sh
@@ -32,13 +32,12 @@ export HU_PLUGIN_PATH="${TARGET_DIR}/wasm32-wasip2/debug"
 # Tests spawn `hu` by name (Command::new("hu")) — put the built binary on PATH.
 export PATH="${TARGET_DIR}/debug:${PATH}"
 
-# `hu meter pub` resolves the message schema from `.msg` files on disk (the
-# dynamic-schema-loader), so it can publish to an empty topic without a live
-# node — exactly like `ros2 topic pub`. This job runs in `.#pureRust-ci` (no
-# ROS env / no AMENT_PREFIX_PATH), so point the loader at the bundled codegen
-# assets, which ship the standard `.msg` set in prefix layout
-# (<pkg>/msg/<Name>.msg). Absolute: `hu` is spawned with an arbitrary CWD.
-export HIROZ_MSG_PATH="$(pwd)/crates/hiroz-codegen/assets/jazzy"
+# NOTE: HIROZ_MSG_PATH is deliberately NOT set here. `hu meter pub` can resolve
+# a schema either from `.msg` files on disk (via HIROZ_MSG_PATH) or by live
+# discovery from a node on the topic. The disk path is covered by
+# `test_hu_meter_pub_empty_topic_from_disk`, which sets HIROZ_MSG_PATH itself on
+# the `hu` subprocess; leaving it unset for the rest of the suite keeps the
+# live-discovery fallback (`test_hu_meter_pub_publishes_to_live_topic`) honest.
 
 # Run single-threaded: each test spawns a router + hiroz node + `hu` subprocess
 # (JIT wasmtime), and two at once on the 2-core runner over-subscribe the cores

--- a/scripts/ci/hu-tests.sh
+++ b/scripts/ci/hu-tests.sh
@@ -32,6 +32,14 @@ export HU_PLUGIN_PATH="${TARGET_DIR}/wasm32-wasip2/debug"
 # Tests spawn `hu` by name (Command::new("hu")) — put the built binary on PATH.
 export PATH="${TARGET_DIR}/debug:${PATH}"
 
+# `hu meter pub` resolves the message schema from `.msg` files on disk (the
+# dynamic-schema-loader), so it can publish to an empty topic without a live
+# node — exactly like `ros2 topic pub`. This job runs in `.#pureRust-ci` (no
+# ROS env / no AMENT_PREFIX_PATH), so point the loader at the bundled codegen
+# assets, which ship the standard `.msg` set in prefix layout
+# (<pkg>/msg/<Name>.msg). Absolute: `hu` is spawned with an arbitrary CWD.
+export HIROZ_MSG_PATH="$(pwd)/crates/hiroz-codegen/assets/jazzy"
+
 # Run single-threaded: each test spawns a router + hiroz node + `hu` subprocess
 # (JIT wasmtime), and two at once on the 2-core runner over-subscribe the cores
 # and starve graph discovery into a timeout. Wall-clock ≈ parallel here anyway.


### PR DESCRIPTION
## Summary

Restores two `hu meter` subcommands that existed on the original `hu` skeleton branch but were dropped when that work was re-split into the 9-PR stack (#232–#240). A feature audit of the skeleton against `main` found these were the only genuine user-facing capabilities missing from the merged result. Both are now fully functional: `delay` reports real end-to-end latency, and `pub` publishes to an empty topic like `ros2 topic pub` — which required adding a runtime `.msg` schema loader to hiroz core.

## Subcommands

- **`hu meter pub <topic> --msg-type <type> --yaml <yaml> [--rate <Hz>] [--times <n>]`** — encodes a YAML/JSON body to CDR and publishes it on the topic's RmwZenoh key. One-shot by default; with `--rate` or `--times>1` it publishes repeatedly on the tick timer. `--times` must be ≥1; rates above the ~1 Hz tick resolution warn rather than silently miscounting.
- **`hu meter delay <topic> [--duration <s>]`** — subscribes and reports the end-to-end latency of each message from its `header.stamp` to receive time, self-exiting via `--duration` (like `hz`/`bw`). Messages without a stamp are reported as such rather than silently shown as zero.

## Key changes

- **Runtime `.msg` schema loader (`crates/hiroz/src/dynamic/registry.rs`, `dynamic-schema-loader` feature).** New `hiroz::dynamic::load_schema(type_name)` locates the `.msg` under `HIROZ_MSG_PATH` (prefix and package-directory layouts), parses it, resolves nested message fields recursively, and registers the schema. This is what lets `hu meter pub` resolve a type with no live node present, exactly like `ros2 topic pub`. Hardened against a cyclic/self-referential `.msg` (cycle guard), a cross-package filename collision (the package-directory form is used only when the entry's basename matches the package), same-package nested fields written unqualified (defaulted to the parent package), and swallowed parse errors (logged, not masqueraded as "not found").
- **Plugin host publish path (`crates/hiroz-union/src/plugin/wasm/host/ros.rs`).** `encode-yaml-to-cdr` resolves the schema from disk first and falls back to live discovery from a publisher or subscriber on the topic. Either way, if the topic already carries a different wire type, that mismatch is reported rather than published with the wrong type (the publish key is built by `resolve_topic_ke` from the live endpoint's type).
- **hiroz discovery/registration fixes (`discovery.rs`, `node.rs`).** Topic schema discovery now resolves from a subscriber, not only a publisher, and typed subscribers register their schema with the type-description service — so the live-discovery fallback works whichever endpoint is present.
- **hu-meter plugin (`plugins/hu-meter/src/lib.rs`).** Adds the `pub`/`delay` dispatch, their `Mode` states and `on_tick` handlers, real latency computation from the header stamp, argument validation, and topic-to-key-expression resolution before publishing raw CDR.
- **Docs and WIT contracts.** `docs/tools/hu-vs-ros2cli.md` and the `encode-yaml-to-cdr` comment in the four WIT copies describe the actual disk-first, discovery-fallback resolution (previously they claimed a live endpoint was required).
- **Tests (`crates/hiroz-tests/tests/hu_meter.rs`).** `delay_basic` (real measured latency from a stamped burst); `pub_arg_and_encode_paths` (argument validation + the unresolvable-type error path); `pub_empty_topic_from_disk` and `pub_empty_topic_nested_type` (publish to a topic with no live node — a raw Zenoh subscriber, which announces no ROS type, confirms receipt, proving the disk loader supplied the schema); `pub_publishes_to_live_topic` (the live-discovery fallback). `HIROZ_MSG_PATH` is deliberately left unset in `scripts/ci/hu-tests.sh` so the discovery fallback stays exercised.

## What fails without this

`hu meter pub` and `hu meter delay` do not exist on `main` — grep for `cmd_pub`/`cmd_delay` in the merged hu-meter returns nothing. There is no failing test on `main`; the capabilities simply weren't ported, so this PR adds both commands and their coverage. Within the PR, the new tests are the failing baseline for each behavior: without the nested-type fix, `pub_empty_topic_nested_type` fails (the loader returns `None` for `geometry_msgs/Twist`); without the type-consistency guard, a disk-resolved type could be published on a conflicting endpoint's key.

## Breaking changes

None to hiroz. The `hu:plugin@0.1.0` WIT `encode-yaml-to-cdr` function gains a `topic` parameter (two args to three) to support topic-aware resolution. This is a pre-1.0, first-public-release interface with no pinned third-party plugins, so it is treated as a non-breaking change to an unstable ABI rather than a versioned break.
