### PR TITLE
ci: bound the nix setup step so a stalled fetch fails fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,13 @@ jobs:
           chmod +x scripts/test-pure-rust.nu
 
       - name: Setup nix environment (Linux)
+        # `nix print-dev-env` has no internal timeout: a substituter fetch that
+        # stalls hangs until GitHub's 6h job limit. Observed healthy range is
+        # 34-63s, so 20m is ~19x headroom while turning a stall into a fast,
+        # re-runnable failure. A cold cache after a flake.lock bump that needs
+        # real source builds will exceed this -- that should surface as a
+        # failure telling you to populate cachix, not run silently for hours.
+        timeout-minutes: 20
         if: runner.os == 'Linux'
         run: |
           nix print-dev-env '.#pureRust-ci' --accept-flake-config > /tmp/nix-dev-env.sh
@@ -203,6 +210,13 @@ jobs:
           chmod +x scripts/test-pure-rust.nu
 
       - name: Setup nix environment (Linux)
+        # `nix print-dev-env` has no internal timeout: a substituter fetch that
+        # stalls hangs until GitHub's 6h job limit. Observed healthy range is
+        # 34-63s, so 20m is ~19x headroom while turning a stall into a fast,
+        # re-runnable failure. A cold cache after a flake.lock bump that needs
+        # real source builds will exceed this -- that should surface as a
+        # failure telling you to populate cachix, not run silently for hours.
+        timeout-minutes: 20
         run: |
           nix print-dev-env '.#pureRust-ci' --accept-flake-config > /tmp/nix-dev-env.sh
           echo "export CI=true" >> /tmp/nix-dev-env.sh
@@ -259,6 +273,13 @@ jobs:
         run: nix profile install nixpkgs#nushell
 
       - name: Setup nix environment
+        # `nix print-dev-env` has no internal timeout: a substituter fetch that
+        # stalls hangs until GitHub's 6h job limit. Observed healthy range is
+        # 34-63s, so 20m is ~19x headroom while turning a stall into a fast,
+        # re-runnable failure. A cold cache after a flake.lock bump that needs
+        # real source builds will exceed this -- that should surface as a
+        # failure telling you to populate cachix, not run silently for hours.
+        timeout-minutes: 20
         run: |
           nix print-dev-env '.#pureRust-ci' --accept-flake-config > /tmp/nix-dev-env.sh
           echo "export CI=true" >> /tmp/nix-dev-env.sh
@@ -341,6 +362,13 @@ jobs:
           chmod +x scripts/test-pure-rust.nu
 
       - name: Setup nix environment (Linux)
+        # `nix print-dev-env` has no internal timeout: a substituter fetch that
+        # stalls hangs until GitHub's 6h job limit. Observed healthy range is
+        # 34-63s, so 20m is ~19x headroom while turning a stall into a fast,
+        # re-runnable failure. A cold cache after a flake.lock bump that needs
+        # real source builds will exceed this -- that should surface as a
+        # failure telling you to populate cachix, not run silently for hours.
+        timeout-minutes: 20
         if: runner.os == 'Linux'
         run: |
           nix print-dev-env '.#pureRust-ci' --accept-flake-config > /tmp/nix-dev-env.sh
@@ -465,6 +493,13 @@ jobs:
           skipPush: ${{ github.event_name == 'pull_request' }}
 
       - name: Setup nix environment
+        # `nix print-dev-env` has no internal timeout: a substituter fetch that
+        # stalls hangs until GitHub's 6h job limit. Observed healthy range is
+        # 34-63s, so 20m is ~19x headroom while turning a stall into a fast,
+        # re-runnable failure. A cold cache after a flake.lock bump that needs
+        # real source builds will exceed this -- that should surface as a
+        # failure telling you to populate cachix, not run silently for hours.
+        timeout-minutes: 20
         run: |
           nix print-dev-env '.#pureRust-ci' --accept-flake-config > /tmp/nix-dev-env.sh
           echo "export CI=true" >> /tmp/nix-dev-env.sh
@@ -574,6 +609,13 @@ jobs:
           chmod +x scripts/test-python.nu
 
       - name: Setup nix environment
+        # `nix print-dev-env` has no internal timeout: a substituter fetch that
+        # stalls hangs until GitHub's 6h job limit. Observed healthy range is
+        # 34-63s, so 20m is ~19x headroom while turning a stall into a fast,
+        # re-runnable failure. A cold cache after a flake.lock bump that needs
+        # real source builds will exceed this -- that should surface as a
+        # failure telling you to populate cachix, not run silently for hours.
+        timeout-minutes: 20
         run: |
           nix print-dev-env '.#ros-${{ matrix.distro }}-ci' --accept-flake-config > /tmp/nix-dev-env.sh
           echo "export CI=true" >> /tmp/nix-dev-env.sh
@@ -687,6 +729,13 @@ jobs:
           chmod +x scripts/test-ros.nu
 
       - name: Setup nix environment
+        # `nix print-dev-env` has no internal timeout: a substituter fetch that
+        # stalls hangs until GitHub's 6h job limit. Observed healthy range is
+        # 34-63s, so 20m is ~19x headroom while turning a stall into a fast,
+        # re-runnable failure. A cold cache after a flake.lock bump that needs
+        # real source builds will exceed this -- that should surface as a
+        # failure telling you to populate cachix, not run silently for hours.
+        timeout-minutes: 20
         run: |
           nix print-dev-env '.#ros-${{ matrix.distro }}-ci' \
             --accept-flake-config > /tmp/nix-dev-env.sh


### PR DESCRIPTION
## Summary

`nix print-dev-env` has no internal timeout. When a substituter fetch stalls, the step hangs until GitHub's 6-hour job limit rather than failing. Adds `timeout-minutes: 20` to all seven `Setup nix environment` steps.

## Key Changes

Seven steps, one value, with the reasoning inline so the number is not mistaken for arbitrary:

```yaml
- name: Setup nix environment
  timeout-minutes: 20
```

Jobs covered: ROS-independent Test, SHM Tests, Code Coverage, ROS-independent Checks, WASM Plugin Tests, Python Tests, ROS Tests.

## What fails without this

Observed, not hypothetical. In run `30430057177` two jobs stalled in this step while their siblings did not:

| Job (same run, same devshell) | Setup nix environment |
|---|---|
| ROS Tests (humble) | 40s |
| Python Tests (jazzy / kilted / lyrical) | 43s / 63s / 41s |
| **Python Tests (humble)** | **1502s, hung** |
| **Generated Python Stubs** | **990s** |

Both hung jobs completed in 35–40s on re-run against the same commit, flake and caches, so the cause was the runner, not the repository. Without a bound, the first would have run to the 6-hour limit; the run was already blocked on it with all 17 other jobs finished.

## Choosing 20 minutes

Measured across the last ~12 CI runs, every successful `Setup nix environment` fell between **34s and 63s**. 20 minutes is roughly 19× the observed worst case, so it cannot fire on a healthy run, and it converts a 6-hour hang into a failure visible within 20 minutes.

The deliberate trade-off: a cold cache after a `flake.lock` bump that requires real source builds will exceed 20 minutes and fail. That is the intended behaviour — a CI job silently compiling ROS for hours should surface as "populate cachix for this lock", not as a job that looks alive. If that turns out to bite in practice, raising the number is a one-line change; the alternative default is no bound at all.

## Breaking Changes

None. No job's behaviour changes unless a step exceeds 20 minutes, which no healthy run has approached.
