### PR TITLE
test(py): declare numpy so the ZPayloadView tests cannot silently skip

### DIFF
--- a/crates/hiroz-py/pyproject.toml
+++ b/crates/hiroz-py/pyproject.toml
@@ -28,8 +28,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# numpy carries the only assertion that proves ZPayloadView is zero-copy
-# (`arr.flags["OWNDATA"] is False`). Declared here rather than installed
+# numpy backs the tests that prove it can consume ZPayloadView's exported
+# buffer without adding a copy. Declared here rather than installed
 # imperatively by the test script so that `pip install -e ".[test]"` is a
 # true instruction -- the tests' own failure message points at it.
 test = ["numpy>=1.21"]

--- a/crates/hiroz-py/pyproject.toml
+++ b/crates/hiroz-py/pyproject.toml
@@ -29,9 +29,9 @@ dependencies = [
 
 [project.optional-dependencies]
 # numpy backs the tests that prove it can consume ZPayloadView's exported
-# buffer without adding a copy. Declared here rather than installed
-# imperatively by the test script so that `pip install -e ".[test]"` is a
-# true instruction -- the tests' own failure message points at it.
+# buffer without adding a copy. This file declares numpy. The test script does
+# not install it imperatively. That keeps `pip install -e ".[test]"` a true
+# instruction, which is what the tests' own failure message points at.
 test = ["numpy>=1.21"]
 
 [tool.maturin]

--- a/crates/hiroz-py/pyproject.toml
+++ b/crates/hiroz-py/pyproject.toml
@@ -27,6 +27,13 @@ dependencies = [
     "hiroz-msgs-py>=0.1.0",
 ]
 
+[project.optional-dependencies]
+# numpy carries the only assertion that proves ZPayloadView is zero-copy
+# (`arr.flags["OWNDATA"] is False`). Declared here rather than installed
+# imperatively by the test script so that `pip install -e ".[test]"` is a
+# true instruction -- the tests' own failure message points at it.
+test = ["numpy>=1.21"]
+
 [tool.maturin]
 features = ["pyo3/extension-module", "jazzy"]
 python-source = "python"

--- a/crates/hiroz-py/tests/test_payload_view.py
+++ b/crates/hiroz-py/tests/test_payload_view.py
@@ -163,12 +163,27 @@ class TestZPayloadView:
 
 
 class TestZPayloadViewNumpy:
-    """Test ZPayloadView with numpy (if available)."""
+    """Test that ZPayloadView really is zero-copy, via numpy's OWNDATA flag.
+
+    numpy is a declared test dependency, so its absence is a failure rather
+    than a skip. These tests previously guarded with ``importorskip`` and
+    numpy was never installed, so both had *always* skipped — and the only
+    assertion in the suite that proves the zero-copy claim
+    (``arr.flags["OWNDATA"] is False``) had never executed. A permanently
+    skipped test is indistinguishable from a passing one in the summary line.
+    """
 
     @pytest.fixture(autouse=True)
     def check_numpy(self):
-        """Skip tests if numpy is not available."""
-        pytest.importorskip("numpy")
+        """Fail loudly if numpy is missing, rather than skipping silently."""
+        try:
+            import numpy  # noqa: F401
+        except ImportError as exc:  # pragma: no cover - env misconfiguration
+            pytest.fail(
+                "numpy is a declared test dependency but is not installed, so "
+                "the ZPayloadView zero-copy assertions cannot run. Install it "
+                "with the test extra; do not restore importorskip here."
+            )
 
     def test_numpy_frombuffer(self, byte_array_pubsub):
         """Test that numpy.frombuffer works with ZPayloadView."""

--- a/crates/hiroz-py/tests/test_payload_view.py
+++ b/crates/hiroz-py/tests/test_payload_view.py
@@ -163,14 +163,19 @@ class TestZPayloadView:
 
 
 class TestZPayloadViewNumpy:
-    """Test that ZPayloadView really is zero-copy, via numpy's OWNDATA flag.
+    """Test that numpy can consume ZPayloadView without adding a copy.
 
     numpy is a declared test dependency, so its absence is a failure rather
     than a skip. These tests previously guarded with ``importorskip`` and
-    numpy was never installed, so both had *always* skipped — and the only
-    assertion in the suite that proves the zero-copy claim
-    (``arr.flags["OWNDATA"] is False``) had never executed. A permanently
+    numpy was never installed, so both had *always* skipped. A permanently
     skipped test is indistinguishable from a passing one in the summary line.
+
+    Scope, precisely: ``arr.flags["OWNDATA"] is False`` proves numpy borrowed
+    the buffer ZPayloadView exported rather than copying it. It does *not*
+    prove the transport was zero-copy — ``ZPayloadView::new`` falls back to
+    ``PayloadBytes::Owned`` for a fragmented payload, and numpy borrows that
+    owned copy just as happily. ``test_payload_view_is_zero_copy`` asserts
+    ``payload.is_zero_copy_py``, which is the transport-level check.
     """
 
     @pytest.fixture(autouse=True)

--- a/crates/hiroz-py/tests/test_payload_view.py
+++ b/crates/hiroz-py/tests/test_payload_view.py
@@ -178,7 +178,7 @@ class TestZPayloadViewNumpy:
         """Fail loudly if numpy is missing, rather than skipping silently."""
         try:
             import numpy  # noqa: F401
-        except ImportError as exc:  # pragma: no cover - env misconfiguration
+        except ImportError:  # pragma: no cover - env misconfiguration
             pytest.fail(
                 "numpy is a declared test dependency but is not installed, so "
                 "the ZPayloadView zero-copy assertions cannot run. Install it "

--- a/crates/hiroz-py/tests/test_payload_view.py
+++ b/crates/hiroz-py/tests/test_payload_view.py
@@ -165,22 +165,22 @@ class TestZPayloadView:
 class TestZPayloadViewNumpy:
     """Test that numpy can consume ZPayloadView without adding a copy.
 
-    numpy is a declared test dependency, so its absence is a failure rather
-    than a skip. These tests previously guarded with ``importorskip`` and
-    numpy was never installed, so both had *always* skipped. A permanently
-    skipped test is indistinguishable from a passing one in the summary line.
+    numpy is a declared test dependency. Its absence is a failure, not a skip.
+    These tests previously guarded with ``importorskip``. No job installed
+    numpy, so both tests had *always* skipped. The summary line shows a
+    permanently skipped test and a passing test in the same way.
 
-    Scope, precisely: ``arr.flags["OWNDATA"] is False`` proves numpy borrowed
-    the buffer ZPayloadView exported rather than copying it. It does *not*
-    prove the transport was zero-copy — ``ZPayloadView::new`` falls back to
-    ``PayloadBytes::Owned`` for a fragmented payload, and numpy borrows that
-    owned copy just as happily. ``test_payload_view_is_zero_copy`` asserts
+    Scope, precisely: ``arr.flags["OWNDATA"] is False`` proves that numpy
+    borrowed the buffer ZPayloadView exported. It does *not* prove that the
+    transport was zero-copy. ``ZPayloadView::new`` falls back to
+    ``PayloadBytes::Owned`` for a fragmented payload. numpy borrows that owned
+    copy in the same way. ``test_payload_view_is_zero_copy`` asserts
     ``payload.is_zero_copy_py``, which is the transport-level check.
     """
 
     @pytest.fixture(autouse=True)
     def check_numpy(self):
-        """Fail loudly if numpy is missing, rather than skipping silently."""
+        """Fail the test when numpy is missing. Do not skip silently."""
         try:
             import numpy  # noqa: F401
         except ImportError:  # pragma: no cover - env misconfiguration

--- a/scripts/test-python.nu
+++ b/scripts/test-python.nu
@@ -42,6 +42,14 @@ def setup-venv [] {
     run-cmd "cd crates/hiroz-py; source .venv/bin/activate && pip install -e ../hiroz-msgs/python/" --shell bash --distro (get-distro)
     print "  Installed hiroz-msgs-py (message types)"
 
+    # Test-only dependency. `TestZPayloadViewNumpy` carries the only assertion
+    # that proves ZPayloadView is zero-copy (`arr.flags["OWNDATA"] is False`),
+    # and the venv is created with plain `python -m venv`, so it inherits
+    # nothing from the surrounding devShell. Without this the tests skip and
+    # the suite still reports success -- see #266.
+    run-cmd "cd crates/hiroz-py; source .venv/bin/activate && pip install 'numpy>=1.21'" --shell bash --distro (get-distro)
+    print "  Installed numpy (test dependency for the zero-copy assertions)"
+
     # Install hiroz-py in editable mode using maturin
     run-cmd "cd crates/hiroz-py; source .venv/bin/activate && RUSTFLAGS='-D warnings' maturin develop" --shell bash --distro (get-distro)
     print "  Installed hiroz-py (Rust bindings)"

--- a/scripts/test-python.nu
+++ b/scripts/test-python.nu
@@ -47,8 +47,8 @@ def setup-venv [] {
     # and the venv is created with plain `python -m venv`, so it inherits
     # nothing from the surrounding devShell. Without this the tests skip and
     # the suite still reports success -- see #266.
-    run-cmd "cd crates/hiroz-py; source .venv/bin/activate && pip install 'numpy>=1.21'" --shell bash --distro (get-distro)
-    print "  Installed numpy (test dependency for the zero-copy assertions)"
+    run-cmd "cd crates/hiroz-py; source .venv/bin/activate && pip install -e '.[test]'" --shell bash --distro (get-distro)
+    print "  Installed the test extra (numpy, for the zero-copy assertions)"
 
     # Install hiroz-py in editable mode using maturin
     run-cmd "cd crates/hiroz-py; source .venv/bin/activate && RUSTFLAGS='-D warnings' maturin develop" --shell bash --distro (get-distro)

--- a/scripts/test-python.nu
+++ b/scripts/test-python.nu
@@ -42,11 +42,11 @@ def setup-venv [] {
     run-cmd "cd crates/hiroz-py; source .venv/bin/activate && pip install -e ../hiroz-msgs/python/" --shell bash --distro (get-distro)
     print "  Installed hiroz-msgs-py (message types)"
 
-    # Test-only dependency. `TestZPayloadViewNumpy` carries the only assertion
-    # that proves ZPayloadView is zero-copy (`arr.flags["OWNDATA"] is False`),
-    # and the venv is created with plain `python -m venv`, so it inherits
-    # nothing from the surrounding devShell. Without this the tests skip and
-    # the suite still reports success -- see #266.
+    # Test-only dependency. `TestZPayloadViewNumpy` checks that numpy consumes
+    # ZPayloadView's exported buffer without adding a copy, and the venv is
+    # created with plain `python -m venv`, so it inherits nothing from the
+    # surrounding devShell. Without this the tests skip and the suite still
+    # reports success -- see #266.
     run-cmd "cd crates/hiroz-py; source .venv/bin/activate && pip install -e '.[test]'" --shell bash --distro (get-distro)
     print "  Installed the test extra (numpy, for the zero-copy assertions)"
 

--- a/scripts/test-python.nu
+++ b/scripts/test-python.nu
@@ -43,10 +43,10 @@ def setup-venv [] {
     print "  Installed hiroz-msgs-py (message types)"
 
     # Test-only dependency. `TestZPayloadViewNumpy` checks that numpy consumes
-    # ZPayloadView's exported buffer without adding a copy, and the venv is
-    # created with plain `python -m venv`, so it inherits nothing from the
-    # surrounding devShell. Without this the tests skip and the suite still
-    # reports success -- see #266.
+    # ZPayloadView's exported buffer without adding a copy. Plain `python -m
+    # venv` creates this venv, so it inherits no package from the surrounding
+    # devShell. Without this install the tests skip. The suite then still
+    # reports success. See #266.
     run-cmd "cd crates/hiroz-py; source .venv/bin/activate && pip install -e '.[test]'" --shell bash --distro (get-distro)
     print "  Installed the test extra (numpy, for the zero-copy assertions)"
 


### PR DESCRIPTION
## Summary

`TestZPayloadViewNumpy` guarded on `pytest.importorskip("numpy")`. No file in this repo declared numpy. This PR declares numpy as a test extra, installs it during venv setup, and makes its absence fail instead of skip.

Relates to #266.

## The defect

Every place that could declare numpy, before this change:

| Possible source | Status |
|---|---|
| `crates/hiroz-py/pyproject.toml` `dependencies` | lists `msgspec` and `hiroz-msgs-py` only |
| `crates/hiroz-py/pyproject.toml` optional extras | no `[project.optional-dependencies]` section |
| `setup-venv` in `scripts/test-python.nu` | plain `python -m venv`; installs `hiroz-msgs-py` and `hiroz-py` only |
| transitive through `hiroz-msgs-py` | depends on `msgspec>=0.18.0` only |

numpy resolves at test time from the ROS environment's `site-packages`. That source is ambient, not declared. If it disappears:

- both tests stop executing;
- the suite still reports green;
- the only signal is a smaller test count, which nothing compares against a baseline.

> [!IMPORTANT]
> #266 states that these tests "have never run". The evidence below contradicts that. The ROS environment supplied numpy before this change, so `importorskip` passed through. Both tests ran. This PR's justification does not depend on that premise.

## What this PR does

| Change | File |
|---|---|
| Declare a `test` extra (`numpy>=1.21`) | [`crates/hiroz-py/pyproject.toml`](https://github.com/ZettaScaleLabs/hiroz/blob/515fdbf4b1e49ba0eddf8f4507111da353394282/crates/hiroz-py/pyproject.toml#L30-L35) |
| Install it with `pip install -e '.[test]'` during venv setup | `setup-venv` in `scripts/test-python.nu` |
| Replace `importorskip` with an import that calls `pytest.fail` | [`check_numpy`](https://github.com/ZettaScaleLabs/hiroz/blob/515fdbf4b1e49ba0eddf8f4507111da353394282/crates/hiroz-py/tests/test_payload_view.py#L181-L191) |

This declares the dependency once. The failure message names the command that installs it.

## Evidence

**There is no failing baseline. This is a hardening change.**

Measurements on head `515fdbf4b1e49ba0eddf8f4507111da353394282`:

| Measurement | Source | Result |
|---|---|---|
| Both numpy tests execute | "Python Tests (hiroz-py) (jazzy)" check | `TestZPayloadViewNumpy::test_numpy_frombuffer PASSED`, `TestZPayloadViewNumpy::test_numpy_zero_copy_verification PASSED` |
| Suite result | same job | `48 passed, 7 warnings in 17.01s` — 0 skipped |
| numpy is ambient, not installed by the extra | same job | `pip install -e '.[test]'` reports `Requirement already satisfied: numpy>=1.21 in <ros-env>/site-packages (from hiroz-py==0.1.0) (2.4.4)` |
| All checks | GitHub checks on this head | 31 of 31 completed and green |

That green is contingent. Nothing declared the dependency, nothing pinned it, nothing recorded that these tests need it. Declaring it converts "green because numpy happened to be present" into "green because numpy is required and present". This PR restores no lost coverage, because no coverage is currently lost.

## Breaking changes

None. This adds one optional extra and changes the test environment. `hiroz-py`'s runtime dependencies do not change, so `pip install hiroz-py` does not pull numpy.

## Coverage this does not have

None of these block the change. They bound what the evidence above establishes.

| Tag | Gap | Detail |
|---|---|---|
| **G1** | The new `pytest.fail` path is never exercised | The `except ImportError` branch is marked `# pragma: no cover`. No CI job runs the suite without numpy, so reading establishes the loud-failure behaviour, not execution. |
| **G2** | The extra pins a floor, not a version | `numpy>=1.21`, with no lockfile. A future numpy release that changes buffer-protocol behaviour is still accepted. |
| **G3** | `OWNDATA is False` is not a transport-level check | It proves numpy borrowed the buffer `ZPayloadView` exported instead of copying it. It does not prove the transport was zero-copy. |

**G3** in detail: [`ZPayloadView::new`](https://github.com/ZettaScaleLabs/hiroz/blob/515fdbf4b1e49ba0eddf8f4507111da353394282/crates/hiroz-py/src/payload_view.rs#L56-L67) falls back to `PayloadBytes::Owned` for a fragmented payload, and numpy borrows that owned copy just as happily. The transport-level check is `payload.is_zero_copy_py`, asserted separately by `test_payload_view_is_zero_copy`.
