### PR TITLE
ci(interop): fix the lyrical ABI skew and make interop failures diagnosable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,14 +110,17 @@ jobs:
           NU_VERSION=0.102.0
           ARCH=$(uname -m | sed 's/x86_64/x86_64/;s/aarch64/aarch64/')
           NU_TARBALL="nu-${NU_VERSION}-${ARCH}-unknown-linux-gnu"
-          # Download to a file rather than piping into tar. A piped curl reports
-          # a network failure as `gzip: stdin: unexpected end of file` and the
-          # step's exit code comes from tar, so a dropped connection reads as a
-          # corrupt archive. Observed on a jazzy leg: `curl: (56) Connection
-          # died` produced `tar: Error is not recoverable` and exit 2.
+          # Download to a file. Do not pipe into tar.
           #
-          # --retry alone does not cover connection resets mid-transfer;
-          # --retry-all-errors does.
+          # A piped curl reports a network failure as `gzip: stdin: unexpected
+          # end of file`. The step then takes its exit code from tar. A dropped
+          # connection therefore reads as a corrupt archive.
+          #
+          # A jazzy leg showed this. `curl: (56) Connection died` produced
+          # `tar: Error is not recoverable` and exit 2.
+          #
+          # `--retry` alone does not cover a connection reset mid-transfer.
+          # `--retry-all-errors` does.
           curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
             -o nu.tar.gz \
             "https://github.com/nushell/nushell/releases/download/${NU_VERSION}/${NU_TARBALL}.tar.gz"
@@ -126,17 +129,19 @@ jobs:
 
       - name: Install ROS dependencies
         run: |
-          # `ros-<distro>-rclcpp` is named explicitly so apt upgrades the copy
+          # Name `ros-<distro>-rclcpp` explicitly. apt then upgrades the copy
           # baked into the image. Every other package here comes from the
-          # repository; if the image is stale, those two disagree on ABI.
+          # repository. If the image is stale, the two disagree on ABI.
           #
-          # Not hypothetical: `ros:lyrical-ros-base` shipped rclcpp 32.0.0
-          # (built 2026-06-06) while the repository served 32.0.2 (2026-07-30,
-          # the same build date as demo-nodes-cpp 0.37.9). `ExecutorOptions`
-          # holds a pimpl and is stack-allocated in demo_nodes_cpp's
-          # `send_request`, so the layout mismatch made ~ExecutorOptions() free
-          # a stack address — glibc reported "double free or corruption (out)"
-          # and the client aborted (#303). Verified both directions.
+          # This is not hypothetical. `ros:lyrical-ros-base` shipped rclcpp
+          # 32.0.0, built 2026-06-06. The repository served 32.0.2, built
+          # 2026-07-30. That is the same day as demo-nodes-cpp 0.37.9.
+          #
+          # `ExecutorOptions` holds a pimpl. demo_nodes_cpp allocates one on
+          # the stack in `send_request`. The layout mismatch therefore made
+          # ~ExecutorOptions() free a stack address. glibc reported
+          # "double free or corruption (out)" and the client aborted. See #303.
+          # Verified in both directions.
           apt-get install -y \
             ros-${{ matrix.distro }}-rclcpp \
             ros-${{ matrix.distro }}-example-interfaces \
@@ -148,27 +153,33 @@ jobs:
             ros-${{ matrix.distro }}-nav-msgs \
             protobuf-compiler
 
-      # An interop run tests hiroz against a specific set of ROS binaries, and
-      # nothing recorded which. When the lyrical leg started failing (#303) the
-      # first question — "what changed?" — was unanswerable from the logs, and
-      # re-running a job replaces its log, so the last-known-good run's inputs
-      # were already gone by the time anyone looked.
+      # An interop run tests hiroz against a specific set of ROS binaries.
+      # Nothing recorded which ones.
       #
-      # Recording them costs a second and makes any two runs comparable. It also
-      # ruled out three hypotheses in #303 that would otherwise have needed a
-      # guess: the image, the ROS package builds, and the C runtime.
+      # When the lyrical leg started to fail, the logs could not answer the
+      # first question: what changed? A re-run replaces the job's log. The
+      # inputs of the last good run had therefore already gone. See #303.
+      #
+      # Recording them costs a second. It makes any two runs comparable. It
+      # also ruled out three hypotheses in #303:
+      #   - the container image
+      #   - the ROS package builds
+      #   - the C runtime
       - name: Record what this run tests against
         run: |
           echo "::group::Environment under test"
           echo "distro: ${{ matrix.distro }}"
           echo "image:  ${{ matrix.image }}   (floating tag — see versions below)"
           grep -E '^(NAME|VERSION)=' /etc/os-release || true
-          # The core libraries come first, and they are the point: the four
-          # application packages below are installed from the repository on every
-          # run, so they always read as current. Only the core libraries carry
-          # the image-vs-repository skew that caused #303, and printing the
-          # application packages alone would report "nothing changed" for exactly
-          # the failure this step exists to explain.
+          # The core libraries come first. They are the point.
+          #
+          # apt installs the four application packages below from the
+          # repository on every run. Those packages therefore always read as
+          # current. Only the core libraries carry the image-versus-repository
+          # skew that caused #303.
+          #
+          # A list of the application packages alone would report "nothing
+          # changed" for the exact failure this step must explain.
           echo "--- ROS core libraries (where image/repo skew shows up) ---"
           dpkg-query -W -f='${Package} ${Version}\n' \
             "ros-${{ matrix.distro }}-rclcpp" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,31 @@ jobs:
             ros-${{ matrix.distro }}-nav-msgs \
             protobuf-compiler
 
+      # An interop run tests hiroz against a specific set of ROS binaries, and
+      # nothing recorded which. When the lyrical leg started failing (#303) the
+      # first question — "what changed?" — was unanswerable from the logs, and
+      # re-running a job replaces its log, so the last-known-good run's inputs
+      # were already gone by the time anyone looked.
+      #
+      # Recording them costs a second and makes any two runs comparable. It also
+      # ruled out three hypotheses in #303 that would otherwise have needed a
+      # guess: the image, the ROS package builds, and the C runtime.
+      - name: Record what this run tests against
+        run: |
+          echo "::group::Environment under test"
+          echo "distro: ${{ matrix.distro }}"
+          echo "image:  ${{ matrix.image }}   (floating tag — see versions below)"
+          grep -E '^(NAME|VERSION)=' /etc/os-release || true
+          echo "--- ROS packages under test ---"
+          dpkg-query -W -f='${Package} ${Version}\n' \
+            "ros-${{ matrix.distro }}-rmw-zenoh-cpp" \
+            "ros-${{ matrix.distro }}-demo-nodes-cpp" \
+            "ros-${{ matrix.distro }}-example-interfaces" \
+            "ros-${{ matrix.distro }}-action-tutorials-cpp" 2>&1 || true
+          echo "--- C runtime (glibc detects the heap corruption in #303) ---"
+          dpkg-query -W -f='${Package} ${Version}\n' libc6 2>&1 || true
+          echo "::endgroup::"
+
       - name: Fix broken rmw_zenoh_cpp config for Kilted
         if: matrix.distro == 'kilted'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,19 @@ jobs:
 
       - name: Install ROS dependencies
         run: |
+          # `ros-<distro>-rclcpp` is named explicitly so apt upgrades the copy
+          # baked into the image. Every other package here comes from the
+          # repository; if the image is stale, those two disagree on ABI.
+          #
+          # Not hypothetical: `ros:lyrical-ros-base` shipped rclcpp 32.0.0
+          # (built 2026-06-06) while the repository served 32.0.2 (2026-07-30,
+          # the same build date as demo-nodes-cpp 0.37.9). `ExecutorOptions`
+          # holds a pimpl and is stack-allocated in demo_nodes_cpp's
+          # `send_request`, so the layout mismatch made ~ExecutorOptions() free
+          # a stack address — glibc reported "double free or corruption (out)"
+          # and the client aborted (#303). Verified both directions.
           apt-get install -y \
+            ros-${{ matrix.distro }}-rclcpp \
             ros-${{ matrix.distro }}-example-interfaces \
             ros-${{ matrix.distro }}-rmw-zenoh-cpp \
             ros-${{ matrix.distro }}-demo-nodes-cpp \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,8 +110,19 @@ jobs:
           NU_VERSION=0.102.0
           ARCH=$(uname -m | sed 's/x86_64/x86_64/;s/aarch64/aarch64/')
           NU_TARBALL="nu-${NU_VERSION}-${ARCH}-unknown-linux-gnu"
-          curl -fsSL "https://github.com/nushell/nushell/releases/download/${NU_VERSION}/${NU_TARBALL}.tar.gz" \
-            | tar -xz -C /usr/local/bin --strip-components=1 "${NU_TARBALL}/nu"
+          # Download to a file rather than piping into tar. A piped curl reports
+          # a network failure as `gzip: stdin: unexpected end of file` and the
+          # step's exit code comes from tar, so a dropped connection reads as a
+          # corrupt archive. Observed on a jazzy leg: `curl: (56) Connection
+          # died` produced `tar: Error is not recoverable` and exit 2.
+          #
+          # --retry alone does not cover connection resets mid-transfer;
+          # --retry-all-errors does.
+          curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+            -o nu.tar.gz \
+            "https://github.com/nushell/nushell/releases/download/${NU_VERSION}/${NU_TARBALL}.tar.gz"
+          tar -xzf nu.tar.gz -C /usr/local/bin --strip-components=1 "${NU_TARBALL}/nu"
+          rm -f nu.tar.gz
 
       - name: Install ROS dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,6 +163,20 @@ jobs:
           echo "distro: ${{ matrix.distro }}"
           echo "image:  ${{ matrix.image }}   (floating tag — see versions below)"
           grep -E '^(NAME|VERSION)=' /etc/os-release || true
+          # The core libraries come first, and they are the point: the four
+          # application packages below are installed from the repository on every
+          # run, so they always read as current. Only the core libraries carry
+          # the image-vs-repository skew that caused #303, and printing the
+          # application packages alone would report "nothing changed" for exactly
+          # the failure this step exists to explain.
+          echo "--- ROS core libraries (where image/repo skew shows up) ---"
+          dpkg-query -W -f='${Package} ${Version}\n' \
+            "ros-${{ matrix.distro }}-rclcpp" \
+            "ros-${{ matrix.distro }}-rcl" \
+            "ros-${{ matrix.distro }}-rmw" \
+            "ros-${{ matrix.distro }}-rcutils" \
+            "ros-${{ matrix.distro }}-rcpputils" \
+            "ros-${{ matrix.distro }}-rosidl-runtime-c" 2>&1 || true
           echo "--- ROS packages under test ---"
           dpkg-query -W -f='${Package} ${Version}\n' \
             "ros-${{ matrix.distro }}-rmw-zenoh-cpp" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,17 +131,12 @@ jobs:
         run: |
           # Name `ros-<distro>-rclcpp` explicitly. apt then upgrades the copy
           # baked into the image. Every other package here comes from the
-          # repository. If the image is stale, the two disagree on ABI.
+          # repository. If the image is stale, the two disagree on ABI. The
+          # mismatch then corrupts memory instead of failing to link.
           #
-          # This is not hypothetical. `ros:lyrical-ros-base` shipped rclcpp
-          # 32.0.0, built 2026-06-06. The repository served 32.0.2, built
-          # 2026-07-30. That is the same day as demo-nodes-cpp 0.37.9.
-          #
-          # `ExecutorOptions` holds a pimpl. demo_nodes_cpp allocates one on
-          # the stack in `send_request`. The layout mismatch therefore made
-          # ~ExecutorOptions() free a stack address. glibc reported
-          # "double free or corruption (out)" and the client aborted. See #303.
-          # Verified in both directions.
+          # #303 carries the diagnosis: the version pair, the valgrind trace and
+          # the hypotheses it ruled out. Keep them there. A version number in a
+          # comment goes stale, and a stale comment is worse than none.
           apt-get install -y \
             ros-${{ matrix.distro }}-rclcpp \
             ros-${{ matrix.distro }}-example-interfaces \
@@ -161,10 +156,7 @@ jobs:
       # inputs of the last good run had therefore already gone. See #303.
       #
       # Recording them costs a second. It makes any two runs comparable. It
-      # also ruled out three hypotheses in #303:
-      #   - the container image
-      #   - the ROS package builds
-      #   - the C runtime
+      # also ruled out three hypotheses in #303.
       - name: Record what this run tests against
         run: |
           echo "::group::Environment under test"


### PR DESCRIPTION
## Summary

Three changes to the interop job. One turns the red `lyrical` leg green; two make the next failure diagnosable instead of a guess.

Fixes #303.

## What this PR does

| # | Change | Why |
|---|---|---|
| 1 | Install `ros-<distro>-rclcpp` explicitly | The images pin ROS package versions but not the apt source. Naming `rclcpp` makes apt upgrade the copy baked into the image, so it matches the repo everything else comes from |
| 2 | Record the image, OS release, the six core ROS libraries, the four packages under test and `libc6` before the tests run | An interop run tests hiroz against a specific set of ROS binaries, and nothing recorded which |
| 3 | Retry the Nushell download, and stop piping it into `tar` | A dropped connection failed a whole leg and reported it as a corrupt archive |

## Change 1 — the actual fix

`ros:lyrical-ros-base` ships `rclcpp` **32.0.0** (built 2026-06-06). The repository serves **32.0.2** (2026-07-30), the same build date as `demo-nodes-cpp` 0.37.9. Installing `demo-nodes-cpp` pulls the July binary but leaves June's `librclcpp.so` in place, because the dependency is already satisfied.

`rclcpp::ExecutorOptions` holds a pimpl and is stack-allocated in `demo_nodes_cpp`'s `send_request`, so the layout mismatch makes `~ExecutorOptions()` free a stack address. glibc reports `double free or corruption (out)` and the client aborts with exit 250.

The defect is not in hiroz, and not in zenoh: it reproduces on a stock image with the **default** RMW and no hiroz process. Full diagnosis, including the valgrind trace and the hypotheses ruled out, is in #303.

## Change 3 — why it is not just a retry

The observed failure was:

```
curl: (56) Connection died, tried 5 times before giving up
gzip: stdin: unexpected end of file
tar: Error is not recoverable: exiting now      → exit 2
```

Piping `curl` into `tar` means the step's exit status comes from `tar`, so a network failure is indistinguishable from a bad tarball. The download now goes to a file first. `--retry` alone does not cover a connection reset mid-transfer; `--retry-all-errors` does.

## Evidence

| Check | Result |
|---|---|
| Interop legs on `017fc88d` | **humble, jazzy, kilted, lyrical — all SUCCESS** |
| `lyrical` before this PR | red since 2026-08-06, `test_hiroz_add_two_ints_server_to_rcl_client` aborting |
| Fix confirmed in a container, both directions | without change 1: exit 250, `double free or corruption`. With it: `Result of add_two_ints: 5`, exit 0 |

**Change 1 is not inert on the other distros, and the description previously implied it was.** Naming `rclcpp` also upgrades it on humble: `ros-humble-rclcpp` moves from `16.0.19-1jammy.20260421` to `16.0.19-1jammy.20260724`, so humble now runs a July `librclcpp.so` against April's `rcl`, `rcutils`, `rmw` and `rosidl-runtime-c`. jazzy and kilted are untouched (`already the newest version`).

That mixed set is safe today, and it was checked rather than assumed: diffing installed-versus-candidate headers inside the image for every package `rclcpp` depends on shows them byte-identical apart from a patch-version macro in `rcpputils/version.h`. Green on one run is evidence the suite passes, not evidence the inputs are unchanged — so the change is stated here rather than left to be discovered.

## What this does not do

- **It does not fix the images.** They will drift again whenever the repository moves ahead of them. The durable fix is for the images to pin their apt *source*, not only the package version — reported upstream as [`osrf/docker_images#897`](https://github.com/osrf/docker_images/issues/897), and linked from #303.
- **It fixes `rclcpp` only, which is sufficient today rather than in general.** The image also bakes in `rclcpp-action`, `-components`, `-lifecycle`, `tf2_ros`, `robot_state_publisher` and `rosbag2` at the older build, and ROS debs carry unversioned dependencies, so naming `rclcpp` cannot drag them along. After this change those image-built consumers disagree with the newer `librclcpp.so` — the skew is inverted rather than eliminated. It does not fire today, and that was tested rather than assumed: 32.0.2 *removed* a 16-byte member, so an old-layout caller over-allocates and the new library under-writes, which is harmless, whereas #303 was the over-writing direction. Running `component_container`, `buffer_server`, `robot_state_publisher` and `rosbag2 recorder` under `rmw_zenoh_cpp` produced no corruption. It would matter if the interop suite grew a tf2 or rosbag2 test, or if the next upstream layout change went the other way.
- Change 2 records versions but does not pin them. ROS apt repositories keep only the newest build of each package, so pinning is not usable here — a pin stops resolving the next time upstream rebuilds.

## Breaking changes

None. CI only.
