### PR TITLE
ci(go): make the FFI tests run instead of silently skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,6 +613,13 @@ jobs:
       - name: Go pure tests (codegen + testdata)
         run: nu scripts/test-go.nu --codegen-only
 
+      # Without this the FFI tests have nothing to link against. They used to
+      # skip in that case and report success, so this step never ran at all --
+      # see issue #270. The script now errors instead of skipping, so this
+      # build is what makes the step real rather than decorative.
+      - name: Build hiroz with the ffi feature (required by the FFI tests)
+        run: cargo build -j4 -p hiroz --features ffi --release
+
       - name: Go FFI tests (hiroz unit tests)
         run: nu scripts/test-go.nu --ffi-only
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,7 +613,8 @@ jobs:
       - name: Go pure tests (codegen + testdata)
         run: nu scripts/test-go.nu --codegen-only
 
-      # Without this the FFI tests have nothing to link against and skip -- #270.
+      # Without this the FFI tests have nothing to link against. The step below
+      # then fails, because `--require-ffi` refuses to skip -- #270.
       - name: Build hiroz with the ffi feature (required by the FFI tests)
         run: cargo build -j4 -p hiroz --features ffi --release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,10 +613,7 @@ jobs:
       - name: Go pure tests (codegen + testdata)
         run: nu scripts/test-go.nu --codegen-only
 
-      # Without this the FFI tests have nothing to link against. They used to
-      # skip in that case and report success, so this step never ran at all --
-      # see issue #270. The script now errors instead of skipping, so this
-      # build is what makes the step real rather than decorative.
+      # Without this the FFI tests have nothing to link against and skip -- #270.
       - name: Build hiroz with the ffi feature (required by the FFI tests)
         run: cargo build -j4 -p hiroz --features ffi --release
 

--- a/scripts/test-go.nu
+++ b/scripts/test-go.nu
@@ -88,7 +88,7 @@ def test-codegen [] {
 }
 
 # Test hiroz-go runtime library
-def test-runtime [] {
+def test-runtime [--require-ffi] {
     log-step "Testing hiroz-go (runtime library)"
 
     # Format check
@@ -139,17 +139,25 @@ def test-runtime [] {
         print $ffi_result.stdout
         log-success "hiroz FFI tests pass"
         cd ../..
-    } else {
-        # Not a skip. In CI this step is named "Go FFI tests"; letting it pass
-        # without a library meant it reported success having run nothing --
-        # the FFI surface has never been exercised by any check, which is how
-        # a missing re-entrancy guard in `RawPublisher::publish_bytes` shipped
-        # unnoticed on the path `rmw-zenoh-rs` publishes through. See #270.
+    } else if $require_ffi {
+        # Only when the FFI tests were explicitly asked for -- which is what CI
+        # does. Letting that path pass without a library meant the "Go FFI
+        # tests" step reported success having run nothing, so the FFI surface
+        # was never exercised by any check. That is how a missing re-entrancy
+        # guard in `RawPublisher::publish_bytes` shipped unnoticed, on the path
+        # `rmw-zenoh-rs` publishes through. See #270.
         error make {
             msg: ("hiroz FFI tests cannot run: no libhiroz.a in target/release or target/debug. "
                 + "Build it first with `cargo build -p hiroz --features ffi --release`. "
                 + "This is a failure, not a skip -- see issue #270.")
         }
+    } else {
+        # Default and --runtime-only keep skipping, so a Go-only contributor
+        # without a Rust toolchain can still run the suite. Only the explicit
+        # --ffi-only contract is enforced.
+        print ""
+        log-warning "Skipping hiroz FFI tests (Rust library not built)"
+        print "   Build with: cargo build -p hiroz --features ffi --release"
     }
 }
 
@@ -377,7 +385,7 @@ def main [
     } else if $vet_only {
         test-vet
     } else if $ffi_only {
-        test-runtime  # includes FFI tests when library is present
+        test-runtime --require-ffi  # FFI tests are the point here: absence is a failure
     } else if $integration {
         test-integration --race=$race
     } else {

--- a/scripts/test-go.nu
+++ b/scripts/test-go.nu
@@ -140,9 +140,16 @@ def test-runtime [] {
         log-success "hiroz FFI tests pass"
         cd ../..
     } else {
-        print ""
-        log-warning "Skipping hiroz FFI tests (Rust library not built)"
-        print "   Build with: cargo build -p hiroz --features ffi --release"
+        # Not a skip. In CI this step is named "Go FFI tests"; letting it pass
+        # without a library meant it reported success having run nothing --
+        # the FFI surface has never been exercised by any check, which is how
+        # a missing re-entrancy guard in `RawPublisher::publish_bytes` shipped
+        # unnoticed on the path `rmw-zenoh-rs` publishes through. See #270.
+        error make {
+            msg: ("hiroz FFI tests cannot run: no libhiroz.a in target/release or target/debug. "
+                + "Build it first with `cargo build -p hiroz --features ffi --release`. "
+                + "This is a failure, not a skip -- see issue #270.")
+        }
     }
 }
 

--- a/scripts/test-go.nu
+++ b/scripts/test-go.nu
@@ -136,8 +136,23 @@ def test-runtime [--require-ffi] {
             print $ffi_result.stderr
             exit 1
         }
+        # `go test` exits 0 for a package that has no test files. It prints
+        # `? <pkg> [no test files]` and reports success. A deleted test file, or
+        # one excluded by a build tag, would therefore pass this step having run
+        # nothing -- the same silent skip this flag exists to stop, reached by a
+        # different route. Count the run events instead of trusting the status.
+        let ran = ($ffi_result.stdout | lines | filter {|l| $l | str starts-with "=== RUN" } | length)
+        if $ran == 0 {
+            print $ffi_result.stdout
+            error make {
+                msg: ("hiroz FFI tests ran 0 tests. `go test` exits 0 when a package has no "
+                    + "test files, so this is a silent skip and not a pass. "
+                    + "Check that crates/hiroz-go/hiroz/*_test.go exist and no build tag "
+                    + "excludes them -- see issue #270.")
+            }
+        }
         print $ffi_result.stdout
-        log-success "hiroz FFI tests pass"
+        log-success $"hiroz FFI tests pass \(($ran) tests ran)"
         cd ../..
     } else if $require_ffi {
         # Only when the FFI tests were explicitly asked for -- which is what CI


### PR DESCRIPTION
## Summary

The `Go FFI tests` step in the `Go Tests` job has never run a test. It reports success anyway.

Part of #270, and the cheapest part of it.

## The defect

| fact | where |
|---|---|
| The step runs `nu scripts/test-go.nu --ffi-only` | [`ci.yml` L617-L618](https://github.com/ZettaScaleLabs/hiroz/blob/198e4e3d4a50b412bae9822c0bfdcba325d414a4/.github/workflows/ci.yml#L617-L618) |
| That path runs the FFI tests only if `libhiroz.a` exists | [`has-ffi-library`](https://github.com/ZettaScaleLabs/hiroz/blob/198e4e3d4a50b412bae9822c0bfdcba325d414a4/scripts/test-go.nu#L19-L22), guarding [the FFI branch](https://github.com/ZettaScaleLabs/hiroz/blob/198e4e3d4a50b412bae9822c0bfdcba325d414a4/scripts/test-go.nu#L121-L122) |
| No step in the `go-tests` job built `hiroz` with `--features ffi` | `go-tests` job in `.github/workflows/ci.yml` |
| A missing library was a warning; the script exited 0 | `test-runtime` in `scripts/test-go.nu` |

Every run logged `Skipping hiroz FFI tests (Rust library not built)`. The step concluded `success`.

What that leaves unchecked:

| scope | detail |
|---|---|
| 42 `pub unsafe extern "C"` functions | `crates/hiroz/src/ffi/` |
| No clippy invocation enables `ffi` | checked across `.github/workflows/`, `scripts/test-pure-rust.nu`, `scripts/test-ros.nu` |
| The module is not entirely uncompiled | `Interop Tests` [builds it with `--features ffi`](https://github.com/ZettaScaleLabs/hiroz/blob/198e4e3d4a50b412bae9822c0bfdcba325d414a4/.github/workflows/test.yml#L179-L183), then [runs `--integration`](https://github.com/ZettaScaleLabs/hiroz/blob/198e4e3d4a50b412bae9822c0bfdcba325d414a4/.github/workflows/test.yml#L200-L205) |
| That workflow is not an unconditional gate | it skips on draft PRs; it carries a `paths-ignore` list |
| It also omits the Go `hiroz` package unit tests | those are what `--ffi-only` covers |

The gap is not hypothetical. #270 records a re-entrancy defect on [`publish_bytes`](https://github.com/ZettaScaleLabs/hiroz/blob/198e4e3d4a50b412bae9822c0bfdcba325d414a4/crates/hiroz/src/ffi/publisher.rs#L38-L44) that manual review found, not any check. That is the path `rmw-zenoh-rs` publishes through. Its fix is #250, still open.

## What this PR does

| change | file |
|---|---|
| Build `hiroz` with `--features ffi --release` before the FFI step, so the tests have something to link against | `.github/workflows/ci.yml` |
| Add `--require-ffi` to `test-runtime`; a missing library becomes an `error make`, not a warning | `scripts/test-go.nu` |
| Pass `--require-ffi` only from `--ffi-only` | `scripts/test-go.nu` |

Two files, +21/-2.

`--ffi-only` is the path CI uses, and running the FFI tests is its entire point. The [default and `--runtime-only` paths still warn and skip](https://github.com/ZettaScaleLabs/hiroz/blob/198e4e3d4a50b412bae9822c0bfdcba325d414a4/scripts/test-go.nu#L154-L161), so a Go-only contributor without a Rust toolchain can run the suite. `--codegen-only` and `--vet-only` never touched the library. This PR does not change them.

## Evidence

All measurements taken on `198e4e3d4a50b412bae9822c0bfdcba325d414a4`, the current head.

| claim | measurement |
|---|---|
| The FFI tests now run | The `Go FFI tests` step of `Go Tests (ubuntu-latest)` printed 119 `--- PASS` lines and `ok github.com/ZettaScaleLabs/hiroz/crates/hiroz-go/hiroz` |
| Nothing failed in that step | 0 `--- FAIL` lines |
| The skip is gone | `Skipping hiroz FFI tests` does not appear in that job's log |
| Both matrix legs pass | `Go Tests (ubuntu-latest)` and `Go Tests (macos-latest)` are both `SUCCESS` |
| CI is green | 28 checks completed, 0 failed, 0 pending |

## Breaking changes

None to library code.

| tag | what changes | who is affected | before → after | action |
|---|---|---|---|---|
| **BC1** | `test-go.nu --ffi-only` with no `libhiroz.a` | CI, and anyone invoking that flag directly | warn and exit 0 → error with a build hint | run `cargo build -p hiroz --features ffi --release` first |

The default invocation, `--runtime-only`, `--codegen-only` and `--vet-only` are not affected by **BC1**.

## Coverage this does not have

None of these block this change. They bound what green CI proves.

> [!IMPORTANT]
> This does not close #270.

| tag | gap | detail |
|---|---|---|
| **G1** | The header is not regenerated in CI | `cbindgen` is not installed on the runners. [`build.rs`](https://github.com/ZettaScaleLabs/hiroz/blob/198e4e3d4a50b412bae9822c0bfdcba325d414a4/crates/hiroz/build.rs#L55-L60) turns its absence into a non-fatal `cargo:warning=`. The Go side compiles against the committed `crates/hiroz-go/hiroz/hiroz_ffi.h`. |
| **G2** | Clippy still does not lint the module | Enabling `--features ffi` for clippy is deliberately out of scope. |
| **G3** | `test-integration` and `test-examples` still skip and succeed when the library is absent | [`test-integration`](https://github.com/ZettaScaleLabs/hiroz/blob/198e4e3d4a50b412bae9822c0bfdcba325d414a4/scripts/test-go.nu#L179-L183) and [`test-examples`](https://github.com/ZettaScaleLabs/hiroz/blob/198e4e3d4a50b412bae9822c0bfdcba325d414a4/scripts/test-go.nu#L224-L228). |

Caveats on the table above:

- **G1**: the committed header declares all 42 symbols, compared by name against the Rust sources at this head. **Symbol names are not the whole contract, and the header *is* drifted on struct fields:** `hiroz_context_config_t` ends at `bool enable_logging`, while Rust's `CContextConfig` carries a further `namespace: *const c_char`. #277 fixes that drift and adds the gate. Nothing here detects drift of either kind. #270 tracks installing `cbindgen` and gating on `git diff --exit-code`. The `Go Tests` log on this head contains `warning: hiroz@0.1.0: cbindgen not found (No such file or directory (os error 2)), skipping header generation`.
- **G2**: reading the sources at this head, 22 of the 42 functions have no `# Safety` section — 13 in `action.rs`, 6 in `service.rs`, 3 in `serialize.rs`. [`hiroz_free_bytes`](https://github.com/ZettaScaleLabs/hiroz/blob/198e4e3d4a50b412bae9822c0bfdcba325d414a4/crates/hiroz/src/ffi/serialize.rs#L78-L83) also has the implicit `from_raw_parts_mut` cast. Writing 22 perfunctory `# Safety` blocks without establishing each contract would be worse than leaving them. Those are items 1-3 of #270.
- **G3**: the `Go Tests` job invokes neither. The `Interop Tests` workflow builds the library before calling `--integration`, so neither skips in practice today. This PR fixes neither.

