### PR TITLE
fix(codegen): stable ordering for generated python stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,6 +514,11 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           skipPush: ${{ github.event_name == 'pull_request' }}
 
+      - name: Install Nushell
+        run: |
+          nix profile install nixpkgs#nushell
+          chmod +x scripts/test-pure-rust.nu
+
       - name: Setup nix environment
         run: |
           nix print-dev-env '.#pureRust-ci' --accept-flake-config > /tmp/nix-dev-env.sh
@@ -527,28 +532,10 @@ jobs:
       # Deliberately does NOT restore the `python-tests` job's generated-types
       # cache: a restored copy would be compared against the tree instead of a
       # freshly generated one, and the check would report on the cache.
-      #
-      # `touch build.rs` forces the generator to run even when cargo considers
-      # the crate up to date -- otherwise a warm target dir makes this a no-op
-      # that passes without generating anything.
       - name: Generated Python stubs are up to date
         run: |
           source /tmp/nix-dev-env.sh
-          touch crates/hiroz-msgs/build.rs
-          cargo build -j4 -p hiroz-msgs --features python_registry
-          # `git status --porcelain`, not `git diff`: diff only reports tracked
-          # files, so a stub for a newly-added package would be generated,
-          # left untracked, and silently pass.
-          drift=$(git status --porcelain -- crates/hiroz-msgs/python/hiroz_msgs_py/types)
-          if [ -n "$drift" ]; then
-            echo "$drift"
-            git diff -- crates/hiroz-msgs/python/hiroz_msgs_py/types
-            echo "::error::Generated Python stubs are stale. Run"
-            echo "  cargo build -p hiroz-msgs --features python_registry"
-            echo "and commit the result."
-            exit 1
-          fi
-          echo "Generated Python stubs match the message assets."
+          nu scripts/test-pure-rust.nu check-python-stubs
 
   go-tests:
     name: Go Tests (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,77 @@ jobs:
           source /tmp/nix-dev-env.sh
           bash scripts/ci/hu-tests.sh
 
+  python-stubs-fresh:
+    name: Generated Python Stubs (ubuntu-latest)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          large-packages: true
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: true
+          swap-storage: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://hiroz.cachix.org
+            extra-trusted-public-keys = hiroz.cachix.org-1:wKJuqEckTG0DL3Df7Ly9OVsg5S5TGBHtvlPGs+vlqrY=
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v15
+        with:
+          name: hiroz
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: ${{ github.event_name == 'pull_request' }}
+
+      - name: Setup nix environment
+        run: |
+          nix print-dev-env '.#pureRust-ci' --accept-flake-config > /tmp/nix-dev-env.sh
+          echo "export CI=true" >> /tmp/nix-dev-env.sh
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest-python-stubs
+
+      # Deliberately does NOT restore the `python-tests` job's generated-types
+      # cache: a restored copy would be compared against the tree instead of a
+      # freshly generated one, and the check would report on the cache.
+      #
+      # `touch build.rs` forces the generator to run even when cargo considers
+      # the crate up to date -- otherwise a warm target dir makes this a no-op
+      # that passes without generating anything.
+      - name: Generated Python stubs are up to date
+        run: |
+          source /tmp/nix-dev-env.sh
+          touch crates/hiroz-msgs/build.rs
+          cargo build -j4 -p hiroz-msgs --features python_registry
+          # `git status --porcelain`, not `git diff`: diff only reports tracked
+          # files, so a stub for a newly-added package would be generated,
+          # left untracked, and silently pass.
+          drift=$(git status --porcelain -- crates/hiroz-msgs/python/hiroz_msgs_py/types)
+          if [ -n "$drift" ]; then
+            echo "$drift"
+            git diff -- crates/hiroz-msgs/python/hiroz_msgs_py/types
+            echo "::error::Generated Python stubs are stale. Run"
+            echo "  cargo build -p hiroz-msgs --features python_registry"
+            echo "and commit the result."
+            exit 1
+          fi
+          echo "Generated Python stubs match the message assets."
+
   go-tests:
     name: Go Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,17 @@ result*
 *.egg-info
 __pycache__/
 
-# Auto-generated Python message types (regenerated from .msg files during Rust build)
-crates/hiroz-msgs/python/hiroz_msgs_py/types/*.py
-crates/hiroz-msgs/python/hiroz_msgs_py/types/__init__.py
+# The generated Python message types under
+# crates/hiroz-msgs/python/hiroz_msgs_py/types/ are deliberately tracked, not
+# ignored. They are regenerated from the .msg assets during the Rust build, and
+# the "Generated Python Stubs" CI job fails if the committed copy has drifted
+# from what the generator produces. Ignoring them (as this file used to, while
+# twelve of the thirteen were tracked anyway) hid that drift.
+#
+# The negation is required: the generic `_*` rule near the top of this file
+# matches `__init__.py`, which is why that one generated file stayed untracked
+# while its twelve siblings did not.
+!crates/hiroz-msgs/python/hiroz_msgs_py/types/__init__.py
 crates/hiroz-msgs/python/build/lib/hiroz_msgs_py/types/*.py
 crates/hiroz-msgs/python/build/
 crates/hiroz-msgs/python/uv.lock

--- a/crates/hiroz-codegen/src/python_msgspec_generator.rs
+++ b/crates/hiroz-codegen/src/python_msgspec_generator.rs
@@ -56,6 +56,13 @@ pub fn generate_python_bindings(
             .or_default()
             .insert(srv.response.parsed.name.clone(), svc_hash);
     }
+    // Sort for the same reason the message groups above are sorted: `services`
+    // arrives in `discover_all` order, which follows directory iteration and so
+    // varies by machine and filesystem. Without this the emitted stubs differ
+    // between builds by pure reordering, and every build dirties the tree.
+    for srv_msgs in service_messages.values_mut() {
+        srv_msgs.sort_by(|a, b| a.parsed.name.cmp(&b.parsed.name));
+    }
 
     // Generate Python msgspec structs (one file per package)
     for (package_name, package_msgs) in &packages {

--- a/crates/hiroz-msgs/python/hiroz_msgs_py/types/__init__.py
+++ b/crates/hiroz-msgs/python/hiroz_msgs_py/types/__init__.py
@@ -1,0 +1,30 @@
+"""Auto-generated ROS 2 message types package."""
+
+# Import all message types
+from . import action_msgs
+from . import builtin_interfaces
+from . import example_interfaces
+from . import geometry_msgs
+from . import lifecycle_msgs
+from . import nav_msgs
+from . import rcl_interfaces
+from . import sensor_msgs
+from . import service_msgs
+from . import std_msgs
+from . import type_description_interfaces
+from . import unique_identifier_msgs
+
+__all__ = [
+    "action_msgs",
+    "builtin_interfaces",
+    "example_interfaces",
+    "geometry_msgs",
+    "lifecycle_msgs",
+    "nav_msgs",
+    "rcl_interfaces",
+    "sensor_msgs",
+    "service_msgs",
+    "std_msgs",
+    "type_description_interfaces",
+    "unique_identifier_msgs",
+]

--- a/crates/hiroz-msgs/python/hiroz_msgs_py/types/action_msgs.py
+++ b/crates/hiroz-msgs/python/hiroz_msgs_py/types/action_msgs.py
@@ -2,6 +2,13 @@
 import msgspec
 from typing import ClassVar
 
+class GoalInfo(msgspec.Struct, frozen=True, kw_only=True):
+    goal_id: "unique_identifier_msgs.UUID | None" = None
+    stamp: "builtin_interfaces.Time | None" = msgspec.field(default_factory=lambda: {'sec': 0, 'nanosec': 0})
+
+    __msgtype__: ClassVar[str] = 'action_msgs/msg/GoalInfo'
+    __hash__: ClassVar[str] = 'RIHS01_6398fe763154554353930716b225947f93b672f0fb2e49fdd01bb7a7e37933e9'
+
 class GoalStatus(msgspec.Struct, frozen=True, kw_only=True):
     goal_info: "action_msgs.GoalInfo | None" = None
     status: int = 0
@@ -14,13 +21,6 @@ class GoalStatusArray(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'action_msgs/msg/GoalStatusArray'
     __hash__: ClassVar[str] = 'RIHS01_6c1684b00f177d37438febe6e709fc4e2b0d4248dca4854946f9ed8b30cda83e'
-
-class GoalInfo(msgspec.Struct, frozen=True, kw_only=True):
-    goal_id: "unique_identifier_msgs.UUID | None" = None
-    stamp: "builtin_interfaces.Time | None" = msgspec.field(default_factory=lambda: {'sec': 0, 'nanosec': 0})
-
-    __msgtype__: ClassVar[str] = 'action_msgs/msg/GoalInfo'
-    __hash__: ClassVar[str] = 'RIHS01_6398fe763154554353930716b225947f93b672f0fb2e49fdd01bb7a7e37933e9'
 
 class CancelGoalRequest(msgspec.Struct, frozen=True, kw_only=True):
     goal_info: "action_msgs.GoalInfo | None" = None

--- a/crates/hiroz-msgs/python/hiroz_msgs_py/types/example_interfaces.py
+++ b/crates/hiroz-msgs/python/hiroz_msgs_py/types/example_interfaces.py
@@ -2,39 +2,11 @@
 import msgspec
 from typing import ClassVar
 
-class Int8(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
+class Bool(msgspec.Struct, frozen=True, kw_only=True):
+    data: bool = False
 
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int8'
-    __hash__: ClassVar[str] = 'RIHS01_2e9ef643d84ff37840fe787d1269aa06268960e294f4a0f5eb1e9d4eb21cbb57'
-
-class Int16MultiArray(msgspec.Struct, frozen=True, kw_only=True):
-    layout: "example_interfaces.MultiArrayLayout | None" = None
-    data: list[int] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int16MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_d663e739410479619bfb7b9b94b0a764998acffadb8b7f5b200affa87b7ffdd2'
-
-class UInt16MultiArray(msgspec.Struct, frozen=True, kw_only=True):
-    layout: "example_interfaces.MultiArrayLayout | None" = None
-    data: list[int] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt16MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_507f6456c1965ef6eab8a9cfa8860bd484e1b7039b4c4ea2c75c648182fceade'
-
-class MultiArrayDimension(msgspec.Struct, frozen=True, kw_only=True):
-    label: str = ""
-    size: int = 0
-    stride: int = 0
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/MultiArrayDimension'
-    __hash__: ClassVar[str] = 'RIHS01_a785cb9839e177e3eb760260139a919fec87821edc3314c592f2725abbf0bfcd'
-
-class String(msgspec.Struct, frozen=True, kw_only=True):
-    data: str = ""
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/String'
-    __hash__: ClassVar[str] = 'RIHS01_5509d866a579951f2fc6c19577c32605ba16f308cae7b498341d79536d4eb06b'
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Bool'
+    __hash__: ClassVar[str] = 'RIHS01_4765c142500f8fd4e1a32fb3edd7b7d9d822a16ec270445f5120e772c5f9aed5'
 
 class Byte(msgspec.Struct, frozen=True, kw_only=True):
     data: int = 0
@@ -42,11 +14,36 @@ class Byte(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'example_interfaces/msg/Byte'
     __hash__: ClassVar[str] = 'RIHS01_f014e0424be54b8ba7c35490aea4198be92df1de4e88f4e19a2fbbce2e020bb9'
 
-class Int32(msgspec.Struct, frozen=True, kw_only=True):
+class ByteMultiArray(msgspec.Struct, frozen=True, kw_only=True):
+    layout: "example_interfaces.MultiArrayLayout | None" = None
+    data: bytes = b""
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/ByteMultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_257fc3429b3c4dd0aea678c234f543665d1144b396f82c7ee60fed151e1dace3'
+
+class Char(msgspec.Struct, frozen=True, kw_only=True):
     data: int = 0
 
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int32'
-    __hash__: ClassVar[str] = 'RIHS01_5cd04cd7f3adb9d6c6064c316047b24c76622eb89144f300b536d657fd55e652'
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Char'
+    __hash__: ClassVar[str] = 'RIHS01_320dcd57e1183fb08463cc3ab50bf7e5ce0ecee39f64d15a9e9eeca3384c91a5'
+
+class Empty(msgspec.Struct, frozen=True, kw_only=True):
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Empty'
+    __hash__: ClassVar[str] = 'RIHS01_73c22a7341eeccf8ef504a991e60d4078223f0931a5d5d212800e7c978903c58'
+
+class Float32(msgspec.Struct, frozen=True, kw_only=True):
+    data: float = 0.0
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Float32'
+    __hash__: ClassVar[str] = 'RIHS01_6a112d9235f8e8088d7a2bc77cb955341ac0d5c9870bdc592651a4186bb246f3'
+
+class Float32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+    layout: "example_interfaces.MultiArrayLayout | None" = None
+    data: list[float] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Float32MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_8705278e8d206a9711133794ce6466281e9698138331c4b3d91e6cc9e9dfee26'
 
 class Float64(msgspec.Struct, frozen=True, kw_only=True):
     data: float = 0.0
@@ -61,67 +58,24 @@ class Float64MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'example_interfaces/msg/Float64MultiArray'
     __hash__: ClassVar[str] = 'RIHS01_62a0985e7920b7bc489d1392f08c06ba0080fff5b8eaa09b27dcac122f50ad95'
 
-class MultiArrayLayout(msgspec.Struct, frozen=True, kw_only=True):
-    dim: list["example_interfaces.MultiArrayDimension"] = msgspec.field(default_factory=list)
-    data_offset: int = 0
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/MultiArrayLayout'
-    __hash__: ClassVar[str] = 'RIHS01_ba42ea30074e5826a1e91f70f3660dda2996937169487f877fc20a8a402e2c27'
-
-class Empty(msgspec.Struct, frozen=True, kw_only=True):
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Empty'
-    __hash__: ClassVar[str] = 'RIHS01_73c22a7341eeccf8ef504a991e60d4078223f0931a5d5d212800e7c978903c58'
-
-class UInt64(msgspec.Struct, frozen=True, kw_only=True):
+class Int16(msgspec.Struct, frozen=True, kw_only=True):
     data: int = 0
 
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt64'
-    __hash__: ClassVar[str] = 'RIHS01_6a3f8548c5818b7add62dd6cbbd840fd1ab17fbf9d73cad6690557b7326d8908'
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int16'
+    __hash__: ClassVar[str] = 'RIHS01_332d94306732e4e35da38e5ae744ff35bbdaeca300908dc43488d3a844687cd6'
 
-class Float32(msgspec.Struct, frozen=True, kw_only=True):
-    data: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Float32'
-    __hash__: ClassVar[str] = 'RIHS01_6a112d9235f8e8088d7a2bc77cb955341ac0d5c9870bdc592651a4186bb246f3'
-
-class Bool(msgspec.Struct, frozen=True, kw_only=True):
-    data: bool = False
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Bool'
-    __hash__: ClassVar[str] = 'RIHS01_4765c142500f8fd4e1a32fb3edd7b7d9d822a16ec270445f5120e772c5f9aed5'
-
-class Int8MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+class Int16MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     layout: "example_interfaces.MultiArrayLayout | None" = None
     data: list[int] = msgspec.field(default_factory=list)
 
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int8MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_6d26932aefc0e5c0c473613376338609bac9925e3527dc4e8fab6b6783b6d680'
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int16MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_d663e739410479619bfb7b9b94b0a764998acffadb8b7f5b200affa87b7ffdd2'
 
-class Float32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
-    layout: "example_interfaces.MultiArrayLayout | None" = None
-    data: list[float] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Float32MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_8705278e8d206a9711133794ce6466281e9698138331c4b3d91e6cc9e9dfee26'
-
-class UInt8(msgspec.Struct, frozen=True, kw_only=True):
+class Int32(msgspec.Struct, frozen=True, kw_only=True):
     data: int = 0
 
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt8'
-    __hash__: ClassVar[str] = 'RIHS01_9255b6d0dd98f5b573afbff223131279b788ac45cf051fb462c12dd9a30f4061'
-
-class Int64(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int64'
-    __hash__: ClassVar[str] = 'RIHS01_1b3b9a6502f560d079520c73c685a9550e5a1838d2cefd537fe0aba75a3639a0'
-
-class Char(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Char'
-    __hash__: ClassVar[str] = 'RIHS01_320dcd57e1183fb08463cc3ab50bf7e5ce0ecee39f64d15a9e9eeca3384c91a5'
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int32'
+    __hash__: ClassVar[str] = 'RIHS01_5cd04cd7f3adb9d6c6064c316047b24c76622eb89144f300b536d657fd55e652'
 
 class Int32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     layout: "example_interfaces.MultiArrayLayout | None" = None
@@ -130,11 +84,11 @@ class Int32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int32MultiArray'
     __hash__: ClassVar[str] = 'RIHS01_b347aff8e38e2ce3f7f4023db7922d2d4abb9d593b03c40b1427640c26595bfa'
 
-class UInt32(msgspec.Struct, frozen=True, kw_only=True):
+class Int64(msgspec.Struct, frozen=True, kw_only=True):
     data: int = 0
 
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt32'
-    __hash__: ClassVar[str] = 'RIHS01_e86cccba586f30c16498f3ccd3550a764b255239a6142be3a4d7a2fa9a43515c'
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int64'
+    __hash__: ClassVar[str] = 'RIHS01_1b3b9a6502f560d079520c73c685a9550e5a1838d2cefd537fe0aba75a3639a0'
 
 class Int64MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     layout: "example_interfaces.MultiArrayLayout | None" = None
@@ -143,25 +97,58 @@ class Int64MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int64MultiArray'
     __hash__: ClassVar[str] = 'RIHS01_ebce42c0d2b81bc5309deb0b2d83e30236aeb4899aea3cc7ddd18787af39c94a'
 
+class Int8(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int8'
+    __hash__: ClassVar[str] = 'RIHS01_2e9ef643d84ff37840fe787d1269aa06268960e294f4a0f5eb1e9d4eb21cbb57'
+
+class Int8MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+    layout: "example_interfaces.MultiArrayLayout | None" = None
+    data: list[int] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int8MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_6d26932aefc0e5c0c473613376338609bac9925e3527dc4e8fab6b6783b6d680'
+
+class MultiArrayDimension(msgspec.Struct, frozen=True, kw_only=True):
+    label: str = ""
+    size: int = 0
+    stride: int = 0
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/MultiArrayDimension'
+    __hash__: ClassVar[str] = 'RIHS01_a785cb9839e177e3eb760260139a919fec87821edc3314c592f2725abbf0bfcd'
+
+class MultiArrayLayout(msgspec.Struct, frozen=True, kw_only=True):
+    dim: list["example_interfaces.MultiArrayDimension"] = msgspec.field(default_factory=list)
+    data_offset: int = 0
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/MultiArrayLayout'
+    __hash__: ClassVar[str] = 'RIHS01_ba42ea30074e5826a1e91f70f3660dda2996937169487f877fc20a8a402e2c27'
+
+class String(msgspec.Struct, frozen=True, kw_only=True):
+    data: str = ""
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/String'
+    __hash__: ClassVar[str] = 'RIHS01_5509d866a579951f2fc6c19577c32605ba16f308cae7b498341d79536d4eb06b'
+
 class UInt16(msgspec.Struct, frozen=True, kw_only=True):
     data: int = 0
 
     __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt16'
     __hash__: ClassVar[str] = 'RIHS01_e123d0a691fa0ce58b682f1a4eee55137dd3f20c81665f0c556f53596c7fb377'
 
-class UInt64MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+class UInt16MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     layout: "example_interfaces.MultiArrayLayout | None" = None
     data: list[int] = msgspec.field(default_factory=list)
 
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt64MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_c05a348bd887aac76a947c901f67f93bf9a7fa14b28dce02eb495dadeb8842e4'
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt16MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_507f6456c1965ef6eab8a9cfa8860bd484e1b7039b4c4ea2c75c648182fceade'
 
-class UInt8MultiArray(msgspec.Struct, frozen=True, kw_only=True):
-    layout: "example_interfaces.MultiArrayLayout | None" = None
-    data: bytes = b""
+class UInt32(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
 
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt8MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_7a49ef5ed9b7182488303b4027d54719ba7266e776bd446dac30e79b56fb0a71'
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt32'
+    __hash__: ClassVar[str] = 'RIHS01_e86cccba586f30c16498f3ccd3550a764b255239a6142be3a4d7a2fa9a43515c'
 
 class UInt32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     layout: "example_interfaces.MultiArrayLayout | None" = None
@@ -170,18 +157,31 @@ class UInt32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt32MultiArray'
     __hash__: ClassVar[str] = 'RIHS01_0683176c523a116c76141c6d4abd150dbff492b72185f1260ce38a18a35aafcf'
 
-class ByteMultiArray(msgspec.Struct, frozen=True, kw_only=True):
+class UInt64(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt64'
+    __hash__: ClassVar[str] = 'RIHS01_6a3f8548c5818b7add62dd6cbbd840fd1ab17fbf9d73cad6690557b7326d8908'
+
+class UInt64MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+    layout: "example_interfaces.MultiArrayLayout | None" = None
+    data: list[int] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt64MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_c05a348bd887aac76a947c901f67f93bf9a7fa14b28dce02eb495dadeb8842e4'
+
+class UInt8(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt8'
+    __hash__: ClassVar[str] = 'RIHS01_9255b6d0dd98f5b573afbff223131279b788ac45cf051fb462c12dd9a30f4061'
+
+class UInt8MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     layout: "example_interfaces.MultiArrayLayout | None" = None
     data: bytes = b""
 
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/ByteMultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_257fc3429b3c4dd0aea678c234f543665d1144b396f82c7ee60fed151e1dace3'
-
-class Int16(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/Int16'
-    __hash__: ClassVar[str] = 'RIHS01_332d94306732e4e35da38e5ae744ff35bbdaeca300908dc43488d3a844687cd6'
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/UInt8MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_7a49ef5ed9b7182488303b4027d54719ba7266e776bd446dac30e79b56fb0a71'
 
 class AddTwoIntsRequest(msgspec.Struct, frozen=True, kw_only=True):
     a: int = 0
@@ -196,18 +196,6 @@ class AddTwoIntsResponse(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'example_interfaces/msg/AddTwoIntsResponse'
     __hash__: ClassVar[str] = 'RIHS01_e118de6bf5eeb66a2491b5bda11202e7b68f198d6f67922cf30364858239c81a'
 
-class TriggerRequest(msgspec.Struct, frozen=True, kw_only=True):
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/TriggerRequest'
-    __hash__: ClassVar[str] = 'RIHS01_cfeeee47f8105dd7685e4c92d46d4074669cb1c477402be1dea37486542a69e0'
-
-class TriggerResponse(msgspec.Struct, frozen=True, kw_only=True):
-    success: bool = False
-    message: str = ""
-
-    __msgtype__: ClassVar[str] = 'example_interfaces/msg/TriggerResponse'
-    __hash__: ClassVar[str] = 'RIHS01_cfeeee47f8105dd7685e4c92d46d4074669cb1c477402be1dea37486542a69e0'
-
 class SetBoolRequest(msgspec.Struct, frozen=True, kw_only=True):
     data: bool = False
 
@@ -220,4 +208,16 @@ class SetBoolResponse(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'example_interfaces/msg/SetBoolResponse'
     __hash__: ClassVar[str] = 'RIHS01_a69782e5631b12e15c8e218410de1685bbf13e382718295adad14037a24afbe8'
+
+class TriggerRequest(msgspec.Struct, frozen=True, kw_only=True):
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/TriggerRequest'
+    __hash__: ClassVar[str] = 'RIHS01_cfeeee47f8105dd7685e4c92d46d4074669cb1c477402be1dea37486542a69e0'
+
+class TriggerResponse(msgspec.Struct, frozen=True, kw_only=True):
+    success: bool = False
+    message: str = ""
+
+    __msgtype__: ClassVar[str] = 'example_interfaces/msg/TriggerResponse'
+    __hash__: ClassVar[str] = 'RIHS01_cfeeee47f8105dd7685e4c92d46d4074669cb1c477402be1dea37486542a69e0'
 

--- a/crates/hiroz-msgs/python/hiroz_msgs_py/types/geometry_msgs.py
+++ b/crates/hiroz-msgs/python/hiroz_msgs_py/types/geometry_msgs.py
@@ -2,112 +2,12 @@
 import msgspec
 from typing import ClassVar
 
-class QuaternionStamped(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    quaternion: "geometry_msgs.Quaternion | None" = None
+class Accel(msgspec.Struct, frozen=True, kw_only=True):
+    linear: "geometry_msgs.Vector3 | None" = None
+    angular: "geometry_msgs.Vector3 | None" = None
 
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/QuaternionStamped'
-    __hash__: ClassVar[str] = 'RIHS01_381add86c6c3160644d228ca342182c7fd6c7fab11c7a85ad817a9cc22dbac6e'
-
-class Vector3Stamped(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    vector: "geometry_msgs.Vector3 | None" = None
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Vector3Stamped'
-    __hash__: ClassVar[str] = 'RIHS01_d4829622288cbb443886e7ea94ea5671a3b1be6bab4ad04224432a65f7d7887a'
-
-class PolygonInstanceStamped(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    polygon: "geometry_msgs.PolygonInstance | None" = None
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PolygonInstanceStamped'
-    __hash__: ClassVar[str] = 'RIHS01_802f37ea4398d7ce547936aab1fd278923716a13c63373887cd896957434ce2f'
-
-class Point32(msgspec.Struct, frozen=True, kw_only=True):
-    x: float = 0.0
-    y: float = 0.0
-    z: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Point32'
-    __hash__: ClassVar[str] = 'RIHS01_2fc4db7cae16a4582c79a56b66173a8d48d52c7dc520ddc55a0d4bcf2a4bfdbc'
-
-class Polygon(msgspec.Struct, frozen=True, kw_only=True):
-    points: list["geometry_msgs.Point32"] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Polygon'
-    __hash__: ClassVar[str] = 'RIHS01_3782f9f0bf044964d692d6c017d705e37611afb1f0bf6a9dee248a7dda0f784a'
-
-class Vector3(msgspec.Struct, frozen=True, kw_only=True):
-    x: float = 0.0
-    y: float = 0.0
-    z: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Vector3'
-    __hash__: ClassVar[str] = 'RIHS01_cc12fe83e4c02719f1ce8070bfd14aecd40f75a96696a67a2a1f37f7dbb0765d'
-
-class Pose2D(msgspec.Struct, frozen=True, kw_only=True):
-    x: float = 0.0
-    y: float = 0.0
-    theta: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Pose2D'
-    __hash__: ClassVar[str] = 'RIHS01_d68efa5b46e70f7b16ca23085474fdac5a44b638783ec42f661da64da4724ccc'
-
-class WrenchStamped(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    wrench: "geometry_msgs.Wrench | None" = None
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/WrenchStamped'
-    __hash__: ClassVar[str] = 'RIHS01_8dc3deaf06b2ab281f9f9a742a8961c328ca7cec16e3fd6586d3a5c83fa78f77'
-
-class TwistStamped(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    twist: "geometry_msgs.Twist | None" = None
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/TwistStamped'
-    __hash__: ClassVar[str] = 'RIHS01_5f0fcd4f81d5d06ad9b4c4c63e3ea51b82d6ae4d0558f1d475229b1121db6f64'
-
-class PoseWithCovariance(msgspec.Struct, frozen=True, kw_only=True):
-    pose: "geometry_msgs.Pose | None" = None
-    covariance: list[float] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PoseWithCovariance'
-    __hash__: ClassVar[str] = 'RIHS01_9a7c0fd234b7f45c6098745ecccd773ca1085670e64107135397aee31c02e1bb'
-
-class PolygonInstance(msgspec.Struct, frozen=True, kw_only=True):
-    polygon: "geometry_msgs.Polygon | None" = None
-    id: int = 0
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PolygonInstance'
-    __hash__: ClassVar[str] = 'RIHS01_fa1cb3dc774329865258afef74f65b0553d487510c6d0f93ba38cc32d62ac0e5'
-
-class AccelWithCovariance(msgspec.Struct, frozen=True, kw_only=True):
-    accel: "geometry_msgs.Accel | None" = None
-    covariance: list[float] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/AccelWithCovariance'
-    __hash__: ClassVar[str] = 'RIHS01_230d51bd53bc36f260574e73b42941cefe44684753480b6fc330c032c5db5997'
-
-class PolygonStamped(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    polygon: "geometry_msgs.Polygon | None" = None
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PolygonStamped'
-    __hash__: ClassVar[str] = 'RIHS01_b7cf07932f1523d4b4088075945c1a0141f7cd21da87cc940fc61652e9138b46'
-
-class PointStamped(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    point: "geometry_msgs.Point | None" = None
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PointStamped'
-    __hash__: ClassVar[str] = 'RIHS01_4c0296af86e01e562e9e0405d138a01537247580076c58ea38d7923ac1045897'
-
-class Transform(msgspec.Struct, frozen=True, kw_only=True):
-    translation: "geometry_msgs.Vector3 | None" = None
-    rotation: "geometry_msgs.Quaternion | None" = None
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Transform'
-    __hash__: ClassVar[str] = 'RIHS01_beb83fbe698636351461f6f35d1abb20010c43d55374d81bd041f1ba2581fddc'
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Accel'
+    __hash__: ClassVar[str] = 'RIHS01_dc448243ded9b1fcbcca24aba0c22f013dae06c354ba2d849571c0a2a3f57ca0'
 
 class AccelStamped(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
@@ -116,12 +16,19 @@ class AccelStamped(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'geometry_msgs/msg/AccelStamped'
     __hash__: ClassVar[str] = 'RIHS01_ef1df9eabae0a708cc049a061ebcddc4e2a5f745730100ba680e086a9698b165'
 
-class PoseStamped(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    pose: "geometry_msgs.Pose | None" = None
+class AccelWithCovariance(msgspec.Struct, frozen=True, kw_only=True):
+    accel: "geometry_msgs.Accel | None" = None
+    covariance: list[float] = msgspec.field(default_factory=list)
 
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PoseStamped'
-    __hash__: ClassVar[str] = 'RIHS01_10f3786d7d40fd2b54367835614bff85d4ad3b5dab62bf8bca0cc232d73b4cd8'
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/AccelWithCovariance'
+    __hash__: ClassVar[str] = 'RIHS01_230d51bd53bc36f260574e73b42941cefe44684753480b6fc330c032c5db5997'
+
+class AccelWithCovarianceStamped(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    accel: "geometry_msgs.AccelWithCovariance | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/AccelWithCovarianceStamped'
+    __hash__: ClassVar[str] = 'RIHS01_61c9ad8928e71dd95ce791b2f02809ee2a0bbcc42cd0e4047fd00a822a08e444'
 
 class Inertia(msgspec.Struct, frozen=True, kw_only=True):
     m: float = 0.0
@@ -136,49 +43,12 @@ class Inertia(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Inertia'
     __hash__: ClassVar[str] = 'RIHS01_2ddd5dab5c347825ba2e56c895ddccfd0b8efe53ae931bf67f905529930b4bd7'
 
-class Quaternion(msgspec.Struct, frozen=True, kw_only=True):
-    x: float = 0.0
-    y: float = 0.0
-    z: float = 0.0
-    w: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Quaternion'
-    __hash__: ClassVar[str] = 'RIHS01_8a765f66778c8ff7c8ab94afcc590a2ed5325a1d9a076ffff38fbce36f458684'
-
-class TwistWithCovariance(msgspec.Struct, frozen=True, kw_only=True):
-    twist: "geometry_msgs.Twist | None" = None
-    covariance: list[float] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/TwistWithCovariance'
-    __hash__: ClassVar[str] = 'RIHS01_49f574f033f095d8b6cd1beaca5ca7925e296e84af1716d16c89d38b059c8c18'
-
-class Pose(msgspec.Struct, frozen=True, kw_only=True):
-    position: "geometry_msgs.Point | None" = None
-    orientation: "geometry_msgs.Quaternion | None" = None
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Pose'
-    __hash__: ClassVar[str] = 'RIHS01_d501954e9476cea2996984e812054b68026ae0bfae789d9a10b23daf35cc90fa'
-
-class PoseWithCovarianceStamped(msgspec.Struct, frozen=True, kw_only=True):
+class InertiaStamped(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
-    pose: "geometry_msgs.PoseWithCovariance | None" = None
+    inertia: "geometry_msgs.Inertia | None" = None
 
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PoseWithCovarianceStamped'
-    __hash__: ClassVar[str] = 'RIHS01_26432f9803e43727d3c8f668d1fdb3c630f548af631e2f4e31382371bfea3b6e'
-
-class Wrench(msgspec.Struct, frozen=True, kw_only=True):
-    force: "geometry_msgs.Vector3 | None" = None
-    torque: "geometry_msgs.Vector3 | None" = None
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Wrench'
-    __hash__: ClassVar[str] = 'RIHS01_018e8519d57c16adbe97c9fe1460ef21fec7e31bc541de3d653a35895677ce52'
-
-class AccelWithCovarianceStamped(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    accel: "geometry_msgs.AccelWithCovariance | None" = None
-
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/AccelWithCovarianceStamped'
-    __hash__: ClassVar[str] = 'RIHS01_61c9ad8928e71dd95ce791b2f02809ee2a0bbcc42cd0e4047fd00a822a08e444'
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/InertiaStamped'
+    __hash__: ClassVar[str] = 'RIHS01_766be45976252babf7f9d8ac4ae7c912a7ceccf71035622529f27518b695aa09'
 
 class Point(msgspec.Struct, frozen=True, kw_only=True):
     x: float = 0.0
@@ -188,20 +58,62 @@ class Point(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Point'
     __hash__: ClassVar[str] = 'RIHS01_6963084842a9b04494d6b2941d11444708d892da2f4b09843b9c43f42a7f6881'
 
-class TransformStamped(msgspec.Struct, frozen=True, kw_only=True):
+class Point32(msgspec.Struct, frozen=True, kw_only=True):
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Point32'
+    __hash__: ClassVar[str] = 'RIHS01_2fc4db7cae16a4582c79a56b66173a8d48d52c7dc520ddc55a0d4bcf2a4bfdbc'
+
+class PointStamped(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
-    child_frame_id: str = ""
-    transform: "geometry_msgs.Transform | None" = None
+    point: "geometry_msgs.Point | None" = None
 
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/TransformStamped'
-    __hash__: ClassVar[str] = 'RIHS01_0a241f87d04668d94099cbb5ba11691d5ad32c2f29682e4eb5653424bd275206'
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PointStamped'
+    __hash__: ClassVar[str] = 'RIHS01_4c0296af86e01e562e9e0405d138a01537247580076c58ea38d7923ac1045897'
 
-class Accel(msgspec.Struct, frozen=True, kw_only=True):
-    linear: "geometry_msgs.Vector3 | None" = None
-    angular: "geometry_msgs.Vector3 | None" = None
+class Polygon(msgspec.Struct, frozen=True, kw_only=True):
+    points: list["geometry_msgs.Point32"] = msgspec.field(default_factory=list)
 
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Accel'
-    __hash__: ClassVar[str] = 'RIHS01_dc448243ded9b1fcbcca24aba0c22f013dae06c354ba2d849571c0a2a3f57ca0'
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Polygon'
+    __hash__: ClassVar[str] = 'RIHS01_3782f9f0bf044964d692d6c017d705e37611afb1f0bf6a9dee248a7dda0f784a'
+
+class PolygonInstance(msgspec.Struct, frozen=True, kw_only=True):
+    polygon: "geometry_msgs.Polygon | None" = None
+    id: int = 0
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PolygonInstance'
+    __hash__: ClassVar[str] = 'RIHS01_fa1cb3dc774329865258afef74f65b0553d487510c6d0f93ba38cc32d62ac0e5'
+
+class PolygonInstanceStamped(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    polygon: "geometry_msgs.PolygonInstance | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PolygonInstanceStamped'
+    __hash__: ClassVar[str] = 'RIHS01_802f37ea4398d7ce547936aab1fd278923716a13c63373887cd896957434ce2f'
+
+class PolygonStamped(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    polygon: "geometry_msgs.Polygon | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PolygonStamped'
+    __hash__: ClassVar[str] = 'RIHS01_b7cf07932f1523d4b4088075945c1a0141f7cd21da87cc940fc61652e9138b46'
+
+class Pose(msgspec.Struct, frozen=True, kw_only=True):
+    position: "geometry_msgs.Point | None" = None
+    orientation: "geometry_msgs.Quaternion | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Pose'
+    __hash__: ClassVar[str] = 'RIHS01_d501954e9476cea2996984e812054b68026ae0bfae789d9a10b23daf35cc90fa'
+
+class Pose2D(msgspec.Struct, frozen=True, kw_only=True):
+    x: float = 0.0
+    y: float = 0.0
+    theta: float = 0.0
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Pose2D'
+    __hash__: ClassVar[str] = 'RIHS01_d68efa5b46e70f7b16ca23085474fdac5a44b638783ec42f661da64da4724ccc'
 
 class PoseArray(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
@@ -210,12 +122,57 @@ class PoseArray(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PoseArray'
     __hash__: ClassVar[str] = 'RIHS01_af0cc36d190e104d546d168d6b39df04fa4b4ccecf59cb4c9ed328d3d5004aa0'
 
-class TwistWithCovarianceStamped(msgspec.Struct, frozen=True, kw_only=True):
+class PoseStamped(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
-    twist: "geometry_msgs.TwistWithCovariance | None" = None
+    pose: "geometry_msgs.Pose | None" = None
 
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/TwistWithCovarianceStamped'
-    __hash__: ClassVar[str] = 'RIHS01_77b67434531e6529b7a0091357b186b6ebdb17fd9ffd3e0c7ce9d3fb11a44563'
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PoseStamped'
+    __hash__: ClassVar[str] = 'RIHS01_10f3786d7d40fd2b54367835614bff85d4ad3b5dab62bf8bca0cc232d73b4cd8'
+
+class PoseWithCovariance(msgspec.Struct, frozen=True, kw_only=True):
+    pose: "geometry_msgs.Pose | None" = None
+    covariance: list[float] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PoseWithCovariance'
+    __hash__: ClassVar[str] = 'RIHS01_9a7c0fd234b7f45c6098745ecccd773ca1085670e64107135397aee31c02e1bb'
+
+class PoseWithCovarianceStamped(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    pose: "geometry_msgs.PoseWithCovariance | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/PoseWithCovarianceStamped'
+    __hash__: ClassVar[str] = 'RIHS01_26432f9803e43727d3c8f668d1fdb3c630f548af631e2f4e31382371bfea3b6e'
+
+class Quaternion(msgspec.Struct, frozen=True, kw_only=True):
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+    w: float = 0.0
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Quaternion'
+    __hash__: ClassVar[str] = 'RIHS01_8a765f66778c8ff7c8ab94afcc590a2ed5325a1d9a076ffff38fbce36f458684'
+
+class QuaternionStamped(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    quaternion: "geometry_msgs.Quaternion | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/QuaternionStamped'
+    __hash__: ClassVar[str] = 'RIHS01_381add86c6c3160644d228ca342182c7fd6c7fab11c7a85ad817a9cc22dbac6e'
+
+class Transform(msgspec.Struct, frozen=True, kw_only=True):
+    translation: "geometry_msgs.Vector3 | None" = None
+    rotation: "geometry_msgs.Quaternion | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Transform'
+    __hash__: ClassVar[str] = 'RIHS01_beb83fbe698636351461f6f35d1abb20010c43d55374d81bd041f1ba2581fddc'
+
+class TransformStamped(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    child_frame_id: str = ""
+    transform: "geometry_msgs.Transform | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/TransformStamped'
+    __hash__: ClassVar[str] = 'RIHS01_0a241f87d04668d94099cbb5ba11691d5ad32c2f29682e4eb5653424bd275206'
 
 class Twist(msgspec.Struct, frozen=True, kw_only=True):
     linear: "geometry_msgs.Vector3 | None" = None
@@ -224,12 +181,41 @@ class Twist(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Twist'
     __hash__: ClassVar[str] = 'RIHS01_9c45bf16fe0983d80e3cfe750d6835843d265a9a6c46bd2e609fcddde6fb8d2a'
 
-class InertiaStamped(msgspec.Struct, frozen=True, kw_only=True):
+class TwistStamped(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
-    inertia: "geometry_msgs.Inertia | None" = None
+    twist: "geometry_msgs.Twist | None" = None
 
-    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/InertiaStamped'
-    __hash__: ClassVar[str] = 'RIHS01_766be45976252babf7f9d8ac4ae7c912a7ceccf71035622529f27518b695aa09'
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/TwistStamped'
+    __hash__: ClassVar[str] = 'RIHS01_5f0fcd4f81d5d06ad9b4c4c63e3ea51b82d6ae4d0558f1d475229b1121db6f64'
+
+class TwistWithCovariance(msgspec.Struct, frozen=True, kw_only=True):
+    twist: "geometry_msgs.Twist | None" = None
+    covariance: list[float] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/TwistWithCovariance'
+    __hash__: ClassVar[str] = 'RIHS01_49f574f033f095d8b6cd1beaca5ca7925e296e84af1716d16c89d38b059c8c18'
+
+class TwistWithCovarianceStamped(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    twist: "geometry_msgs.TwistWithCovariance | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/TwistWithCovarianceStamped'
+    __hash__: ClassVar[str] = 'RIHS01_77b67434531e6529b7a0091357b186b6ebdb17fd9ffd3e0c7ce9d3fb11a44563'
+
+class Vector3(msgspec.Struct, frozen=True, kw_only=True):
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Vector3'
+    __hash__: ClassVar[str] = 'RIHS01_cc12fe83e4c02719f1ce8070bfd14aecd40f75a96696a67a2a1f37f7dbb0765d'
+
+class Vector3Stamped(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    vector: "geometry_msgs.Vector3 | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Vector3Stamped'
+    __hash__: ClassVar[str] = 'RIHS01_d4829622288cbb443886e7ea94ea5671a3b1be6bab4ad04224432a65f7d7887a'
 
 class VelocityStamped(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
@@ -239,4 +225,18 @@ class VelocityStamped(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'geometry_msgs/msg/VelocityStamped'
     __hash__: ClassVar[str] = 'RIHS01_55e7196186c8dbe4375278d7f1ac050dd8c9bacade1cf3eef8460fa667bd2457'
+
+class Wrench(msgspec.Struct, frozen=True, kw_only=True):
+    force: "geometry_msgs.Vector3 | None" = None
+    torque: "geometry_msgs.Vector3 | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/Wrench'
+    __hash__: ClassVar[str] = 'RIHS01_018e8519d57c16adbe97c9fe1460ef21fec7e31bc541de3d653a35895677ce52'
+
+class WrenchStamped(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    wrench: "geometry_msgs.Wrench | None" = None
+
+    __msgtype__: ClassVar[str] = 'geometry_msgs/msg/WrenchStamped'
+    __hash__: ClassVar[str] = 'RIHS01_8dc3deaf06b2ab281f9f9a742a8961c328ca7cec16e3fd6586d3a5c83fa78f77'
 

--- a/crates/hiroz-msgs/python/hiroz_msgs_py/types/lifecycle_msgs.py
+++ b/crates/hiroz-msgs/python/hiroz_msgs_py/types/lifecycle_msgs.py
@@ -2,13 +2,12 @@
 import msgspec
 from typing import ClassVar
 
-class TransitionDescription(msgspec.Struct, frozen=True, kw_only=True):
-    transition: "lifecycle_msgs.Transition | None" = None
-    start_state: "lifecycle_msgs.State | None" = None
-    goal_state: "lifecycle_msgs.State | None" = None
+class State(msgspec.Struct, frozen=True, kw_only=True):
+    id: int = 0
+    label: str = ""
 
-    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/TransitionDescription'
-    __hash__: ClassVar[str] = 'RIHS01_c5f1cd4bb1ad2ba0e3329d4ac7015c52a674a72c1faf7974c37a33f4f6048b28'
+    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/State'
+    __hash__: ClassVar[str] = 'RIHS01_dd2d02b82f3ebc858e53c431b1e6e91f3ffc71436fc81d0715214ac6ee2107a0'
 
 class Transition(msgspec.Struct, frozen=True, kw_only=True):
     id: int = 0
@@ -16,6 +15,14 @@ class Transition(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/Transition'
     __hash__: ClassVar[str] = 'RIHS01_c65d7b31ea134cba4f54fc867b817979be799f7452035cd35fac9b7421fb3424'
+
+class TransitionDescription(msgspec.Struct, frozen=True, kw_only=True):
+    transition: "lifecycle_msgs.Transition | None" = None
+    start_state: "lifecycle_msgs.State | None" = None
+    goal_state: "lifecycle_msgs.State | None" = None
+
+    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/TransitionDescription'
+    __hash__: ClassVar[str] = 'RIHS01_c5f1cd4bb1ad2ba0e3329d4ac7015c52a674a72c1faf7974c37a33f4f6048b28'
 
 class TransitionEvent(msgspec.Struct, frozen=True, kw_only=True):
     timestamp: "builtin_interfaces.Time | None" = msgspec.field(default_factory=lambda: {'sec': 0, 'nanosec': 0})
@@ -25,35 +32,6 @@ class TransitionEvent(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/TransitionEvent'
     __hash__: ClassVar[str] = 'RIHS01_f90405bf3073265eec4847f23ac63298cf2dd3933a6d541be11a9232dd840c32'
-
-class State(msgspec.Struct, frozen=True, kw_only=True):
-    id: int = 0
-    label: str = ""
-
-    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/State'
-    __hash__: ClassVar[str] = 'RIHS01_dd2d02b82f3ebc858e53c431b1e6e91f3ffc71436fc81d0715214ac6ee2107a0'
-
-class GetAvailableStatesRequest(msgspec.Struct, frozen=True, kw_only=True):
-
-    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/GetAvailableStatesRequest'
-    __hash__: ClassVar[str] = 'RIHS01_00a07d79d2207d71e81a8cbc1880e5d924cc16d4688ea8e8e06e443dc8f8aa1d'
-
-class GetAvailableStatesResponse(msgspec.Struct, frozen=True, kw_only=True):
-    available_states: list["lifecycle_msgs.State"] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/GetAvailableStatesResponse'
-    __hash__: ClassVar[str] = 'RIHS01_00a07d79d2207d71e81a8cbc1880e5d924cc16d4688ea8e8e06e443dc8f8aa1d'
-
-class GetStateRequest(msgspec.Struct, frozen=True, kw_only=True):
-
-    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/GetStateRequest'
-    __hash__: ClassVar[str] = 'RIHS01_800a0a5aae599782b02932de0caf563f6dc4e7e94b794eadde075ba2cbef9795'
-
-class GetStateResponse(msgspec.Struct, frozen=True, kw_only=True):
-    current_state: "lifecycle_msgs.State | None" = None
-
-    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/GetStateResponse'
-    __hash__: ClassVar[str] = 'RIHS01_800a0a5aae599782b02932de0caf563f6dc4e7e94b794eadde075ba2cbef9795'
 
 class ChangeStateRequest(msgspec.Struct, frozen=True, kw_only=True):
     transition: "lifecycle_msgs.Transition | None" = None
@@ -67,6 +45,17 @@ class ChangeStateResponse(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/ChangeStateResponse'
     __hash__: ClassVar[str] = 'RIHS01_356fe34f0475a43acf54542013af4167b0e729f77ea22ffb045c6ad8e20668e5'
 
+class GetAvailableStatesRequest(msgspec.Struct, frozen=True, kw_only=True):
+
+    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/GetAvailableStatesRequest'
+    __hash__: ClassVar[str] = 'RIHS01_00a07d79d2207d71e81a8cbc1880e5d924cc16d4688ea8e8e06e443dc8f8aa1d'
+
+class GetAvailableStatesResponse(msgspec.Struct, frozen=True, kw_only=True):
+    available_states: list["lifecycle_msgs.State"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/GetAvailableStatesResponse'
+    __hash__: ClassVar[str] = 'RIHS01_00a07d79d2207d71e81a8cbc1880e5d924cc16d4688ea8e8e06e443dc8f8aa1d'
+
 class GetAvailableTransitionsRequest(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/GetAvailableTransitionsRequest'
@@ -77,4 +66,15 @@ class GetAvailableTransitionsResponse(msgspec.Struct, frozen=True, kw_only=True)
 
     __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/GetAvailableTransitionsResponse'
     __hash__: ClassVar[str] = 'RIHS01_59b7ecefce0982a8a844b9f2c4f14764c1c4543cc55e72924e2aa4adad83e9bc'
+
+class GetStateRequest(msgspec.Struct, frozen=True, kw_only=True):
+
+    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/GetStateRequest'
+    __hash__: ClassVar[str] = 'RIHS01_800a0a5aae599782b02932de0caf563f6dc4e7e94b794eadde075ba2cbef9795'
+
+class GetStateResponse(msgspec.Struct, frozen=True, kw_only=True):
+    current_state: "lifecycle_msgs.State | None" = None
+
+    __msgtype__: ClassVar[str] = 'lifecycle_msgs/msg/GetStateResponse'
+    __hash__: ClassVar[str] = 'RIHS01_800a0a5aae599782b02932de0caf563f6dc4e7e94b794eadde075ba2cbef9795'
 

--- a/crates/hiroz-msgs/python/hiroz_msgs_py/types/nav_msgs.py
+++ b/crates/hiroz-msgs/python/hiroz_msgs_py/types/nav_msgs.py
@@ -2,13 +2,12 @@
 import msgspec
 from typing import ClassVar
 
-class OccupancyGrid(msgspec.Struct, frozen=True, kw_only=True):
+class Goals(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
-    info: "nav_msgs.MapMetaData | None" = None
-    data: list[int] = msgspec.field(default_factory=list)
+    goals: list["geometry_msgs.PoseStamped"] = msgspec.field(default_factory=list)
 
-    __msgtype__: ClassVar[str] = 'nav_msgs/msg/OccupancyGrid'
-    __hash__: ClassVar[str] = 'RIHS01_8d348150c12913a31ee0ec170fbf25089e4745d17035792a1ba94d6f0bc0cfc7'
+    __msgtype__: ClassVar[str] = 'nav_msgs/msg/Goals'
+    __hash__: ClassVar[str] = 'RIHS01_02305a51633b5c04d8979b878a7577cafd422f8a07465c878b17a920af3759e9'
 
 class GridCells(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
@@ -29,19 +28,13 @@ class MapMetaData(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'nav_msgs/msg/MapMetaData'
     __hash__: ClassVar[str] = 'RIHS01_2772d4b2000ef2b35dbaeb80fd3946c1369f817fb4f75677d916d27c17d763c8'
 
-class Goals(msgspec.Struct, frozen=True, kw_only=True):
+class OccupancyGrid(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
-    goals: list["geometry_msgs.PoseStamped"] = msgspec.field(default_factory=list)
+    info: "nav_msgs.MapMetaData | None" = None
+    data: list[int] = msgspec.field(default_factory=list)
 
-    __msgtype__: ClassVar[str] = 'nav_msgs/msg/Goals'
-    __hash__: ClassVar[str] = 'RIHS01_02305a51633b5c04d8979b878a7577cafd422f8a07465c878b17a920af3759e9'
-
-class Path(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    poses: list["geometry_msgs.PoseStamped"] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'nav_msgs/msg/Path'
-    __hash__: ClassVar[str] = 'RIHS01_1957a5bb3cee5da65c4e52e52b65a93df227efce4c20f8458b36e73066ca334b'
+    __msgtype__: ClassVar[str] = 'nav_msgs/msg/OccupancyGrid'
+    __hash__: ClassVar[str] = 'RIHS01_8d348150c12913a31ee0ec170fbf25089e4745d17035792a1ba94d6f0bc0cfc7'
 
 class Odometry(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
@@ -52,18 +45,12 @@ class Odometry(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'nav_msgs/msg/Odometry'
     __hash__: ClassVar[str] = 'RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0'
 
-class LoadMapRequest(msgspec.Struct, frozen=True, kw_only=True):
-    map_url: str = ""
+class Path(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    poses: list["geometry_msgs.PoseStamped"] = msgspec.field(default_factory=list)
 
-    __msgtype__: ClassVar[str] = 'nav_msgs/msg/LoadMapRequest'
-    __hash__: ClassVar[str] = 'RIHS01_1a192ac56c40fed2767dac26f0b371785372276bd465c902676d2dca135aae5a'
-
-class LoadMapResponse(msgspec.Struct, frozen=True, kw_only=True):
-    map: "nav_msgs.OccupancyGrid | None" = None
-    result: int = 0
-
-    __msgtype__: ClassVar[str] = 'nav_msgs/msg/LoadMapResponse'
-    __hash__: ClassVar[str] = 'RIHS01_1a192ac56c40fed2767dac26f0b371785372276bd465c902676d2dca135aae5a'
+    __msgtype__: ClassVar[str] = 'nav_msgs/msg/Path'
+    __hash__: ClassVar[str] = 'RIHS01_1957a5bb3cee5da65c4e52e52b65a93df227efce4c20f8458b36e73066ca334b'
 
 class GetMapRequest(msgspec.Struct, frozen=True, kw_only=True):
 
@@ -75,19 +62,6 @@ class GetMapResponse(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'nav_msgs/msg/GetMapResponse'
     __hash__: ClassVar[str] = 'RIHS01_c8ae77c9995b3554b5ba80e4d4d443f970ac65143102a1d893ec24fc07b31147'
-
-class SetMapRequest(msgspec.Struct, frozen=True, kw_only=True):
-    map: "nav_msgs.OccupancyGrid | None" = None
-    initial_pose: "geometry_msgs.PoseWithCovarianceStamped | None" = None
-
-    __msgtype__: ClassVar[str] = 'nav_msgs/msg/SetMapRequest'
-    __hash__: ClassVar[str] = 'RIHS01_5e11a5b2ca53d8ae85b666a019f16c9904ebc787828f1f566c4e048a1ddedfb4'
-
-class SetMapResponse(msgspec.Struct, frozen=True, kw_only=True):
-    success: bool = False
-
-    __msgtype__: ClassVar[str] = 'nav_msgs/msg/SetMapResponse'
-    __hash__: ClassVar[str] = 'RIHS01_5e11a5b2ca53d8ae85b666a019f16c9904ebc787828f1f566c4e048a1ddedfb4'
 
 class GetPlanRequest(msgspec.Struct, frozen=True, kw_only=True):
     start: "geometry_msgs.PoseStamped | None" = None
@@ -102,4 +76,30 @@ class GetPlanResponse(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'nav_msgs/msg/GetPlanResponse'
     __hash__: ClassVar[str] = 'RIHS01_234f7aff100f5edb8150366601687b027bcdc253db47decb88fff846193fe5e8'
+
+class LoadMapRequest(msgspec.Struct, frozen=True, kw_only=True):
+    map_url: str = ""
+
+    __msgtype__: ClassVar[str] = 'nav_msgs/msg/LoadMapRequest'
+    __hash__: ClassVar[str] = 'RIHS01_1a192ac56c40fed2767dac26f0b371785372276bd465c902676d2dca135aae5a'
+
+class LoadMapResponse(msgspec.Struct, frozen=True, kw_only=True):
+    map: "nav_msgs.OccupancyGrid | None" = None
+    result: int = 0
+
+    __msgtype__: ClassVar[str] = 'nav_msgs/msg/LoadMapResponse'
+    __hash__: ClassVar[str] = 'RIHS01_1a192ac56c40fed2767dac26f0b371785372276bd465c902676d2dca135aae5a'
+
+class SetMapRequest(msgspec.Struct, frozen=True, kw_only=True):
+    map: "nav_msgs.OccupancyGrid | None" = None
+    initial_pose: "geometry_msgs.PoseWithCovarianceStamped | None" = None
+
+    __msgtype__: ClassVar[str] = 'nav_msgs/msg/SetMapRequest'
+    __hash__: ClassVar[str] = 'RIHS01_5e11a5b2ca53d8ae85b666a019f16c9904ebc787828f1f566c4e048a1ddedfb4'
+
+class SetMapResponse(msgspec.Struct, frozen=True, kw_only=True):
+    success: bool = False
+
+    __msgtype__: ClassVar[str] = 'nav_msgs/msg/SetMapResponse'
+    __hash__: ClassVar[str] = 'RIHS01_5e11a5b2ca53d8ae85b666a019f16c9904ebc787828f1f566c4e048a1ddedfb4'
 

--- a/crates/hiroz-msgs/python/hiroz_msgs_py/types/rcl_interfaces.py
+++ b/crates/hiroz-msgs/python/hiroz_msgs_py/types/rcl_interfaces.py
@@ -2,13 +2,13 @@
 import msgspec
 from typing import ClassVar
 
-class ParameterEventDescriptors(msgspec.Struct, frozen=True, kw_only=True):
-    new_parameters: list["rcl_interfaces.ParameterDescriptor"] = msgspec.field(default_factory=list)
-    changed_parameters: list["rcl_interfaces.ParameterDescriptor"] = msgspec.field(default_factory=list)
-    deleted_parameters: list["rcl_interfaces.ParameterDescriptor"] = msgspec.field(default_factory=list)
+class FloatingPointRange(msgspec.Struct, frozen=True, kw_only=True):
+    from_value: float = 0.0
+    to_value: float = 0.0
+    step: float = 0.0
 
-    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ParameterEventDescriptors'
-    __hash__: ClassVar[str] = 'RIHS01_456f90915d72ef69379e702ef3ba2a115098ff677eab9c0080fa11239c6b147e'
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/FloatingPointRange'
+    __hash__: ClassVar[str] = 'RIHS01_e6af23a23c177fee5f3075c8b1e435162a9b63c863d78c06017460b49684262d'
 
 class IntegerRange(msgspec.Struct, frozen=True, kw_only=True):
     from_value: int = 0
@@ -18,20 +18,26 @@ class IntegerRange(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/IntegerRange'
     __hash__: ClassVar[str] = 'RIHS01_f7b7fdc0f65f07702e099218e13288c3963bcb9345bde78b560e6cd19800fc5a'
 
+class ListParametersResult(msgspec.Struct, frozen=True, kw_only=True):
+    names: list[str] = msgspec.field(default_factory=list)
+    prefixes: list[str] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ListParametersResult'
+    __hash__: ClassVar[str] = 'RIHS01_237ae3428413dcbcfb452b510c42355f3a2b021dc091afa3e18526d57022f1cd'
+
+class LoggerLevel(msgspec.Struct, frozen=True, kw_only=True):
+    name: str = ""
+    level: int = 0
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/LoggerLevel'
+    __hash__: ClassVar[str] = 'RIHS01_95785cc42f048ab4f395af65035aeaf2181d8e1c7a44edb8ad4558445fdb43c0'
+
 class Parameter(msgspec.Struct, frozen=True, kw_only=True):
     name: str = ""
     value: "rcl_interfaces.ParameterValue | None" = None
 
     __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/Parameter'
     __hash__: ClassVar[str] = 'RIHS01_ddfe6442cffc462317adb5c92536a7b6dd55858c5c3e1e328165a6b73c2831af'
-
-class FloatingPointRange(msgspec.Struct, frozen=True, kw_only=True):
-    from_value: float = 0.0
-    to_value: float = 0.0
-    step: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/FloatingPointRange'
-    __hash__: ClassVar[str] = 'RIHS01_e6af23a23c177fee5f3075c8b1e435162a9b63c863d78c06017460b49684262d'
 
 class ParameterDescriptor(msgspec.Struct, frozen=True, kw_only=True):
     name: str = ""
@@ -45,6 +51,29 @@ class ParameterDescriptor(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ParameterDescriptor'
     __hash__: ClassVar[str] = 'RIHS01_52175dbfda6c51153101d33d2a9da05743f66f02d5ab2ca9ec4709b46b73d704'
+
+class ParameterEvent(msgspec.Struct, frozen=True, kw_only=True):
+    stamp: "builtin_interfaces.Time | None" = msgspec.field(default_factory=lambda: {'sec': 0, 'nanosec': 0})
+    node: str = ""
+    new_parameters: list["rcl_interfaces.Parameter"] = msgspec.field(default_factory=list)
+    changed_parameters: list["rcl_interfaces.Parameter"] = msgspec.field(default_factory=list)
+    deleted_parameters: list["rcl_interfaces.Parameter"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ParameterEvent'
+    __hash__: ClassVar[str] = 'RIHS01_043e627780fcad87a22d225bc2a037361dba713fca6a6b9f4b869a5aa0393204'
+
+class ParameterEventDescriptors(msgspec.Struct, frozen=True, kw_only=True):
+    new_parameters: list["rcl_interfaces.ParameterDescriptor"] = msgspec.field(default_factory=list)
+    changed_parameters: list["rcl_interfaces.ParameterDescriptor"] = msgspec.field(default_factory=list)
+    deleted_parameters: list["rcl_interfaces.ParameterDescriptor"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ParameterEventDescriptors'
+    __hash__: ClassVar[str] = 'RIHS01_456f90915d72ef69379e702ef3ba2a115098ff677eab9c0080fa11239c6b147e'
+
+class ParameterType(msgspec.Struct, frozen=True, kw_only=True):
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ParameterType'
+    __hash__: ClassVar[str] = 'RIHS01_df29ed057a834862187be24dd187d981790ff3ea6502f4cd27b432cbc42c6d46'
 
 class ParameterValue(msgspec.Struct, frozen=True, kw_only=True):
     type: int = 0
@@ -61,34 +90,19 @@ class ParameterValue(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ParameterValue'
     __hash__: ClassVar[str] = 'RIHS01_115fc089a387e23c7ecd3525c9189c379109119d6ab82e8dfbde0fdf6a7f9b68'
 
+class SetLoggerLevelsResult(msgspec.Struct, frozen=True, kw_only=True):
+    successful: bool = False
+    reason: str = ""
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/SetLoggerLevelsResult'
+    __hash__: ClassVar[str] = 'RIHS01_9316e5e679a5b72d2dd7fd80c539bae9e106fa0890a06dc5da3a8177a3ff6909'
+
 class SetParametersResult(msgspec.Struct, frozen=True, kw_only=True):
     successful: bool = False
     reason: str = ""
 
     __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/SetParametersResult'
     __hash__: ClassVar[str] = 'RIHS01_cfcc0fb0371ee5159b403960ef4300f8f9d2f1fd6117c8666b7f9654d528a9b1'
-
-class ParameterEvent(msgspec.Struct, frozen=True, kw_only=True):
-    stamp: "builtin_interfaces.Time | None" = msgspec.field(default_factory=lambda: {'sec': 0, 'nanosec': 0})
-    node: str = ""
-    new_parameters: list["rcl_interfaces.Parameter"] = msgspec.field(default_factory=list)
-    changed_parameters: list["rcl_interfaces.Parameter"] = msgspec.field(default_factory=list)
-    deleted_parameters: list["rcl_interfaces.Parameter"] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ParameterEvent'
-    __hash__: ClassVar[str] = 'RIHS01_043e627780fcad87a22d225bc2a037361dba713fca6a6b9f4b869a5aa0393204'
-
-class ListParametersResult(msgspec.Struct, frozen=True, kw_only=True):
-    names: list[str] = msgspec.field(default_factory=list)
-    prefixes: list[str] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ListParametersResult'
-    __hash__: ClassVar[str] = 'RIHS01_237ae3428413dcbcfb452b510c42355f3a2b021dc091afa3e18526d57022f1cd'
-
-class ParameterType(msgspec.Struct, frozen=True, kw_only=True):
-
-    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ParameterType'
-    __hash__: ClassVar[str] = 'RIHS01_df29ed057a834862187be24dd187d981790ff3ea6502f4cd27b432cbc42c6d46'
 
 class DescribeParametersRequest(msgspec.Struct, frozen=True, kw_only=True):
     names: list[str] = msgspec.field(default_factory=list)
@@ -101,6 +115,67 @@ class DescribeParametersResponse(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/DescribeParametersResponse'
     __hash__: ClassVar[str] = 'RIHS01_845b484d71eb0673dae682f2e3ba3c4851a65a3dcfb97bddd82c5b57e91e4cff'
+
+class GetLoggerLevelsRequest(msgspec.Struct, frozen=True, kw_only=True):
+    names: list[str] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/GetLoggerLevelsRequest'
+    __hash__: ClassVar[str] = 'RIHS01_03bf1bebd0d6514c7ed0ba7c5e08dc9f2f39c759fe99e1e30ea4157d7674f72d'
+
+class GetLoggerLevelsResponse(msgspec.Struct, frozen=True, kw_only=True):
+    levels: list["rcl_interfaces.LoggerLevel"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/GetLoggerLevelsResponse'
+    __hash__: ClassVar[str] = 'RIHS01_03bf1bebd0d6514c7ed0ba7c5e08dc9f2f39c759fe99e1e30ea4157d7674f72d'
+
+class GetParameterTypesRequest(msgspec.Struct, frozen=True, kw_only=True):
+    names: list[str] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/GetParameterTypesRequest'
+    __hash__: ClassVar[str] = 'RIHS01_da199c878688b3e530bdfe3ca8f74cb9fa0c303101e980a9e8f260e25e1c80ca'
+
+class GetParameterTypesResponse(msgspec.Struct, frozen=True, kw_only=True):
+    types: bytes = b""
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/GetParameterTypesResponse'
+    __hash__: ClassVar[str] = 'RIHS01_da199c878688b3e530bdfe3ca8f74cb9fa0c303101e980a9e8f260e25e1c80ca'
+
+class GetParametersRequest(msgspec.Struct, frozen=True, kw_only=True):
+    names: list[str] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/GetParametersRequest'
+    __hash__: ClassVar[str] = 'RIHS01_bf9803d5c74cf989a5de3e0c2e99444599a627c7ff75f97b8c05b01003675cbc'
+
+class GetParametersResponse(msgspec.Struct, frozen=True, kw_only=True):
+    values: list["rcl_interfaces.ParameterValue"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/GetParametersResponse'
+    __hash__: ClassVar[str] = 'RIHS01_bf9803d5c74cf989a5de3e0c2e99444599a627c7ff75f97b8c05b01003675cbc'
+
+class ListParametersRequest(msgspec.Struct, frozen=True, kw_only=True):
+    prefixes: list[str] = msgspec.field(default_factory=list)
+    depth: int = 0
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ListParametersRequest'
+    __hash__: ClassVar[str] = 'RIHS01_3e6062bfbb27bfb8730d4cef2558221f51a11646d78e7bb30a1e83afac3aad9d'
+
+class ListParametersResponse(msgspec.Struct, frozen=True, kw_only=True):
+    result: "rcl_interfaces.ListParametersResult | None" = None
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ListParametersResponse'
+    __hash__: ClassVar[str] = 'RIHS01_3e6062bfbb27bfb8730d4cef2558221f51a11646d78e7bb30a1e83afac3aad9d'
+
+class SetLoggerLevelsRequest(msgspec.Struct, frozen=True, kw_only=True):
+    levels: list["rcl_interfaces.LoggerLevel"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/SetLoggerLevelsRequest'
+    __hash__: ClassVar[str] = 'RIHS01_3ff86cb4e91fbf9abae15c234ecc874448de6ece8e193401c077cf116e4f6d78'
+
+class SetLoggerLevelsResponse(msgspec.Struct, frozen=True, kw_only=True):
+    results: list["rcl_interfaces.SetLoggerLevelsResult"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/SetLoggerLevelsResponse'
+    __hash__: ClassVar[str] = 'RIHS01_3ff86cb4e91fbf9abae15c234ecc874448de6ece8e193401c077cf116e4f6d78'
 
 class SetParametersAtomicallyRequest(msgspec.Struct, frozen=True, kw_only=True):
     parameters: list["rcl_interfaces.Parameter"] = msgspec.field(default_factory=list)
@@ -125,41 +200,4 @@ class SetParametersResponse(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/SetParametersResponse'
     __hash__: ClassVar[str] = 'RIHS01_56eed9a67e169f9cb6c1f987bc88f868c14a8fc9f743a263bc734c154015d7e0'
-
-class GetParameterTypesRequest(msgspec.Struct, frozen=True, kw_only=True):
-    names: list[str] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/GetParameterTypesRequest'
-    __hash__: ClassVar[str] = 'RIHS01_da199c878688b3e530bdfe3ca8f74cb9fa0c303101e980a9e8f260e25e1c80ca'
-
-class GetParameterTypesResponse(msgspec.Struct, frozen=True, kw_only=True):
-    types: bytes = b""
-
-    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/GetParameterTypesResponse'
-    __hash__: ClassVar[str] = 'RIHS01_da199c878688b3e530bdfe3ca8f74cb9fa0c303101e980a9e8f260e25e1c80ca'
-
-class ListParametersRequest(msgspec.Struct, frozen=True, kw_only=True):
-    prefixes: list[str] = msgspec.field(default_factory=list)
-    depth: int = 0
-
-    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ListParametersRequest'
-    __hash__: ClassVar[str] = 'RIHS01_3e6062bfbb27bfb8730d4cef2558221f51a11646d78e7bb30a1e83afac3aad9d'
-
-class ListParametersResponse(msgspec.Struct, frozen=True, kw_only=True):
-    result: "rcl_interfaces.ListParametersResult | None" = None
-
-    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/ListParametersResponse'
-    __hash__: ClassVar[str] = 'RIHS01_3e6062bfbb27bfb8730d4cef2558221f51a11646d78e7bb30a1e83afac3aad9d'
-
-class GetParametersRequest(msgspec.Struct, frozen=True, kw_only=True):
-    names: list[str] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/GetParametersRequest'
-    __hash__: ClassVar[str] = 'RIHS01_bf9803d5c74cf989a5de3e0c2e99444599a627c7ff75f97b8c05b01003675cbc'
-
-class GetParametersResponse(msgspec.Struct, frozen=True, kw_only=True):
-    values: list["rcl_interfaces.ParameterValue"] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'rcl_interfaces/msg/GetParametersResponse'
-    __hash__: ClassVar[str] = 'RIHS01_bf9803d5c74cf989a5de3e0c2e99444599a627c7ff75f97b8c05b01003675cbc'
 

--- a/crates/hiroz-msgs/python/hiroz_msgs_py/types/sensor_msgs.py
+++ b/crates/hiroz-msgs/python/hiroz_msgs_py/types/sensor_msgs.py
@@ -2,99 +2,6 @@
 import msgspec
 from typing import ClassVar
 
-class RegionOfInterest(msgspec.Struct, frozen=True, kw_only=True):
-    x_offset: int = 0
-    y_offset: int = 0
-    height: int = 0
-    width: int = 0
-    do_rectify: bool = False
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/RegionOfInterest'
-    __hash__: ClassVar[str] = 'RIHS01_ad16bcba5f9131dcdba6fbded19f726f5440e3c513b4fb586dd3027eeed8abb1'
-
-class RelativeHumidity(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    relative_humidity: float = 0.0
-    variance: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/RelativeHumidity'
-    __hash__: ClassVar[str] = 'RIHS01_8687c99b4fb393cb2e545e407b5ea7fd0b5d8960bcd849a0f86c544740138839'
-
-class Illuminance(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    illuminance: float = 0.0
-    variance: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/Illuminance'
-    __hash__: ClassVar[str] = 'RIHS01_b954b25f452fcf81a91c9c2a7e3b3fd85c4c873d452aecb3cfd8fd1da732a22d'
-
-class JoyFeedbackArray(msgspec.Struct, frozen=True, kw_only=True):
-    array: list["sensor_msgs.JoyFeedback"] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/JoyFeedbackArray'
-    __hash__: ClassVar[str] = 'RIHS01_3287c32e1b688cae04555e465443df3cca7dae76ee4ebf85c4658d585037bcaa'
-
-class PointCloud(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    points: list["geometry_msgs.Point32"] = msgspec.field(default_factory=list)
-    channels: list["sensor_msgs.ChannelFloat32"] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/PointCloud'
-    __hash__: ClassVar[str] = 'RIHS01_614593df71d3c2b9bd4604a71b750fd218f0d65c045ea988b713719455a65b3b'
-
-class Range(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    radiation_type: int = 0
-    field_of_view: float = 0.0
-    min_range: float = 0.0
-    max_range: float = 0.0
-    range: float = 0.0
-    variance: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/Range'
-    __hash__: ClassVar[str] = 'RIHS01_b42b62562e93cbfe9d42b82fe5994dfa3d63d7d5c90a317981703f7388adff3a'
-
-class JointState(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    name: list[str] = msgspec.field(default_factory=list)
-    position: list[float] = msgspec.field(default_factory=list)
-    velocity: list[float] = msgspec.field(default_factory=list)
-    effort: list[float] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/JointState'
-    __hash__: ClassVar[str] = 'RIHS01_a13ee3a330e346c9d87b5aa18d24e11690752bd33a0350f11c5882bc9179260e'
-
-class FluidPressure(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    fluid_pressure: float = 0.0
-    variance: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/FluidPressure'
-    __hash__: ClassVar[str] = 'RIHS01_22dfb2b145a0bd5a31a1ac3882a1b32148b51d9b2f3bab250290d66f3595bc32'
-
-class MultiEchoLaserScan(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    angle_min: float = 0.0
-    angle_max: float = 0.0
-    angle_increment: float = 0.0
-    time_increment: float = 0.0
-    scan_time: float = 0.0
-    range_min: float = 0.0
-    range_max: float = 0.0
-    ranges: list["sensor_msgs.LaserEcho"] = msgspec.field(default_factory=list)
-    intensities: list["sensor_msgs.LaserEcho"] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/MultiEchoLaserScan'
-    __hash__: ClassVar[str] = 'RIHS01_ba5eac341cd5bbb2701527aa4568e8baec172b69cadb9a1945d6f149d087ee48'
-
-class MagneticField(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    magnetic_field: "geometry_msgs.Vector3 | None" = None
-    magnetic_field_covariance: list[float] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/MagneticField'
-    __hash__: ClassVar[str] = 'RIHS01_e80f32f56a20486c9923008fc1a1db07bbb273cbbf6a5b3bfa00835ee00e4dff'
-
 class BatteryState(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
     voltage: float = 0.0
@@ -116,88 +23,6 @@ class BatteryState(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'sensor_msgs/msg/BatteryState'
     __hash__: ClassVar[str] = 'RIHS01_4bee5dfce981c98faa6828b868307a0a73f992ed0789f374ee96c8f840e69741'
 
-class TimeReference(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    time_ref: "builtin_interfaces.Time | None" = msgspec.field(default_factory=lambda: {'sec': 0, 'nanosec': 0})
-    source: str = ""
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/TimeReference'
-    __hash__: ClassVar[str] = 'RIHS01_dd66e84cf40bbb5d5a40472e6ecf2675a031334d4c426abdb2ad41801a8efc99'
-
-class NavSatFix(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    status: "sensor_msgs.NavSatStatus | None" = None
-    latitude: float = 0.0
-    longitude: float = 0.0
-    altitude: float = 0.0
-    position_covariance: list[float] = msgspec.field(default_factory=list)
-    position_covariance_type: int = 0
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/NavSatFix'
-    __hash__: ClassVar[str] = 'RIHS01_62223ab3fe210a15976021da7afddc9e200dc9ec75231c1b6a557fc598a65404'
-
-class MultiDOFJointState(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    joint_names: list[str] = msgspec.field(default_factory=list)
-    transforms: list["geometry_msgs.Transform"] = msgspec.field(default_factory=list)
-    twist: list["geometry_msgs.Twist"] = msgspec.field(default_factory=list)
-    wrench: list["geometry_msgs.Wrench"] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/MultiDOFJointState'
-    __hash__: ClassVar[str] = 'RIHS01_4d4ded702cfba7ff3ec783835c1a1425f75e53939a430ff355d1fee4b3bbc40b'
-
-class CompressedImage(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    format: str = ""
-    data: bytes = b""
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/CompressedImage'
-    __hash__: ClassVar[str] = 'RIHS01_15640771531571185e2efc8a100baf923961a4d15d5569652e6cb6691e8e371a'
-
-class Image(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    height: int = 0
-    width: int = 0
-    encoding: str = ""
-    is_bigendian: int = 0
-    step: int = 0
-    data: bytes = b""
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/Image'
-    __hash__: ClassVar[str] = 'RIHS01_d31d41a9a4c4bc8eae9be757b0beed306564f7526c88ea6a4588fb9582527d47'
-
-class PointField(msgspec.Struct, frozen=True, kw_only=True):
-    name: str = ""
-    offset: int = 0
-    datatype: int = 0
-    count: int = 0
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/PointField'
-    __hash__: ClassVar[str] = 'RIHS01_5c6a4750728c2bcfbbf7037225b20b02d4429634732146b742dee1726637ef01'
-
-class JoyFeedback(msgspec.Struct, frozen=True, kw_only=True):
-    type: int = 0
-    id: int = 0
-    intensity: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/JoyFeedback'
-    __hash__: ClassVar[str] = 'RIHS01_231dd362f71d6fc08272770d07120ad5fe5874ce2dbac70109b28986834290cd'
-
-class LaserScan(msgspec.Struct, frozen=True, kw_only=True):
-    header: "std_msgs.Header | None" = None
-    angle_min: float = 0.0
-    angle_max: float = 0.0
-    angle_increment: float = 0.0
-    time_increment: float = 0.0
-    scan_time: float = 0.0
-    range_min: float = 0.0
-    range_max: float = 0.0
-    ranges: list[float] = msgspec.field(default_factory=list)
-    intensities: list[float] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/LaserScan'
-    __hash__: ClassVar[str] = 'RIHS01_64c191398013af96509d518dac71d5164f9382553fce5c1f8cca5be7924bd828'
-
 class CameraInfo(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
     height: int = 0
@@ -214,27 +39,48 @@ class CameraInfo(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'sensor_msgs/msg/CameraInfo'
     __hash__: ClassVar[str] = 'RIHS01_b3dfd68ff46c9d56c80fd3bd4ed22c7a4ddce8c8348f2f59c299e73118e7e275'
 
-class LaserEcho(msgspec.Struct, frozen=True, kw_only=True):
-    echoes: list[float] = msgspec.field(default_factory=list)
+class ChannelFloat32(msgspec.Struct, frozen=True, kw_only=True):
+    name: str = ""
+    values: list[float] = msgspec.field(default_factory=list)
 
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/LaserEcho'
-    __hash__: ClassVar[str] = 'RIHS01_0fbc05a0db7d37fe52c0f0375356db55da0046f7ef5bd27ca6b34bd0582bc952'
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/ChannelFloat32'
+    __hash__: ClassVar[str] = 'RIHS01_92665437ddf39346f4ba39ee32e648390605b633cc077d40f4bd4d7b58af6cd4'
 
-class Temperature(msgspec.Struct, frozen=True, kw_only=True):
+class CompressedImage(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
-    temperature: float = 0.0
+    format: str = ""
+    data: bytes = b""
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/CompressedImage'
+    __hash__: ClassVar[str] = 'RIHS01_15640771531571185e2efc8a100baf923961a4d15d5569652e6cb6691e8e371a'
+
+class FluidPressure(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    fluid_pressure: float = 0.0
     variance: float = 0.0
 
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/Temperature'
-    __hash__: ClassVar[str] = 'RIHS01_72514a14126ab9f8a9abec974c78e5610a367b59db5da355ff1fb982d5bad4b8'
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/FluidPressure'
+    __hash__: ClassVar[str] = 'RIHS01_22dfb2b145a0bd5a31a1ac3882a1b32148b51d9b2f3bab250290d66f3595bc32'
 
-class Joy(msgspec.Struct, frozen=True, kw_only=True):
+class Illuminance(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
-    axes: list[float] = msgspec.field(default_factory=list)
-    buttons: list[int] = msgspec.field(default_factory=list)
+    illuminance: float = 0.0
+    variance: float = 0.0
 
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/Joy'
-    __hash__: ClassVar[str] = 'RIHS01_0d356c79cad3401e35ffeb75a96a96e08be3ef896b8b83841d73e890989372c5'
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/Illuminance'
+    __hash__: ClassVar[str] = 'RIHS01_b954b25f452fcf81a91c9c2a7e3b3fd85c4c873d452aecb3cfd8fd1da732a22d'
+
+class Image(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    height: int = 0
+    width: int = 0
+    encoding: str = ""
+    is_bigendian: int = 0
+    step: int = 0
+    data: bytes = b""
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/Image'
+    __hash__: ClassVar[str] = 'RIHS01_d31d41a9a4c4bc8eae9be757b0beed306564f7526c88ea6a4588fb9582527d47'
 
 class Imu(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
@@ -247,6 +93,119 @@ class Imu(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'sensor_msgs/msg/Imu'
     __hash__: ClassVar[str] = 'RIHS01_7d9a00ff131080897a5ec7e26e315954b8eae3353c3f995c55faf71574000b5b'
+
+class JointState(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    name: list[str] = msgspec.field(default_factory=list)
+    position: list[float] = msgspec.field(default_factory=list)
+    velocity: list[float] = msgspec.field(default_factory=list)
+    effort: list[float] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/JointState'
+    __hash__: ClassVar[str] = 'RIHS01_a13ee3a330e346c9d87b5aa18d24e11690752bd33a0350f11c5882bc9179260e'
+
+class Joy(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    axes: list[float] = msgspec.field(default_factory=list)
+    buttons: list[int] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/Joy'
+    __hash__: ClassVar[str] = 'RIHS01_0d356c79cad3401e35ffeb75a96a96e08be3ef896b8b83841d73e890989372c5'
+
+class JoyFeedback(msgspec.Struct, frozen=True, kw_only=True):
+    type: int = 0
+    id: int = 0
+    intensity: float = 0.0
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/JoyFeedback'
+    __hash__: ClassVar[str] = 'RIHS01_231dd362f71d6fc08272770d07120ad5fe5874ce2dbac70109b28986834290cd'
+
+class JoyFeedbackArray(msgspec.Struct, frozen=True, kw_only=True):
+    array: list["sensor_msgs.JoyFeedback"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/JoyFeedbackArray'
+    __hash__: ClassVar[str] = 'RIHS01_3287c32e1b688cae04555e465443df3cca7dae76ee4ebf85c4658d585037bcaa'
+
+class LaserEcho(msgspec.Struct, frozen=True, kw_only=True):
+    echoes: list[float] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/LaserEcho'
+    __hash__: ClassVar[str] = 'RIHS01_0fbc05a0db7d37fe52c0f0375356db55da0046f7ef5bd27ca6b34bd0582bc952'
+
+class LaserScan(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    angle_min: float = 0.0
+    angle_max: float = 0.0
+    angle_increment: float = 0.0
+    time_increment: float = 0.0
+    scan_time: float = 0.0
+    range_min: float = 0.0
+    range_max: float = 0.0
+    ranges: list[float] = msgspec.field(default_factory=list)
+    intensities: list[float] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/LaserScan'
+    __hash__: ClassVar[str] = 'RIHS01_64c191398013af96509d518dac71d5164f9382553fce5c1f8cca5be7924bd828'
+
+class MagneticField(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    magnetic_field: "geometry_msgs.Vector3 | None" = None
+    magnetic_field_covariance: list[float] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/MagneticField'
+    __hash__: ClassVar[str] = 'RIHS01_e80f32f56a20486c9923008fc1a1db07bbb273cbbf6a5b3bfa00835ee00e4dff'
+
+class MultiDOFJointState(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    joint_names: list[str] = msgspec.field(default_factory=list)
+    transforms: list["geometry_msgs.Transform"] = msgspec.field(default_factory=list)
+    twist: list["geometry_msgs.Twist"] = msgspec.field(default_factory=list)
+    wrench: list["geometry_msgs.Wrench"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/MultiDOFJointState'
+    __hash__: ClassVar[str] = 'RIHS01_4d4ded702cfba7ff3ec783835c1a1425f75e53939a430ff355d1fee4b3bbc40b'
+
+class MultiEchoLaserScan(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    angle_min: float = 0.0
+    angle_max: float = 0.0
+    angle_increment: float = 0.0
+    time_increment: float = 0.0
+    scan_time: float = 0.0
+    range_min: float = 0.0
+    range_max: float = 0.0
+    ranges: list["sensor_msgs.LaserEcho"] = msgspec.field(default_factory=list)
+    intensities: list["sensor_msgs.LaserEcho"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/MultiEchoLaserScan'
+    __hash__: ClassVar[str] = 'RIHS01_ba5eac341cd5bbb2701527aa4568e8baec172b69cadb9a1945d6f149d087ee48'
+
+class NavSatFix(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    status: "sensor_msgs.NavSatStatus | None" = None
+    latitude: float = 0.0
+    longitude: float = 0.0
+    altitude: float = 0.0
+    position_covariance: list[float] = msgspec.field(default_factory=list)
+    position_covariance_type: int = 0
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/NavSatFix'
+    __hash__: ClassVar[str] = 'RIHS01_62223ab3fe210a15976021da7afddc9e200dc9ec75231c1b6a557fc598a65404'
+
+class NavSatStatus(msgspec.Struct, frozen=True, kw_only=True):
+    status: int = 0
+    service: int = 0
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/NavSatStatus'
+    __hash__: ClassVar[str] = 'RIHS01_d1ed3befa628e09571bd273b888ba1c1fd187c9a5e0006b385d7e5e9095a3204'
+
+class PointCloud(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    points: list["geometry_msgs.Point32"] = msgspec.field(default_factory=list)
+    channels: list["sensor_msgs.ChannelFloat32"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/PointCloud'
+    __hash__: ClassVar[str] = 'RIHS01_614593df71d3c2b9bd4604a71b750fd218f0d65c045ea988b713719455a65b3b'
 
 class PointCloud2(msgspec.Struct, frozen=True, kw_only=True):
     header: "std_msgs.Header | None" = None
@@ -262,19 +221,60 @@ class PointCloud2(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'sensor_msgs/msg/PointCloud2'
     __hash__: ClassVar[str] = 'RIHS01_9198cabf7da3796ae6fe19c4cb3bdd3525492988c70522628af5daa124bae2b5'
 
-class NavSatStatus(msgspec.Struct, frozen=True, kw_only=True):
-    status: int = 0
-    service: int = 0
-
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/NavSatStatus'
-    __hash__: ClassVar[str] = 'RIHS01_d1ed3befa628e09571bd273b888ba1c1fd187c9a5e0006b385d7e5e9095a3204'
-
-class ChannelFloat32(msgspec.Struct, frozen=True, kw_only=True):
+class PointField(msgspec.Struct, frozen=True, kw_only=True):
     name: str = ""
-    values: list[float] = msgspec.field(default_factory=list)
+    offset: int = 0
+    datatype: int = 0
+    count: int = 0
 
-    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/ChannelFloat32'
-    __hash__: ClassVar[str] = 'RIHS01_92665437ddf39346f4ba39ee32e648390605b633cc077d40f4bd4d7b58af6cd4'
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/PointField'
+    __hash__: ClassVar[str] = 'RIHS01_5c6a4750728c2bcfbbf7037225b20b02d4429634732146b742dee1726637ef01'
+
+class Range(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    radiation_type: int = 0
+    field_of_view: float = 0.0
+    min_range: float = 0.0
+    max_range: float = 0.0
+    range: float = 0.0
+    variance: float = 0.0
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/Range'
+    __hash__: ClassVar[str] = 'RIHS01_b42b62562e93cbfe9d42b82fe5994dfa3d63d7d5c90a317981703f7388adff3a'
+
+class RegionOfInterest(msgspec.Struct, frozen=True, kw_only=True):
+    x_offset: int = 0
+    y_offset: int = 0
+    height: int = 0
+    width: int = 0
+    do_rectify: bool = False
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/RegionOfInterest'
+    __hash__: ClassVar[str] = 'RIHS01_ad16bcba5f9131dcdba6fbded19f726f5440e3c513b4fb586dd3027eeed8abb1'
+
+class RelativeHumidity(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    relative_humidity: float = 0.0
+    variance: float = 0.0
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/RelativeHumidity'
+    __hash__: ClassVar[str] = 'RIHS01_8687c99b4fb393cb2e545e407b5ea7fd0b5d8960bcd849a0f86c544740138839'
+
+class Temperature(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    temperature: float = 0.0
+    variance: float = 0.0
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/Temperature'
+    __hash__: ClassVar[str] = 'RIHS01_72514a14126ab9f8a9abec974c78e5610a367b59db5da355ff1fb982d5bad4b8'
+
+class TimeReference(msgspec.Struct, frozen=True, kw_only=True):
+    header: "std_msgs.Header | None" = None
+    time_ref: "builtin_interfaces.Time | None" = msgspec.field(default_factory=lambda: {'sec': 0, 'nanosec': 0})
+    source: str = ""
+
+    __msgtype__: ClassVar[str] = 'sensor_msgs/msg/TimeReference'
+    __hash__: ClassVar[str] = 'RIHS01_dd66e84cf40bbb5d5a40472e6ecf2675a031334d4c426abdb2ad41801a8efc99'
 
 class SetCameraInfoRequest(msgspec.Struct, frozen=True, kw_only=True):
     camera_info: "sensor_msgs.CameraInfo | None" = None

--- a/crates/hiroz-msgs/python/hiroz_msgs_py/types/std_msgs.py
+++ b/crates/hiroz-msgs/python/hiroz_msgs_py/types/std_msgs.py
@@ -2,33 +2,11 @@
 import msgspec
 from typing import ClassVar
 
-class MultiArrayDimension(msgspec.Struct, frozen=True, kw_only=True):
-    label: str = ""
-    size: int = 0
-    stride: int = 0
+class Bool(msgspec.Struct, frozen=True, kw_only=True):
+    data: bool = False
 
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/MultiArrayDimension'
-    __hash__: ClassVar[str] = 'RIHS01_5e773a60a4c7fc8a54985f307c7837aa2994252a126c301957a24e31282c9cbe'
-
-class UInt8MultiArray(msgspec.Struct, frozen=True, kw_only=True):
-    layout: "std_msgs.MultiArrayLayout | None" = None
-    data: bytes = b""
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt8MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_5687e861b8d307a5e48b7515467ae7a5fc2daf805bd0ce6d8e9e604bade9f385'
-
-class Int8(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int8'
-    __hash__: ClassVar[str] = 'RIHS01_26525065a403d972cb672f0777e333f0c799ad444ae5fcd79e43d1e73bd0f440'
-
-class UInt16MultiArray(msgspec.Struct, frozen=True, kw_only=True):
-    layout: "std_msgs.MultiArrayLayout | None" = None
-    data: list[int] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt16MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_94fe73428ec63baecc774f8fb82406123e9291cf728f1b7c91caf5335129492b'
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Bool'
+    __hash__: ClassVar[str] = 'RIHS01_feb91e995ff9ebd09c0cb3d2aed18b11077585839fb5db80193b62d74528f6c9'
 
 class Byte(msgspec.Struct, frozen=True, kw_only=True):
     data: int = 0
@@ -36,63 +14,18 @@ class Byte(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'std_msgs/msg/Byte'
     __hash__: ClassVar[str] = 'RIHS01_41e1a3345f73fe93ede006da826a6ee274af23dd4653976ff249b0f44e3e798f'
 
-class Int8MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+class ByteMultiArray(msgspec.Struct, frozen=True, kw_only=True):
     layout: "std_msgs.MultiArrayLayout | None" = None
-    data: list[int] = msgspec.field(default_factory=list)
+    data: bytes = b""
 
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int8MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_f21998d4b492abd63330765d75d5831238d400740386f651f13a872a4d2188db'
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/ByteMultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_972fec7f50ab3c1d06783c228e79e8a9a509021708c511c059926261ada901d4'
 
-class Float64(msgspec.Struct, frozen=True, kw_only=True):
-    data: float = 0.0
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Float64'
-    __hash__: ClassVar[str] = 'RIHS01_705ba9c3d1a09df43737eb67095534de36fd426c0587779bda2bc51fe790182a'
-
-class UInt64MultiArray(msgspec.Struct, frozen=True, kw_only=True):
-    layout: "std_msgs.MultiArrayLayout | None" = None
-    data: list[int] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt64MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_fc1c685c2f76bdc6983da025cb25d2db5fb5157b059e300f6d957d86f981b366'
-
-class Header(msgspec.Struct, frozen=True, kw_only=True):
-    stamp: "builtin_interfaces.Time | None" = msgspec.field(default_factory=lambda: {'sec': 0, 'nanosec': 0})
-    frame_id: str = ""
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Header'
-    __hash__: ClassVar[str] = 'RIHS01_f49fb3ae2cf070f793645ff749683ac6b06203e41c891e17701b1cb597ce6a01'
-
-class UInt8(msgspec.Struct, frozen=True, kw_only=True):
+class Char(msgspec.Struct, frozen=True, kw_only=True):
     data: int = 0
 
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt8'
-    __hash__: ClassVar[str] = 'RIHS01_6138bd83d8c3569cb80a667db03cfc1629f529fee79d944c39c34e352e72f010'
-
-class Empty(msgspec.Struct, frozen=True, kw_only=True):
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Empty'
-    __hash__: ClassVar[str] = 'RIHS01_20b625256f32d5dbc0d04fee44f43c41e51c70d3502f84b4a08e7a9c26a96312'
-
-class Int32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
-    layout: "std_msgs.MultiArrayLayout | None" = None
-    data: list[int] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int32MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_84a7346323525d1b4dfca899df3820f245e54009dac5a6b69217d14fdefd1701'
-
-class Int16(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int16'
-    __hash__: ClassVar[str] = 'RIHS01_1dcc3464e47c288a55f943a389d337cdb06804de3f5cd7a266b0de718eee17e5'
-
-class Float32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
-    layout: "std_msgs.MultiArrayLayout | None" = None
-    data: list[float] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Float32MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_0599f6f85b4bfca379873a0b4375a0aca022156bd2d7021275d116ed1fa8bfe0'
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Char'
+    __hash__: ClassVar[str] = 'RIHS01_3ad2d04dd29ba19d04b16659afa3ccaedd691914b02a64e82e252f2fa6a586a9'
 
 class ColorRGBA(msgspec.Struct, frozen=True, kw_only=True):
     r: float = 0.0
@@ -103,62 +36,29 @@ class ColorRGBA(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'std_msgs/msg/ColorRGBA'
     __hash__: ClassVar[str] = 'RIHS01_77a7a5b9ae477306097665106e0413ba74440245b1f3d0c6d6405fe5c7813fe8'
 
-class UInt64(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
+class Empty(msgspec.Struct, frozen=True, kw_only=True):
 
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt64'
-    __hash__: ClassVar[str] = 'RIHS01_fbdc52018fc13755dce18024d1a671c856aa8b4aaf63adfb095b608f98e8c943'
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Empty'
+    __hash__: ClassVar[str] = 'RIHS01_20b625256f32d5dbc0d04fee44f43c41e51c70d3502f84b4a08e7a9c26a96312'
 
-class MultiArrayLayout(msgspec.Struct, frozen=True, kw_only=True):
-    dim: list["std_msgs.MultiArrayDimension"] = msgspec.field(default_factory=list)
-    data_offset: int = 0
+class Float32(msgspec.Struct, frozen=True, kw_only=True):
+    data: float = 0.0
 
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/MultiArrayLayout'
-    __hash__: ClassVar[str] = 'RIHS01_4c66e6f78e740ac103a94cf63259f968e48c617e7699e829b63c21a5cb50dac6'
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Float32'
+    __hash__: ClassVar[str] = 'RIHS01_7170d3d8f841f7be3172ce5f4f59f3a4d7f63b0447e8b33327601ad64d83d6e2'
 
-class Int64(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int64'
-    __hash__: ClassVar[str] = 'RIHS01_8cd1048c2f186b6bd9a92472dc1ce51723c0833a221e2b7aecfff111774f4b49'
-
-class Int32(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int32'
-    __hash__: ClassVar[str] = 'RIHS01_b6578ded3c58c626cfe8d1a6fb6e04f706f97e9f03d2727c9ff4e74b1cef0deb'
-
-class ByteMultiArray(msgspec.Struct, frozen=True, kw_only=True):
+class Float32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     layout: "std_msgs.MultiArrayLayout | None" = None
-    data: bytes = b""
+    data: list[float] = msgspec.field(default_factory=list)
 
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/ByteMultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_972fec7f50ab3c1d06783c228e79e8a9a509021708c511c059926261ada901d4'
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Float32MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_0599f6f85b4bfca379873a0b4375a0aca022156bd2d7021275d116ed1fa8bfe0'
 
-class Int16MultiArray(msgspec.Struct, frozen=True, kw_only=True):
-    layout: "std_msgs.MultiArrayLayout | None" = None
-    data: list[int] = msgspec.field(default_factory=list)
+class Float64(msgspec.Struct, frozen=True, kw_only=True):
+    data: float = 0.0
 
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int16MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_b58810e8e5b90fb19a5062469eb8409f5ab11a446d60de7157a1457e52a076ce'
-
-class Char(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Char'
-    __hash__: ClassVar[str] = 'RIHS01_3ad2d04dd29ba19d04b16659afa3ccaedd691914b02a64e82e252f2fa6a586a9'
-
-class UInt32(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt32'
-    __hash__: ClassVar[str] = 'RIHS01_a5c874829b752bc5fa190024b0ad76f578cc278271e855c7d02a818b3516fb4a'
-
-class UInt16(msgspec.Struct, frozen=True, kw_only=True):
-    data: int = 0
-
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt16'
-    __hash__: ClassVar[str] = 'RIHS01_08a406e4b022bc22e907f985d6a9e9dd1d4fbecae573549cf49350113e7757b1'
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Float64'
+    __hash__: ClassVar[str] = 'RIHS01_705ba9c3d1a09df43737eb67095534de36fd426c0587779bda2bc51fe790182a'
 
 class Float64MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     layout: "std_msgs.MultiArrayLayout | None" = None
@@ -167,24 +67,44 @@ class Float64MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'std_msgs/msg/Float64MultiArray'
     __hash__: ClassVar[str] = 'RIHS01_1025ddc6b9552d191f89ef1a8d2f60f3d373e28b283d8891ddcc974e8c55397f'
 
-class Float32(msgspec.Struct, frozen=True, kw_only=True):
-    data: float = 0.0
+class Header(msgspec.Struct, frozen=True, kw_only=True):
+    stamp: "builtin_interfaces.Time | None" = msgspec.field(default_factory=lambda: {'sec': 0, 'nanosec': 0})
+    frame_id: str = ""
 
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Float32'
-    __hash__: ClassVar[str] = 'RIHS01_7170d3d8f841f7be3172ce5f4f59f3a4d7f63b0447e8b33327601ad64d83d6e2'
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Header'
+    __hash__: ClassVar[str] = 'RIHS01_f49fb3ae2cf070f793645ff749683ac6b06203e41c891e17701b1cb597ce6a01'
 
-class UInt32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+class Int16(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int16'
+    __hash__: ClassVar[str] = 'RIHS01_1dcc3464e47c288a55f943a389d337cdb06804de3f5cd7a266b0de718eee17e5'
+
+class Int16MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     layout: "std_msgs.MultiArrayLayout | None" = None
     data: list[int] = msgspec.field(default_factory=list)
 
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt32MultiArray'
-    __hash__: ClassVar[str] = 'RIHS01_6c2577c7ad3cbdcc2164a41c12f1d5ad314ea320f3fb1ee47e78019fe16bb5b0'
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int16MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_b58810e8e5b90fb19a5062469eb8409f5ab11a446d60de7157a1457e52a076ce'
 
-class Bool(msgspec.Struct, frozen=True, kw_only=True):
-    data: bool = False
+class Int32(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
 
-    __msgtype__: ClassVar[str] = 'std_msgs/msg/Bool'
-    __hash__: ClassVar[str] = 'RIHS01_feb91e995ff9ebd09c0cb3d2aed18b11077585839fb5db80193b62d74528f6c9'
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int32'
+    __hash__: ClassVar[str] = 'RIHS01_b6578ded3c58c626cfe8d1a6fb6e04f706f97e9f03d2727c9ff4e74b1cef0deb'
+
+class Int32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+    layout: "std_msgs.MultiArrayLayout | None" = None
+    data: list[int] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int32MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_84a7346323525d1b4dfca899df3820f245e54009dac5a6b69217d14fdefd1701'
+
+class Int64(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int64'
+    __hash__: ClassVar[str] = 'RIHS01_8cd1048c2f186b6bd9a92472dc1ce51723c0833a221e2b7aecfff111774f4b49'
 
 class Int64MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     layout: "std_msgs.MultiArrayLayout | None" = None
@@ -193,9 +113,89 @@ class Int64MultiArray(msgspec.Struct, frozen=True, kw_only=True):
     __msgtype__: ClassVar[str] = 'std_msgs/msg/Int64MultiArray'
     __hash__: ClassVar[str] = 'RIHS01_e60f9fe34d697f0939ad49d33158693c1277fbac0e2f04b7c2995dc21c89b422'
 
+class Int8(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int8'
+    __hash__: ClassVar[str] = 'RIHS01_26525065a403d972cb672f0777e333f0c799ad444ae5fcd79e43d1e73bd0f440'
+
+class Int8MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+    layout: "std_msgs.MultiArrayLayout | None" = None
+    data: list[int] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/Int8MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_f21998d4b492abd63330765d75d5831238d400740386f651f13a872a4d2188db'
+
+class MultiArrayDimension(msgspec.Struct, frozen=True, kw_only=True):
+    label: str = ""
+    size: int = 0
+    stride: int = 0
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/MultiArrayDimension'
+    __hash__: ClassVar[str] = 'RIHS01_5e773a60a4c7fc8a54985f307c7837aa2994252a126c301957a24e31282c9cbe'
+
+class MultiArrayLayout(msgspec.Struct, frozen=True, kw_only=True):
+    dim: list["std_msgs.MultiArrayDimension"] = msgspec.field(default_factory=list)
+    data_offset: int = 0
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/MultiArrayLayout'
+    __hash__: ClassVar[str] = 'RIHS01_4c66e6f78e740ac103a94cf63259f968e48c617e7699e829b63c21a5cb50dac6'
+
 class String(msgspec.Struct, frozen=True, kw_only=True):
     data: str = ""
 
     __msgtype__: ClassVar[str] = 'std_msgs/msg/String'
     __hash__: ClassVar[str] = 'RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18'
+
+class UInt16(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt16'
+    __hash__: ClassVar[str] = 'RIHS01_08a406e4b022bc22e907f985d6a9e9dd1d4fbecae573549cf49350113e7757b1'
+
+class UInt16MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+    layout: "std_msgs.MultiArrayLayout | None" = None
+    data: list[int] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt16MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_94fe73428ec63baecc774f8fb82406123e9291cf728f1b7c91caf5335129492b'
+
+class UInt32(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt32'
+    __hash__: ClassVar[str] = 'RIHS01_a5c874829b752bc5fa190024b0ad76f578cc278271e855c7d02a818b3516fb4a'
+
+class UInt32MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+    layout: "std_msgs.MultiArrayLayout | None" = None
+    data: list[int] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt32MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_6c2577c7ad3cbdcc2164a41c12f1d5ad314ea320f3fb1ee47e78019fe16bb5b0'
+
+class UInt64(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt64'
+    __hash__: ClassVar[str] = 'RIHS01_fbdc52018fc13755dce18024d1a671c856aa8b4aaf63adfb095b608f98e8c943'
+
+class UInt64MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+    layout: "std_msgs.MultiArrayLayout | None" = None
+    data: list[int] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt64MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_fc1c685c2f76bdc6983da025cb25d2db5fb5157b059e300f6d957d86f981b366'
+
+class UInt8(msgspec.Struct, frozen=True, kw_only=True):
+    data: int = 0
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt8'
+    __hash__: ClassVar[str] = 'RIHS01_6138bd83d8c3569cb80a667db03cfc1629f529fee79d944c39c34e352e72f010'
+
+class UInt8MultiArray(msgspec.Struct, frozen=True, kw_only=True):
+    layout: "std_msgs.MultiArrayLayout | None" = None
+    data: bytes = b""
+
+    __msgtype__: ClassVar[str] = 'std_msgs/msg/UInt8MultiArray'
+    __hash__: ClassVar[str] = 'RIHS01_5687e861b8d307a5e48b7515467ae7a5fc2daf805bd0ce6d8e9e604bade9f385'
 

--- a/crates/hiroz-msgs/python/hiroz_msgs_py/types/type_description_interfaces.py
+++ b/crates/hiroz-msgs/python/hiroz_msgs_py/types/type_description_interfaces.py
@@ -2,13 +2,13 @@
 import msgspec
 from typing import ClassVar
 
-class TypeSource(msgspec.Struct, frozen=True, kw_only=True):
-    type_name: str = ""
-    encoding: str = ""
-    raw_file_contents: str = ""
+class Field(msgspec.Struct, frozen=True, kw_only=True):
+    name: str = ""
+    type: "type_description_interfaces.FieldType | None" = None
+    default_value: str = ""
 
-    __msgtype__: ClassVar[str] = 'type_description_interfaces/msg/TypeSource'
-    __hash__: ClassVar[str] = 'RIHS01_faeaec7596c04ecf5b6e99ad225e4c7cbb997ad5435f793526fb3984d011aae5'
+    __msgtype__: ClassVar[str] = 'type_description_interfaces/msg/Field'
+    __hash__: ClassVar[str] = 'RIHS01_c0b01379cd4226281285ccaf6be46653968f855f7c5e41614ff5d7a854efef7c'
 
 class FieldType(msgspec.Struct, frozen=True, kw_only=True):
     type_id: int = 0
@@ -18,21 +18,6 @@ class FieldType(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'type_description_interfaces/msg/FieldType'
     __hash__: ClassVar[str] = 'RIHS01_a70b6dd919645a03a3586f7f821defbc886ea3e531a1d95cc0f380a3973ccaa6'
-
-class TypeDescription(msgspec.Struct, frozen=True, kw_only=True):
-    type_description: "type_description_interfaces.IndividualTypeDescription | None" = None
-    referenced_type_descriptions: list["type_description_interfaces.IndividualTypeDescription"] = msgspec.field(default_factory=list)
-
-    __msgtype__: ClassVar[str] = 'type_description_interfaces/msg/TypeDescription'
-    __hash__: ClassVar[str] = 'RIHS01_739f2508c9fa3a6f330913ff5b9d25fb74159a077da71e1087f51a60c12a080b'
-
-class Field(msgspec.Struct, frozen=True, kw_only=True):
-    name: str = ""
-    type: "type_description_interfaces.FieldType | None" = None
-    default_value: str = ""
-
-    __msgtype__: ClassVar[str] = 'type_description_interfaces/msg/Field'
-    __hash__: ClassVar[str] = 'RIHS01_c0b01379cd4226281285ccaf6be46653968f855f7c5e41614ff5d7a854efef7c'
 
 class IndividualTypeDescription(msgspec.Struct, frozen=True, kw_only=True):
     type_name: str = ""
@@ -47,6 +32,21 @@ class KeyValue(msgspec.Struct, frozen=True, kw_only=True):
 
     __msgtype__: ClassVar[str] = 'type_description_interfaces/msg/KeyValue'
     __hash__: ClassVar[str] = 'RIHS01_274fe56bf14f33c7512e34c646a37579ee36779f745f049a9760763e817f0c42'
+
+class TypeDescription(msgspec.Struct, frozen=True, kw_only=True):
+    type_description: "type_description_interfaces.IndividualTypeDescription | None" = None
+    referenced_type_descriptions: list["type_description_interfaces.IndividualTypeDescription"] = msgspec.field(default_factory=list)
+
+    __msgtype__: ClassVar[str] = 'type_description_interfaces/msg/TypeDescription'
+    __hash__: ClassVar[str] = 'RIHS01_739f2508c9fa3a6f330913ff5b9d25fb74159a077da71e1087f51a60c12a080b'
+
+class TypeSource(msgspec.Struct, frozen=True, kw_only=True):
+    type_name: str = ""
+    encoding: str = ""
+    raw_file_contents: str = ""
+
+    __msgtype__: ClassVar[str] = 'type_description_interfaces/msg/TypeSource'
+    __hash__: ClassVar[str] = 'RIHS01_faeaec7596c04ecf5b6e99ad225e4c7cbb997ad5435f793526fb3984d011aae5'
 
 class GetTypeDescriptionRequest(msgspec.Struct, frozen=True, kw_only=True):
     type_name: str = ""

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -83,7 +83,19 @@ def check-python-stubs [] {
     # `touch build.rs` forces the generator to run even when cargo considers
     # the crate up to date; without it a warm target dir makes this a no-op
     # that passes without generating anything.
+    #
+    # The directory is emptied first so that *deletions* are caught too. The
+    # generator only writes files for packages it currently emits -- it never
+    # removes one -- so dropping a package's assets would otherwise leave its
+    # orphaned stub tracked and unchanged, and the check would pass. Emptying
+    # turns that into a visible ` D` entry. Verified safe: a build from an
+    # empty directory reproduces exactly the committed set (13 of 13), so this
+    # cannot ask for a legitimately-committed stub to be deleted.
+    #
+    # If the build below fails, the stubs are left deleted in the working
+    # tree; `git checkout -- <stub_dir>` restores them.
     let stub_dir = "crates/hiroz-msgs/python/hiroz_msgs_py/types"
+    rm -f ...(glob $"($stub_dir)/*.py")
     touch crates/hiroz-msgs/build.rs
     run-cmd "cargo build -j4 -p hiroz-msgs --features python_registry"
 

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -72,6 +72,35 @@ def check-rustdoc-links [] {
     }
 }
 
+def check-python-stubs [] {
+    log-step "Generated Python stubs are up to date"
+    # The stubs under crates/hiroz-msgs/python/hiroz_msgs_py/types/ are
+    # generated from the .msg/.srv assets and committed. Nothing used to check
+    # that the committed copy still matched the generator, so an asset change
+    # without a rebuild-and-commit went unnoticed -- which is how six
+    # rcl_interfaces classes fell out of the checked-in copy.
+    #
+    # `touch build.rs` forces the generator to run even when cargo considers
+    # the crate up to date; without it a warm target dir makes this a no-op
+    # that passes without generating anything.
+    let stub_dir = "crates/hiroz-msgs/python/hiroz_msgs_py/types"
+    touch crates/hiroz-msgs/build.rs
+    run-cmd "cargo build -j4 -p hiroz-msgs --features python_registry"
+
+    # `git status --porcelain`, not `git diff`: diff reports only tracked
+    # files, so a stub for a newly-added package would be generated, left
+    # untracked, and silently pass.
+    let drift = (^git status --porcelain -- $stub_dir | complete)
+    if ($drift.stdout | str trim | is-not-empty) {
+        print ($drift.stdout | str trim)
+        print (^git diff -- $stub_dir | complete | get stdout)
+        error make {
+            msg: $"generated Python stubs are stale -- run `cargo build -p hiroz-msgs --features python_registry` and commit ($stub_dir)"
+        }
+    }
+    print $"Generated Python stubs match the message assets."
+}
+
 def check-examples [] {
     log-step "Check all examples (cargo check --examples)"
     run-cmd "cargo check --examples"
@@ -109,6 +138,7 @@ def get-test-map [] {
         check-hu: { check-hu }
         check-examples: { check-examples }
         check-rustdoc-links: { check-rustdoc-links }
+        check-python-stubs: { check-python-stubs }
         check-distro-features: { check-distro-features }
         clippy-hiroz-py: { clippy-hiroz-py }
         clippy-tests: { clippy-tests }
@@ -124,6 +154,7 @@ def get-test-pipeline [] {
         "check-hu"
         "check-examples"
         "check-rustdoc-links"
+        "check-python-stubs"
         "check-distro-features"
         "clippy-hiroz-py"
         "clippy-tests"


### PR DESCRIPTION
## Summary

Closes #265. Python stubs under `crates/hiroz-msgs/python/hiroz_msgs_py/types/` come out in a different order on every build, so any build dirties the tree.

Two independent causes produce that symptom; a third change stops it recurring.

## Key Changes

**1. Sort service structs before emission** (`python_msgspec_generator.rs`)

Message groups are already sorted by name; the service `Request`/`Response` groups sharing the same generated file are not — they follow `discover_all` order, which varies by machine and filesystem. This is the cause #265 identifies. (The `srvs.sort_by` further down looks like it covers this but feeds the separate `*_srv_py` modules, not `types/<package>.py`.)

**2. Regenerate the committed stubs**

The checked-in stubs predate the message-name sort, so their classes are in no order at all — a stale baseline, and a second cause rather than a symptom of the first. Without regenerating, change 1 lands and the first build still dirties the tree, which reads as the fix not working.

Mostly reordering, but `rcl_interfaces.py` also gains six classes that had drifted out of the committed copy (`GetLoggerLevels{Request,Response}`, `SetLoggerLevels{Request,Response,Result}`, `LoggerLevel`). Nothing is removed anywhere. Not a user-facing outage: `hiroz-py` always enables `python_registry` and the build writes into the source tree, so anyone who builds already had all six.

**3. Gate it in CI**

`check-python-stubs` in `scripts/test-pure-rust.nu` regenerates and fails on any difference, run by a new `Generated Python Stubs` job and registered in the pipeline so local full-suite runs cover it too. Only viable now that 1 and 2 make the output deterministic.

Also tracks `types/__init__.py`, which `.gitignore`'s generic `_*` rule had hidden — git skips ignored files in both `diff` and `status`, so that one generated file would have sat permanently outside the gate.

## What fails without this

On `main`, a build dirties nine stub files with a pure-reordering diff:

```
$ cargo build -p hiroz-msgs --features python_registry
$ git status --short crates/hiroz-msgs/python
 ... 9 files changed, 709 insertions(+), 671 deletions(-)
```

With 1 and 2, the same build leaves the tree clean — the acceptance test. The sort is load-bearing rather than a no-op: `nav_msgs.py` services move from `LoadMap*, GetMap*, SetMap*` to `GetMap*, GetPlan*, LoadMap*, SetMap*`.

The gate was checked in both directions, via `nu scripts/test-pure-rust.nu check-python-stubs`:

| Scenario | Result |
|---|---|
| Clean tree | pass |
| Asset changed, stub not regenerated | fail |
| Package removed, stub orphaned | fail |
| Generated stub not tracked | fail |

The third row is the case Copilot caught in review: the generator only ever writes files, so an orphaned stub stayed invisible until the check began emptying the directory before regenerating. Safe because a build from an empty directory reproduces exactly the committed set, so it cannot demand deletion of a legitimate stub.

Hand-editing a committed stub is deliberately *not* detectable — regeneration heals the edit before the check runs.

## Breaking Changes

None for Rust. The six restored `rcl_interfaces` classes are purely additive.
