### PR TITLE
fix(ci): rustfmt hook silently ran stable, ignoring rustfmt.toml

### DIFF
--- a/crates/hiroz-tests/tests/service_schema_discovery.rs
+++ b/crates/hiroz-tests/tests/service_schema_discovery.rs
@@ -10,8 +10,7 @@ mod common;
 use std::time::{Duration, Instant};
 
 use common::*;
-use hiroz::Builder;
-use hiroz::dynamic::DynamicError;
+use hiroz::{Builder, dynamic::DynamicError};
 
 /// With no service server present, discovery waits until the timeout and then
 /// returns `SchemaNotFound` — it must not hang or panic.

--- a/nix/pre-commit.nix
+++ b/nix/pre-commit.nix
@@ -63,7 +63,22 @@ git-hooks.lib.${system}.run {
   };
   hooks = {
     # Rust tooling
-    rustfmt.enable = true;
+    # The stock hook orders its PATH alphabetically over packageOverrides, so
+    # `cargo` (stable, ships its own rustfmt) shadows the nightly one. Stable
+    # then drops every unstable option in rustfmt.toml -- warning only, exit 0 --
+    # including imports_granularity. Pin the binary instead.
+    rustfmt = {
+      enable = true;
+      entry = toString (
+        pkgs.writeShellScript "rustfmt-nightly-all" ''
+          export RUSTFMT=${rustfmtNightly}/bin/rustfmt
+          export PATH=${rustfmtNightly}/bin:${rustToolchain}/bin:$PATH
+          exec cargo fmt --all -- --check --color always
+        ''
+      );
+      files = "\\.rs$";
+      pass_filenames = false;
+    };
     taplo.enable = true;
 
     # Python tooling


### PR DESCRIPTION
## Summary

`cargo fmt --all --check` fails on `main`. The cause is that the pre-commit rustfmt hook ran a **stable** rustfmt, which silently discards every unstable option in `rustfmt.toml`. This fixes the hook and the one file that slipped through it.

## Key Changes

- `nix/pre-commit.nix`: pin `RUSTFMT` to the nightly binary and put it first on `PATH`.
- `crates/hiroz-tests/tests/service_schema_discovery.rs`: merge two `use hiroz::` statements (produced by `cargo fmt --all`, which touches nothing else).

## What fails without this

```
$ cargo fmt --all --check
Diff in crates/hiroz-tests/tests/service_schema_discovery.rs:10:
-use hiroz::Builder;
-use hiroz::dynamic::DynamicError;
+use hiroz::{Builder, dynamic::DynamicError};
$ echo $?
1
```

Reproduced on a clean checkout of `main` at `d2a58f9a`.

## Root cause

The stock hook builds its `PATH` from `packageOverrides` in alphabetical order, so `cargo` — the stable toolchain, which ships its own `rustfmt` — precedes the nightly `rustfmt` the flake passes in, and shadows it. Instrumenting the hook inside the sandbox shows stable dropping the entire config with a zero exit:

```
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, ...
Warning: can't set `unstable_features = true`, ...
Warning: can't set `skip_children = true`, ...
fmt-rc=0
```

`imports_granularity` is precisely the rule this file breaks. The hook reached the file all along — it was applying a ruleset with the relevant rule stripped out, so violations of any nightly-only rule were invisible to it, locally and in CI alike.

Verified both directions: with the unformatted file the hook now reports `Diff in ...service_schema_discovery.rs:10` and fails; with it formatted, all seven hooks pass.

## Audit of the remaining hooks

No other hook is affected, so nothing else is changed here.

**Shadowing.** Only `rustfmt` and `clippy` build a `PATH` that can shadow (`makeBinPath` over `packageOverrides`); `clippy` is not enabled in this repo. Every enabled hook's entry is an absolute `/nix/store/...` path, so its binary cannot be shadowed.

**Config application** — the property that actually hid the violation. Each hook carrying config was tested so that a dropped config gives a *different* result, not merely a quieter one:

| hook | config | discriminating test | result |
|---|---|---|---|
| `rustfmt` | `rustfmt.toml` | nightly-only `imports_granularity` | was broken; fixed here |
| `taplo` | `.taplo.toml` | file outside `include` → `excluded=1` | applied |
| `markdownlint` | `MD013` disabled | 100-char line + trailing spaces | fired `MD009` only | 
| `yamllint` | line-length 80 → 120 | 100-char line + trailing spaces | fired `trailing-spaces` only |
| `ruff`, `ruff-format`, `mypy`, `nixfmt` | none in repo | — | nothing to drop |

The 100-character lines are the discriminator: under stock defaults (both 80) they would fail. They passed while a real violation in the same file failed, so each hook is shown to be both live and reading the repo config. `rustfmt` was the only hook whose config could be silently discarded.

Verified the gated target still compiles: `cargo check -p hiroz-tests --test service_schema_discovery --features ros-msgs,jazzy` exits 0.

## Breaking Changes

None. Import reordering only; no semantic change.

## Note

If the `clippy` hook is ever enabled, it prefixes `PATH` with the stable cargo and `cargo clippy` resolves `clippy-driver` through `PATH` — the same shape of bug, failing the same silent way. Not an issue today: the hook is off and CI runs clippy through the dev shell.
