### PR TITLE
test(interop): report why a spawned ros2 process failed

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,3 +7,8 @@ slow-timeout = { period = "30s", terminate-after = 2 }
 [profile.interop]
 slow-timeout = { period = "60s", terminate-after = 2 }
 test-threads = 8
+# These tests drive external `ros2` processes, so one environment problem is not
+# evidence about the rest of the suite. Cancelling on the first failure hid that:
+# a single failing test left 108 of 154 unrun, and the leg then reported far less
+# than a green run would. Run them all and report every failure.
+fail-fast = false

--- a/crates/hiroz-tests/tests/common/mod.rs
+++ b/crates/hiroz-tests/tests/common/mod.rs
@@ -28,6 +28,87 @@ impl ProcessGuard {
     }
 }
 
+/// Concurrently drains a child's piped `stdout` and `stderr` so they can be
+/// reported when the child fails.
+///
+/// A test that spawns an external process and discards its diagnostics can only
+/// report *that* the process failed, never why. `ros2 run` writes its reason to
+/// stderr, so a test which asserts on an exit status must capture both streams
+/// and surface them in the failure message.
+///
+/// **Draining concurrently is what makes piping safe.** A pipe nobody reads
+/// fills, and the child then blocks writing to it — which would convert a fast
+/// failure into whatever timeout the caller's wait loop uses. One reader thread
+/// per stream removes that coupling: they run until EOF, which arrives when the
+/// child exits.
+pub struct OutputCapture {
+    stdout: Arc<std::sync::Mutex<String>>,
+    stderr: Arc<std::sync::Mutex<String>>,
+    readers: Vec<thread::JoinHandle<()>>,
+}
+
+#[allow(dead_code)]
+impl OutputCapture {
+    /// Takes the child's piped handles and starts draining them immediately.
+    ///
+    /// Call directly after `spawn`, before any wait loop. A stream that was not
+    /// piped contributes nothing.
+    pub fn start(child: &mut Child) -> Self {
+        use std::io::Read;
+
+        fn drain<R: Read + Send + 'static>(
+            stream: Option<R>,
+            sink: Arc<std::sync::Mutex<String>>,
+        ) -> Option<thread::JoinHandle<()>> {
+            let mut stream = stream?;
+            Some(thread::spawn(move || {
+                let mut buf = String::new();
+                // A read error is not worth failing over: the caller is already
+                // reporting a failure and this is supplementary detail.
+                let _ = stream.read_to_string(&mut buf);
+                if let Ok(mut sink) = sink.lock() {
+                    *sink = buf;
+                }
+            }))
+        }
+
+        let stdout = Arc::new(std::sync::Mutex::new(String::new()));
+        let stderr = Arc::new(std::sync::Mutex::new(String::new()));
+        let readers = [
+            drain(child.stdout.take(), stdout.clone()),
+            drain(child.stderr.take(), stderr.clone()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+
+        Self {
+            stdout,
+            stderr,
+            readers,
+        }
+    }
+
+    /// Joins the reader threads and renders both streams as a printable block.
+    ///
+    /// Call only once the child has exited, so the readers have reached EOF.
+    pub fn finish(self) -> String {
+        for reader in self.readers {
+            let _ = reader.join();
+        }
+        let mut block = String::new();
+        for (label, sink) in [("stdout", &self.stdout), ("stderr", &self.stderr)] {
+            let text = sink.lock().map(|s| s.clone()).unwrap_or_default();
+            if text.trim().is_empty() {
+                block.push_str(&format!("--- child {label}: <empty> ---\n"));
+            } else {
+                block.push_str(&format!("--- child {label} ---\n{}\n", text.trim_end()));
+            }
+        }
+        block
+    }
+}
+
 impl Drop for ProcessGuard {
     fn drop(&mut self) {
         if let Some(mut child) = self.child.take() {

--- a/crates/hiroz-tests/tests/demo_nodes.rs
+++ b/crates/hiroz-tests/tests/demo_nodes.rs
@@ -383,17 +383,22 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
     // discoverable before it starts.
     wait_for_ready(Duration::from_secs(5));
 
-    // Start RCL client. Null stdout — nothing reads it, and the try_wait loop
-    // below waits on the child's exit, which a full unread pipe would block.
-    let client = Command::new("ros2")
+    // Start RCL client with both streams piped, and drain them on reader threads
+    // (see `OutputCapture`). `ros2 run` reports why it failed on stderr; without
+    // that text a failure here is only diagnosable as an exit code. Draining
+    // concurrently is what keeps piping safe for the try_wait loop below — an
+    // unread pipe would fill and block the child.
+    let mut client = Command::new("ros2")
         .args(["run", "demo_nodes_cpp", "add_two_ints_client"])
         .env("RMW_IMPLEMENTATION", "rmw_zenoh_cpp")
         .env("ZENOH_CONFIG_OVERRIDE", router.rmw_zenoh_env())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .process_group(0)
         .spawn()
         .expect("Failed to start RCL client");
+
+    let client_output = common::OutputCapture::start(&mut client);
 
     // Guard owns the child throughout; poll try_wait through the guard's own
     // handle. Reaping via a separate handle first could let Drop later signal a
@@ -420,10 +425,14 @@ fn test_hiroz_add_two_ints_server_to_rcl_client() {
     // verb, bad args) also exits within 30s and would false-pass.
     match client_status {
         None => panic!(
-            "RCL add_two_ints client did not exit within 30s (likely failed to discover the hiroz server)"
+            "RCL add_two_ints client did not exit within 30s (likely failed to discover the hiroz server)\n{}",
+            client_output.finish()
         ),
         Some(status) if !status.success() => {
-            panic!("RCL add_two_ints client exited with failure status {status:?}")
+            panic!(
+                "RCL add_two_ints client exited with failure status {status:?}\n{}",
+                client_output.finish()
+            )
         }
         Some(_) => {}
     }


### PR DESCRIPTION
## Summary

The `lyrical` interop leg fails on every PR. The reason is currently impossible to read, because the test throws it away.

This makes the failure diagnosable. It does not fix `lyrical`.

Fixes #303's second half — the harness defect. The environment problem it exposes stays open there.

## The defect

`test_hiroz_add_two_ints_server_to_rcl_client` spawns `ros2 run demo_nodes_cpp add_two_ints_client` with both streams sent to `/dev/null`, then asserts on its exit status. So a failure reports an exit code and nothing else:

```
Started process: RCL add_two_ints client
Stopping process group: RCL add_two_ints client
Process RCL add_two_ints client exited gracefully with status: ExitStatus(unix_wait_status(64000))
```

`unix_wait_status(64000)` is exit code **250**, no signal, **23 ms** after start, no output. `ros2 run` writes its reason to stderr — a missing executable, an unresolvable package, a library load failure all look identical here.

## What this PR does

| # | Change | Why |
|---|---|---|
| 1 | Pipe the client's `stdout` and `stderr`, and include both in the panic message on failure or timeout | `ros2 run` reports the cause on stderr |
| 2 | Drain both pipes on reader threads (`OutputCapture` in `tests/common/mod.rs`) | See below — this is the load-bearing part |
| 3 | `fail-fast = false` on the `interop` nextest profile | One environment problem is not evidence about the rest of the suite |

**Change 2 is why change 1 is safe.** The streams were nulled deliberately, and the removed comment said so: *"nothing reads it, and the try_wait loop below waits on the child's exit, which a full unread pipe would block."* That objection is correct. Piping without draining would let a chatty child fill its pipe buffer and block, converting a fast failure into a 30-second timeout — a worse failure mode than the one being fixed. One reader thread per stream removes the coupling; they run until EOF, which arrives when the child exits.

**On change 3:** before this PR the leg reported `46/154 tests run` — this single failure cancelled **108 tests**. A leg that stops at the first external-process problem reports far less than its green counterpart, which is the same "green means less than it looks" shape as #276. The Evidence section below measures the result.

## Evidence

**Both changes are demonstrated by this PR's own CI run**, on the `lyrical` leg that #303 tracks.

**Change 1 and 2 — the cause is now printed.** Where the leg previously reported only `ExitStatus(unix_wait_status(64000))`, it now reports:

```
--- child stdout ---
[ros2run]: Aborted
--- child stderr ---
double free or corruption (out)
```

That took #303 from "the client exits 250 and we cannot tell why" to a named failure mode in one run.

**Change 3 — the suite is no longer erased by it.** On the same leg:

| | tests run | passed |
|---|---:|---:|
| before | 46 / 154 | 45 |
| after | **139** | **138** |

The single environment failure was previously cancelling 108 tests. It now reports one failure and runs the rest, which also revealed that **8 of the 9 `demo_nodes` interop tests pass** — the failure is confined to the hiroz-service → C++-client direction. That narrowing is recorded in #303 and is what makes it actionable.

> [!IMPORTANT]
> **No failing baseline, and none is claimed.** This is a diagnostics change: no test fails without it, and no test asserts on a panic message. Its justification is the two measurements above.

| Check | Result |
|---|---|
| `cargo check -p hiroz-tests --features ros-interop,jazzy --test demo_nodes` | clean |
| `cargo fmt` | clean |

The first compile check was run with `--features ros-msgs,jazzy` and passed **vacuously** — `demo_nodes.rs` is `#![cfg(feature = "ros-interop")]`, so that build produced an empty binary. Only the `ros-interop` run above verifies anything.

## What this does not do

- **It does not fix `lyrical`** — but it is what made the cause findable. The captured stderr turned an exit code into `double free or corruption (out)`, which led to a valgrind trace naming `rclcpp::ExecutorOptions::~ExecutorOptions()` freeing a stack address, and from there to the real cause: the ROS image ships `rclcpp` 32.0.0 while the repository serves 32.0.2, so packages installed later are built against a different ABI. Nothing to do with hiroz or zenoh — it reproduces on a stock image with the default RMW. Diagnosis in #303; fix in #305.
- The four other `Stdio::null()` spawn sites in `demo_nodes.rs` are unchanged. None of them asserts on an exit status, so none can produce this failure mode. They can be converted if a future failure needs it.

## Breaking changes

None. Test-harness only.

