### PR TITLE
perf(py): decode subscriber samples without copying the payload

### DIFF
--- a/crates/hiroz-py/src/node.rs
+++ b/crates/hiroz-py/src/node.rs
@@ -16,6 +16,7 @@ use hiroz::node::ZNode;
 use pyo3::prelude::*;
 use std::any::Any;
 use std::sync::Arc;
+use zenoh_buffers::buffer::SplitBuffer;
 
 /// Try to extract type info from a message class.
 ///
@@ -233,9 +234,25 @@ impl PyZNode {
             // matching rmw_zenoh_cpp's NodeData::subs_ pattern. The caller does not
             // need to assign the returned PyZSubscriber to keep the subscription active.
             let type_name = msg_type_str.clone();
+            // Sample-level callback, not `build_with_callback`. The typed form
+            // would route through `RawBytesCdrSerdes::deserialize`, whose
+            // `Output` is an owned `RawBytesMessage` and so must `to_vec()` the
+            // whole payload before this closure runs — a full copy per message,
+            // scaling with payload size, immediately discarded once msgspec has
+            // decoded it. Taking the `Sample` lets the decode read straight out
+            // of the network buffer, and matches what the polling `recv()` path
+            // in `pubsub.rs` already does.
             let zsub = sub_builder
-                .build_with_callback(move |raw_msg: RawBytesMessage| {
-                    let payload = raw_msg.0;
+                .build_with_sample_callback(move |sample| {
+                    // Same zero-copy setup as `PyZSubscriber::recv`: the ZBuf is
+                    // cheap Arc clones, and publishing it as the deserializer's
+                    // source lets `bytes`-typed fields become sub-ZSlices of the
+                    // received buffer instead of copies.
+                    let payload_zbuf: zenoh_buffers::ZBuf = sample.payload().clone().into();
+                    hiroz_cdr::ZBUF_DESER_SOURCE.with(|cell| {
+                        *cell.borrow_mut() = Some(payload_zbuf.clone());
+                    });
+                    let payload = payload_zbuf.contiguous();
                     Python::with_gil(|py| {
                         match hiroz_msgs::deserialize_from_cdr(&type_name, py, &payload) {
                             Ok(obj) => {
@@ -247,6 +264,9 @@ impl PyZNode {
                                 eprintln!("hiroz_py: deserialization error in callback: {}", e);
                             }
                         }
+                    });
+                    hiroz_cdr::ZBUF_DESER_SOURCE.with(|cell| {
+                        *cell.borrow_mut() = None;
                     });
                 })
                 .map_err(|e| e.into_pyerr())?;

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -867,6 +867,60 @@ where
         })
     }
 
+    /// Build a callback subscriber that receives the whole [`Sample`], undecoded.
+    ///
+    /// [`Self::build_with_callback`] must hand the callback an owned `S::Output`,
+    /// and [`ZDeserializer::Output`] carries no lifetime — so a serdes that only
+    /// forwards bytes (a language binding's identity codec, say) has no way to
+    /// express "borrow the payload", and must copy the entire message before the
+    /// callback has even seen it. That copy scales with payload size and is pure
+    /// waste when the consumer immediately re-reads the bytes into its own
+    /// representation.
+    ///
+    /// This entry point steps around it: the callback gets the `Sample`, so it
+    /// can borrow the payload (`sample.payload().to_bytes()` is a `Cow` that
+    /// borrows whenever the `ZBuf` is contiguous, which the receive path makes it)
+    /// and decode straight out of the network buffer. It can also reach the
+    /// sample's attachment, encoding and timestamp, which the decoded form drops.
+    ///
+    /// Everything else is identical to `build_with_callback` — same encoding
+    /// validation, same [`CallbackDispatcher`] handling, same liveliness and
+    /// graph registration. The callback is user code and is dispatched by exactly
+    /// the same rules.
+    ///
+    /// # Ownership
+    ///
+    /// As with `build_with_callback`, the returned [`ZSub`] must be kept alive for
+    /// the subscription to stay active.
+    pub fn build_with_sample_callback<F>(self, callback: F) -> Result<ZSub<T, (), S>>
+    where
+        F: Fn(Sample) + Send + Sync + 'static,
+        S: ZDeserializer,
+    {
+        let expected_encoding = self.expected_encoding.clone();
+        let callback = Arc::new(move |sample: Sample| {
+            if let Some(ref expected) = expected_encoding {
+                let encoding_str = sample.encoding().to_string();
+                if let Some(received) =
+                    crate::encoding::Encoding::from_zenoh_encoding(&encoding_str)
+                {
+                    if &received != expected {
+                        tracing::warn!(
+                            "Encoding mismatch: expected {:?}, received {:?}",
+                            expected,
+                            received
+                        );
+                    }
+                } else {
+                    tracing::debug!("Unknown encoding format: {}", encoding_str);
+                }
+            }
+            callback(sample);
+        });
+
+        self.build_internal(DataHandler::Callback(callback), None)
+    }
+
     /// Build a subscriber with a callback that processes deserialized messages directly.
     ///
     /// This method creates a subscriber that invokes the provided callback for each

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -869,28 +869,15 @@ where
 
     /// Build a callback subscriber that receives the whole [`Sample`], undecoded.
     ///
-    /// [`Self::build_with_callback`] must hand the callback an owned `S::Output`,
-    /// and [`ZDeserializer::Output`] carries no lifetime — so a serdes that only
-    /// forwards bytes (a language binding's identity codec, say) has no way to
-    /// express "borrow the payload", and must copy the entire message before the
-    /// callback has even seen it. That copy scales with payload size and is pure
-    /// waste when the consumer immediately re-reads the bytes into its own
-    /// representation.
+    /// [`Self::build_with_callback`] hands the callback an owned `S::Output`, and
+    /// [`ZDeserializer::Output`] carries no lifetime — so a serdes that only
+    /// forwards bytes must copy the whole message before the callback sees it.
+    /// Taking the `Sample` instead lets the callback borrow the payload and
+    /// decode out of the network buffer, and reaches the attachment, encoding and
+    /// timestamp that the decoded form drops.
     ///
-    /// This entry point steps around it: the callback gets the `Sample`, so it
-    /// can borrow the payload (`sample.payload().to_bytes()` is a `Cow` that
-    /// borrows whenever the `ZBuf` is contiguous, which the receive path makes it)
-    /// and decode straight out of the network buffer. It can also reach the
-    /// sample's attachment, encoding and timestamp, which the decoded form drops.
-    ///
-    /// Everything else is identical to `build_with_callback` — same encoding
-    /// validation, same liveliness and graph registration, same dispatch. The
-    /// callback is user code and is handled by exactly the same rules.
-    ///
-    /// # Ownership
-    ///
-    /// As with `build_with_callback`, the returned [`ZSub`] must be kept alive for
-    /// the subscription to stay active.
+    /// Otherwise identical to `build_with_callback`, including that the returned
+    /// [`ZSub`] must be kept alive for the subscription to stay active.
     pub fn build_with_sample_callback<F>(self, callback: F) -> Result<ZSub<T, (), S>>
     where
         F: Fn(Sample) + Send + Sync + 'static,

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -884,9 +884,8 @@ where
     /// sample's attachment, encoding and timestamp, which the decoded form drops.
     ///
     /// Everything else is identical to `build_with_callback` — same encoding
-    /// validation, same [`CallbackDispatcher`] handling, same liveliness and
-    /// graph registration. The callback is user code and is dispatched by exactly
-    /// the same rules.
+    /// validation, same liveliness and graph registration, same dispatch. The
+    /// callback is user code and is handled by exactly the same rules.
     ///
     /// # Ownership
     ///


### PR DESCRIPTION
## Summary

The Python subscriber callback path copies every message before the callback can see it.

`build_with_callback` routes through `RawBytesCdrSerdes::deserialize`, whose `Output` is an owned `RawBytesMessage` carrying no lifetime. A serdes that only forwards bytes therefore has no way to express "borrow the payload" and must `to_vec()` the whole message — a full copy per received message, discarded as soon as msgspec has decoded out of it.

## Key Changes

Adds `ZSubBuilder::build_with_sample_callback`, which hands the callback the `Sample` so it can borrow the payload and decode straight out of the network buffer, and switches `hiroz-py` to it.

Everything else about the subscriber is unchanged: same encoding validation, same dispatch, same liveliness and graph registration.

This also brings the callback path in line with the polling `recv()` path in `hiroz-py/src/pubsub.rs`, which already borrowed. The two receive paths disagreeing was the odd part.

## What fails without this

Nothing. This is an optimisation with no failing baseline, and the justification is below.

**The structural claim, which is certain from the source:** `RawBytesCdrSerdes::deserialize` returns an owned value with no lifetime parameter, so the copy is not incidental — the type signature makes it unavoidable on that path. That is visible in the code, not inferred from timing.

**The measurement does not support a perf claim.** Two independent runs, interleaved paired A/B of release wheels differing only at this call site (verified by `strings` on the compiled `.so`: `build_with_sample_callback` appears 0 times in the copy arm, 7 in the borrow arm).

Run 1 (5+6 reps, 16 000 round trips each), half-trip p50:

| payload | copy | borrow | delta |
|---|---|---|---|
| 64 B | 114.5 µs | 114.1 µs | within noise |
| 4 KB | 120.9 µs | 121.0 µs | within noise |
| 64 KB | 224.4 µs | 221.1 µs | −3.4 µs |

Run 2, larger payloads and 12 paired reps, added specifically to test whether the saving scales with payload:

| payload | n | baseline | median delta | sem | significance |
|---|---|---|---|---|---|
| 64 KB | 12 | 252.4 µs | **−0.6 µs** | 3.1 | t = −0.54; sign test p = 1.00 |
| 4 MB | 12 | 6310.3 µs | **−326.2 µs** | 146.4 | t = −1.82, p ≈ 0.10; sign 8/12, p = 0.39 |

**Run 2 contradicts run 1 at 64 KB.** The −3.4 µs from run 1 does not reproduce; at n=12 the 64 KB delta is indistinguishable from zero. Run 1's tight interval was a small sample that happened to cluster.

At 4 MB the point estimate is the right sign and a plausible magnitude (a 4 MB memcpy at ~10 GB/s is ~400 µs), but it does not reach significance, and the between-rep spread (±507 µs, baseline wandering 5.6–7.0 ms) dominates. Resolving it would need n ≈ 40–50 or a harness that suppresses that drift.

**Conclusion: no measured performance benefit is demonstrated at any payload size.**

**So the case for merging rests entirely on the structural argument and the consistency with `recv()`.** The benchmark has now been run twice and supports nothing; treat this PR as a correctness/consistency change, not an optimisation. If that is not reason enough to carry a new public builder method, the right call is to close it.

## Breaking Changes

None. `build_with_sample_callback` is additive; `build_with_callback` is unchanged.

