### PR TITLE
fix(ros): make the interop gate count interop tests

### DIFF
--- a/scripts/test-ros.nu
+++ b/scripts/test-ros.nu
@@ -123,14 +123,18 @@ def run-ros-interop [] {
     # it reads 125, of which only ~41 are interop. Deleting every interop test
     # would still have printed a confident number. Count the interop binaries
     # by name instead, and require each to be present.
-    let interop_suites = [
+    #
+    # The list is distro-dependent. `type_description_interop.rs` is
+    # `#![cfg(not(ros_humble))]` -- Humble has no type description service to
+    # interoperate with -- so requiring it there would fail a healthy run.
+    # Every other suite must be present on every distro.
+    let interop_suites = ([
         pubsub_interop
         service_interop
         action_interop
         parameter_interop
-        type_description_interop
         demo_nodes
-    ]
+    ] | append (if $distro == "humble" { [] } else { [type_description_interop] }))
     let counts = ($interop_suites | each {|suite|
         {
             suite: $suite

--- a/scripts/test-ros.nu
+++ b/scripts/test-ros.nu
@@ -77,49 +77,88 @@ def run-ros-interop [] {
     run-cmd $prebuild_cmd
 
     # Try without verbose logging first (faster)
-    let result = (do -i { run-cmd $cmd --distro $distro | complete })
+    let first = (do -i { run-cmd $cmd --distro $distro | complete })
 
-    # Always surface the runner's own output.
-    #
-    # This used to capture with `complete` and then never print, so a passing
-    # ROS job logged the nextest command, produced not one line of test output,
-    # and printed "All ROS 2 <distro> tests passed!". That banner was
-    # unfalsifiable: nextest exits 0 when it runs *zero* tests, and each interop
-    # test additionally returns early (still passing) when `check_ros2_available`
-    # says no. Nothing in the log distinguished "57 interop tests passed against
-    # rmw_zenoh_cpp" from "the binary matched no tests".
-    print $result.stdout
-    print $result.stderr
+    # Always surface the runner's own output. This used to capture with
+    # `complete` and never print, so a passing job logged the command and then
+    # "All ROS 2 <distro> tests passed!" with nothing in between.
+    print $first.stdout
+    print $first.stderr
 
-    # If tests failed, retry with trace logging for detailed diagnostics
-    # This is CRITICAL for debugging interop issues - shows type hashes, key expressions, service calls
-    if $result.exit_code != 0 {
+    # If tests failed, retry with trace logging for detailed diagnostics.
+    # This is CRITICAL for debugging interop issues - shows type hashes, key
+    # expressions, service calls.
+    let decided = if $first.exit_code != 0 {
         print "\n⚠️  ROS interop tests failed. Retrying with trace logging..."
         $env.RUST_LOG = "hiroz=trace,rmw_zenoh_cpp=debug,warn"
-        run-cmd $cmd --distro $distro
+        let retry = (do -i { run-cmd $cmd --distro $distro | complete })
+        print $retry.stdout
+        print $retry.stderr
+        if $retry.exit_code != 0 {
+            error make {msg: $"ROS interop tests failed. Command: ($cmd)"}
+        }
+        # Gate the run that decided the outcome, not the discarded attempt.
+        $retry
+    } else {
+        $first
     }
 
-    # An exit code of 0 is necessary but not sufficient — require evidence that
-    # tests actually ran. nextest's last line is
-    # `Summary [  12.345s] 57 tests run: 57 passed, 0 skipped`.
-    let summary = ([$result.stdout, $result.stderr] | str join "\n" | lines
-        | where {|l| $l =~ 'tests run:' })
+    let out = ([$decided.stdout, $decided.stderr] | str join "\n")
 
-    if ($summary | is-empty) {
+    # An exit code of 0 is necessary but not sufficient. Three things have to
+    # hold, and each closes a distinct way this job has read as green while
+    # proving nothing.
+
+    # 1. A summary exists at all.
+    if (($out | lines | where {|l| $l =~ 'tests run:'}) | is-empty) {
         error make {
             msg: $"ROS interop run produced no nextest summary line, so it is unknown whether any test ran. Command: ($cmd)"
         }
     }
 
-    let ran = ($summary | last | parse --regex '(?<n>\d+) tests run' | get n.0 | into int)
-    if $ran == 0 {
+    # 2. The *interop* suites ran -- not merely `hiroz-tests`.
+    #
+    # The previous version asserted a non-zero total, then reported it as
+    # "N ROS interop tests". That total is the whole package: on a healthy run
+    # it reads 125, of which only ~41 are interop. Deleting every interop test
+    # would still have printed a confident number. Count the interop binaries
+    # by name instead, and require each to be present.
+    let interop_suites = [
+        pubsub_interop
+        service_interop
+        action_interop
+        parameter_interop
+        type_description_interop
+        demo_nodes
+    ]
+    let counts = ($interop_suites | each {|suite|
+        {
+            suite: $suite
+            n: ($out | lines | where {|l| $l =~ $"hiroz-tests::($suite) "} | length)
+        }
+    })
+    let missing = ($counts | where n == 0 | get suite)
+    if ($missing | is-not-empty) {
         error make {
-            msg: $"ROS interop run executed 0 tests -- a vacuous pass, not a pass. Command: ($cmd)"
+            msg: $"ROS interop suites produced no tests: ($missing | str join ', '). A pass here would be vacuous. Command: ($cmd)"
         }
     }
-    print $"\n($ran) ROS interop tests ran against rmw_zenoh_cpp."
-}
 
+    # 3. No test self-skipped for a missing ros2 CLI.
+    #
+    # Each interop test returns early -- still passing, still counted -- when
+    # `check_ros2_available` is false. That is a pass with no interop in it.
+    let skipped = ($out | lines | where {|l| $l =~ 'ros2 CLI not available'})
+    if ($skipped | is-not-empty) {
+        error make {
+            msg: $"ROS interop tests self-skipped because the ros2 CLI was unavailable; they report as passes but exercised nothing. Command: ($cmd)"
+        }
+    }
+
+    let total = ($counts | get n | math sum)
+    print $"\n($total) ROS interop tests ran against rmw_zenoh_cpp:"
+    for c in $counts { print $"    ($c.suite): ($c.n)" }
+}
 # ============================================================================
 # Test Suite Configuration
 # ============================================================================


### PR DESCRIPTION
## Summary

The interop gate added in #271 does not count interop tests. It asserts a non-zero **package** total, then reports that total as the interop count. A healthy jazzy run reads `125 tests run: 125 passed`, and the gate prints `125 ROS interop tests ran against rmw_zenoh_cpp`. Only 41 of those are interop tests. `hiroz-tests` also holds `lifecycle`, `cache`, `hu_meter`, `parameter_tests` and other non-interop suites. Deleting every interop test still leaves the gate printing a confident number. #271 removed that defect, and its own fix reintroduced it.

Interop test functions per suite, counted at `47ddff36d2d99cc1bb36e7791d70de0cc51b6424`:

| suite | tests |
|---|---|
| `pubsub_interop` | 14 |
| `demo_nodes` | 9 |
| `service_interop` | 7 |
| `type_description_interop` | 4 (absent on Humble) |
| `action_interop` | 4 |
| `parameter_interop` | 3 |
| **total** | **41** (37 on Humble) |

## What this PR does

One file changes: `scripts/test-ros.nu`.

| change | effect |
|---|---|
| Count the interop binaries by name; require each to be present | A run of only non-interop tests fails and names the missing suites, instead of reporting them as interop |
| Fail when the output contains `ros2 CLI not available` | A run whose tests skipped or died for a missing `ros2` CLI is no longer a pass |
| Gate the attempt that decided the outcome | The retry path re-ran nextest, but the gate parsed the *first* attempt's output |
| Drop the `0 tests run` branch | Unreachable: nextest's `--no-tests` default is to fail |
| Print a per-suite breakdown | Replaces the single aggregate number |

**The required suite list is distro-dependent.** `type_description_interop.rs` is [`#![cfg(not(ros_humble))]`](https://github.com/ZettaScaleLabs/hiroz/blob/47ddff36d2d99cc1bb36e7791d70de0cc51b6424/crates/hiroz-tests/tests/type_description_interop.rs#L10-L11), because Humble has no type description service to interoperate with. The gate therefore requires that suite on every distro except Humble, and the other five everywhere. It omits `python_interop` deliberately: the `python-interop` feature gates that suite, and this command does not enable it.

**The self-skip check is not uniform across suites.** The shared message is what makes it detectable.

| suite | guard | behaviour with no usable `ros2` |
|---|---|---|
| `pubsub_interop` | [`check_ros2_available`](https://github.com/ZettaScaleLabs/hiroz/blob/47ddff36d2d99cc1bb36e7791d70de0cc51b6424/crates/hiroz-tests/tests/pubsub_interop.rs#L115-L118), at two call sites | prints `Skipping …: ros2 CLI not available` and returns — passes, and counts |
| `demo_nodes`, `service_interop`, `parameter_interop`, `type_description_interop` | same helper | `panic!` with the same substring — already fails the run |
| `action_interop` | none | no guard at all |

The gate greps for the shared substring, so it catches both spellings.

> [!NOTE]
> Reading, not execution, established the `0 tests run` branch as unreachable. The [`hiroz-union` invocation in `test.yml`](https://github.com/ZettaScaleLabs/hiroz/blob/47ddff36d2d99cc1bb36e7791d70de0cc51b6424/.github/workflows/test.yml#L168-L171) passes `--no-tests=warn` precisely because the default fails the job.

## Evidence

| check | commit | result |
|---|---|---|
| The new suite-presence check fires on a genuinely empty suite | `8e68984af7abd15e50aea6981085e5cacdc7671c` | `ROS Tests (clippy-rmw, interop) (humble)` failed with `ROS interop suites produced no tests: type_description_interop.` The old gate had reported that same Humble run as `116 ROS interop tests ran` |
| Full CI on the head commit | `47ddff36d2d99cc1bb36e7791d70de0cc51b6424` | 28 checks green, 0 failed, 0 pending; `license/cla` success |
| Gate logic against recorded nextest output | `47ddff36d2d99cc1bb36e7791d70de0cc51b6424` | see the table below — a manual check, not an automated test |

Humble legitimately has no `type_description_interop`, so the head commit exempts that suite there. That Humble failure is the proof that the detector detects, rather than merely never firing.

Gate logic fed recorded nextest output:

| input | result |
|---|---|
| healthy jazzy output, all six suites | pass — prints the 41-test breakdown |
| healthy humble output, five suites | pass |
| 84 passing tests, no interop suites | fail — names the missing suites |
| healthy output plus one `ros2 CLI not available` line | fail |
| empty output | fail — no summary line |

## Breaking changes

| tag | what changes | who is affected | before → after | action |
|---|---|---|---|---|
| **BC1** | `scripts/test-ros.nu` fails when interop suites are absent or self-skipped | anyone running the script locally without a working `ros2` CLI | silent green → explicit failure | install and source ROS 2 before running, or run `cargo nextest` directly |

No library, API or message-format change. The change is CI-only, and the gate becomes strictly stricter.

## Coverage this does not have

These gaps do not block the fix. They bound what green CI proves.

| tag | gap | detail |
|---|---|---|
| **G1** | The four `Interop tests with ROS 2 <distro>` jobs are ungated | `.github/workflows/test.yml` runs `cargo nextest run` directly and never calls `scripts/test-ros.nu`. Only the `ROS Tests (clippy-rmw, interop)` jobs in `ci.yml` invoke the gated script |
| **G2** | `--no-tests=warn` keeps one path green by design | The `hiroz-union` invocation in `test.yml` warns instead of failing on a zero-test run |
| **G3** | The suite list is hand-maintained | A new interop suite is not required until someone adds its name to `interop_suites` in `test-ros.nu` |
| **G4** | The gate itself is untested | Its behaviour was checked by hand against recorded output, not by a test that runs in CI |
| **G5** | Per-suite counts are not asserted | Only presence is required, so a suite that shrinks from 14 tests to 1 still passes |
| **G6** | A broken `rmw_zenoh_cpp` still passes the availability guard | The helper is [`Command::new("ros2").arg("--version").output().is_ok()`](https://github.com/ZettaScaleLabs/hiroz/blob/47ddff36d2d99cc1bb36e7791d70de0cc51b6424/crates/hiroz-tests/tests/common/mod.rs#L293-L297), which is true if the process merely spawned. #271 named this failure mode and did not close it. This PR does not close it either |
