### PR TITLE
test(ci): temporary probe — is the lyrical interop failure present on unmodified main?

### DIFF
--- a/crates/hiroz-tests/tests/demo_nodes.rs
+++ b/crates/hiroz-tests/tests/demo_nodes.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "ros-interop")]
+// CI baseline probe: does the lyrical interop job pass on unmodified main today?
 
 mod common;
 


### PR DESCRIPTION
**Temporary. Do not merge. This PR will be closed as soon as the interop matrix reports.**

## Why it exists

`Interop tests with ROS 2 lyrical` fails on #301 across four runs, always the same way:

```
test_hiroz_add_two_ints_server_to_rcl_client ... FAILED
demo_nodes.rs: RCL add_two_ints client exited with failure status ExitStatus(unix_wait_status(64000))
```

The failing assertion is that a prebuilt C++ client from the distro image exits 250 while
talking to a hiroz server whose source is byte-identical to `main`. #301 does not touch
`service.rs`, `hiroz-protocol`, the test harness or `test.yml`, and reverting the one example
change did not affect the result.

`main` last ran the interop matrix on 2026-08-06. The job pulls `ros:lyrical-ros-base`, a tag
that is rebuilt as packages update, so "green on main" describes a six-day-old image rather
than today's.

## What this measures

This branch is `main` plus a single comment line, which is the smallest change that still
triggers the workflow — `**.md` is in `paths-ignore`, and draft PRs are skipped.

| lyrical result here | conclusion |
|---|---|
| fails | the image drifted; #301 is not the cause |
| passes | something in #301 is responsible after all, and the search continues |

Either answer is worth having. The alternative was asserting "not our fault" without evidence.
